### PR TITLE
Install script rework

### DIFF
--- a/advanced/Scripts/blacklist.sh
+++ b/advanced/Scripts/blacklist.sh
@@ -81,13 +81,14 @@ function AddDomain(){
 	if $bool; then
 	  #domain not found in the blacklist file, add it!
 	  if $versbose; then
-	  echo "** Adding $1 to blacklist file"
+	  echo -n "::: Adding $1 to blacklist file..."
 	  fi
 		echo $1 >> $blacklist
 		modifyHost=true
+		echo " done!"
 	else
 	if $versbose; then
-		echo "** $1 already blacklisted! No need to add"
+		echo "::: $1 already exists in blacklist.txt! No need to add"
 		fi
 	fi
 }
@@ -99,12 +100,12 @@ function RemoveDomain(){
   if $bool; then
   	#Domain is not in the blacklist file, no need to Remove
   	if $versbose; then
-  	echo "** $1 is NOT blacklisted! No need to remove"
+  	echo "::: $1 is NOT blacklisted! No need to remove"
   	fi
   else
     #Domain is in the blacklist file, add to a temporary array
     if $versbose; then
-    echo "** Un-blacklisting $dom..."
+    echo "::: Un-blacklisting $dom..."
     fi
     domToRemoveList=("${domToRemoveList[@]}" $1)    
     modifyHost=true	  	
@@ -117,7 +118,8 @@ function ModifyHostFile(){
 	    if [[ -r $blacklist ]];then
 	      numberOf=$(cat $blacklist | sed '/^\s*$/d' | wc -l)
         plural=; [[ "$numberOf" != "1" ]] && plural=s
-        echo "** blacklisting a total of $numberOf domain${plural}..."	   		    
+        echo ":::"
+        echo -n "::: Modifying HOSTS file to blacklist $numberOf domain${plural}..."	   		    
 	    	if [[ -n $piholeIPv6 ]];then	    	  
 	    	  cat $blacklist | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' >> $adList
 	      else	        
@@ -126,12 +128,18 @@ function ModifyHostFile(){
 		   
 	  	fi
 	  else
-
+		
+		echo ":::"
 	  for dom in "${domToRemoveList[@]}"
 		do	  
 	      #we need to remove the domains from the blacklist file and the host file	     
+				echo "::: $dom"
+				echo -n ":::    removing from HOSTS file..."
 	      echo $dom | sed 's/\./\\./g' | xargs -I {} perl -i -ne'print unless /[^.]'{}'(?!.)/;' $adList  
+	      echo " done!"
+	      echo -n ":::    removing from blackist.txt..."
 	      echo $dom | sed 's/\./\\./g' | xargs -I {} perl -i -ne'print unless /'{}'(?!.)/;' $blacklist
+	      echo " done!"
 		done	  
 		fi
 	  
@@ -139,7 +147,8 @@ function ModifyHostFile(){
 
 function Reload() {
 	# Reload hosts file
-	echo "** Refresh lists in dnsmasq..."
+	echo ":::"
+	echo -n "::: Refresh lists in dnsmasq..."
 
 	dnsmasqPid=$(pidof dnsmasq)
 
@@ -150,6 +159,7 @@ function Reload() {
 		# service not running, start it up
 		sudo service dnsmasq start
 	fi
+	echo " done!"
 }
 
 ###################################################
@@ -167,12 +177,11 @@ done
 
 PopBlacklistFile
 
-if $modifyHost || $force; then
-	echo "** Modifying Hosts File"
+if $modifyHost || $force; then	
 	ModifyHostFile
 else
   if $versbose; then
-	echo "** No changes need to be made"
+	echo "::: No changes need to be made"
 	fi
 	exit 1
 fi

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -52,7 +52,7 @@ function HandleOther(){
 	validDomain=$(echo $1 | perl -ne'print if /\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b/')
 	
 	if [ -z "$validDomain" ]; then
-		echo $1 is not a valid argument or domain name
+		echo "::: $1 is not a valid argument or domain name"
 	else	  
 	  domList=("${domList[@]}" $validDomain)
 	fi
@@ -76,17 +76,20 @@ function PopWhitelistFile(){
 function AddDomain(){
 #| sed 's/\./\\./g'
 	bool=false
+	if $versbose; then
+		echo -n "::: Whitelisting $1...."
+	fi
 	grep -Ex -q "$1" $whitelist || bool=true
 	if $bool; then
 	  #domain not found in the whitelist file, add it!
-	  if $versbose; then
-	  echo "** Adding $1 to whitelist file"
-	  fi
-		echo $1 >> $whitelist
+	  echo $1 >> $whitelist
 		modifyHost=true
+		if $versbose; then
+	  	echo " done!"
+	  fi
 	else
 		if $versbose; then
-			echo "** $1 already whitelisted! No need to add"
+			echo " already whitelisted! No need to add"
 		fi
 	fi
 }
@@ -98,7 +101,7 @@ function RemoveDomain(){
   if $bool; then
   	#Domain is not in the whitelist file, no need to Remove
   	if $versbose; then
-  	echo "** $1 is NOT whitelisted! No need to remove"
+  	echo "::: $1 is NOT whitelisted! No need to remove"
   	fi
   else
     #Domain is in the whitelist file, add to a temporary array and remove from whitelist file

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -298,10 +298,10 @@ checkForDependencies(){
  		echo ":::"
     #update package lists
     echo -n "::: Updating package list before install...."
-    #$SUDO apt-get -qq update & spinner $!
+    $SUDO apt-get -qq update & spinner $!
     echo " done!"
     echo -n "::: Upgrading installed apt-get packages...."
-    #$SUDO apt-get -y -qq upgrade & spinner $!
+    $SUDO apt-get -y -qq upgrade & spinner $!
     echo " done!"
     
     echo ":::" 
@@ -423,6 +423,7 @@ runGravity(){
 	#Don't run as SUDO, this was causing issues
 	/usr/local/bin/gravity.sh
 	$SUDO echo "::: ...done."
+	echo ":::"
 }
 
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -346,7 +346,7 @@ getGitFiles(){
 }
 
 is_repo() {
-		echo -n ":::     Checking $1 is a repo..."
+		echo -n ":::    Checking $1 is a repo..."
     # if the directory does not have a .git folder 
     # it is not a repo
     if [ -d "$1/.git" ]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -296,14 +296,24 @@ stopServices(){
 
 
 checkForDependencies(){
- 		echo ":::"
-    #update package lists
-    echo -n "::: Updating package list before install...."
-    $SUDO apt-get -qq update > /dev/null & spinner $!
-    echo " done!"
-    echo -n "::: Upgrading installed apt-get packages...."
-    $SUDO apt-get -y -qq upgrade > /dev/null & spinner $!
-    echo " done!"
+ 		echo ":::" 		
+ 		#Check to see if apt-get update has already been run today
+ 		timestamp=$(stat -c %Y /var/cache/apt/)
+ 		timestampAsDate=$(date -d @$timestamp "+%b %e")
+ 		today=$(date "+%b %e")
+ 		
+ 		if [ ! "$today" == "$timestampAsDate" ]; then 		
+	    #update package lists
+	    echo -n "::: Updating package list before install...."
+	    $SUDO apt-get -qq update > /dev/null & spinner $!
+	    echo " done!"
+	    echo -n "::: Upgrading installed apt-get packages...."
+	    $SUDO apt-get -y -qq upgrade > /dev/null & spinner $!
+	    echo " done!"
+    else
+    	echo "::: Apt-get update already run today, any more would be overkill..."    
+    fi
+    
     
     echo ":::" 
     echo "::: Checking dependencies:"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -418,9 +418,11 @@ runGravity(){
 		$SUDO rm /etc/pihole/list.*
 	fi
 	#Don't run as SUDO, this was causing issues
-	/usr/local/bin/gravity.sh
-	$SUDO echo "::: ...done."
+	echo "::: Running gravity.sh"
 	echo ":::"
+	
+	/usr/local/bin/gravity.sh
+	
 }
 
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -16,21 +16,6 @@
 #
 # curl -L install.pi-hole.net | bash
 
-######## FIRST CHECK ########
-# Must be root to install
-if [[ $EUID -eq 0 ]];then
-	echo "You are root."
-else
-	echo "::: sudo will be used for the install."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		export SUDO="sudo"
-	else
-		echo "::: Please install sudo or run this as root."
-		exit 1
-	fi
-fi
 ######## VARIABLES #########
 tmpLog=/tmp/pihole-install.log
 instalLogLoc=/etc/pihole/install.log
@@ -56,6 +41,29 @@ IPv4gw=$(ip route get 8.8.8.8 | awk '{print $3}')
 
 availableInterfaces=$(ip -o link | awk '{print $2}' | grep -v "lo" | cut -d':' -f1)
 dhcpcdFile=/etc/dhcpcd.conf
+
+######## FIRST CHECK ########
+# Must be root to install
+if [[ $EUID -eq 0 ]];then
+	echo "You are root."
+else
+	echo "::: sudo will be used for the install."
+	# Check if it is actually installed
+	# If it isn't, exit because the install cannot complete
+	if [[ $(dpkg-query -s sudo) ]];then
+		export SUDO="sudo"
+	else
+		echo "::: Please install sudo or run this as root."
+		exit 1
+	fi
+fi
+
+if [ -f "/etc/dnsmasq.d/01-pihole.conf" ]; then
+		#Likely an existing install
+		upgrade=true
+	else
+	  upgrade=false
+fi
 
 ####### FUNCTIONS ##########
 ###All credit for the below function goes to http://fitnr.com/showing-a-bash-spinner.html
@@ -129,7 +137,7 @@ chooseInterface(){
 	done
 }
 
-<<<<<<< HEAD
+
 use4andor6(){
 	# Let use select IPv4 and/or IPv6
 	cmd=(whiptail --separate-output --checklist "Select Protocols" $r $c 2)
@@ -166,13 +174,6 @@ use4andor6(){
 		echo "::: Exiting"
 		exit 1
 	fi
-=======
-useIPv6dialog()
-{
-piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
-whiptail --msgbox --backtitle "IPv6..." --title "IPv6 Supported" "$piholeIPv6 will be used to block ads." $r $c
-$SUDO touch /etc/pihole/.useIPv6
->>>>>>> upstream/development
 }
 
 useIPv6dialog(){
@@ -368,7 +369,7 @@ runGravity(){
 }
 
 checkForAndInstallDependencies(){
-	if [ -d "/var/www/html/admin" ]; then
+	if [ upgrade ]; then
 		#Likely an existing install, no need to apt-get update
 		echo "::: Previous installation detected"
 	else
@@ -378,25 +379,6 @@ checkForAndInstallDependencies(){
 		$SUDO apt-get -yqq upgrade & spinner $!
 	fi
 }
-
-<<<<<<< HEAD
-=======
-installPihole()
-{
-installDependencies
-stopServices
-$SUDO mkdir -p /etc/pihole/
-$SUDO chown www-data:www-data /var/www/html
-$SUDO chmod 775 /var/www/html
-$SUDO usermod -a -G www-data pi
-$SUDO lighty-enable-mod fastcgi fastcgi-php
-installScripts
-installConfigs
-installWebAdmin
-installPiholeWeb
-installCron
-runGravity
->>>>>>> upstream/development
 
 installPihole(){
 	installDependencies

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -16,25 +16,30 @@
 #
 # curl -L install.pi-hole.net | bash
 
-######## VARIABLES #########
+######## FIRST CHECK ########
 # Must be root to install
 if [[ $EUID -eq 0 ]];then
 	echo "You are root."
 else
 	echo "::: sudo will be used for the install."
-  # Check if it is actually installed
-  # If it isn't, exit because the install cannot complete
-  if [[ $(dpkg-query -s sudo) ]];then
+	# Check if it is actually installed
+	# If it isn't, exit because the install cannot complete
+	if [[ $(dpkg-query -s sudo) ]];then
 		export SUDO="sudo"
-  else
+	else
 		echo "::: Please install sudo or run this as root."
-    exit 1
-  fi
+		exit 1
+	fi
 fi
-
-
+######## VARIABLES #########
 tmpLog=/tmp/pihole-install.log
 instalLogLoc=/etc/pihole/install.log
+
+WEB_INTERFACE_GIT_URL="https://github.com/jacobsalmela/AdminLTE.git"
+WEB_INTERFACE_DIR="/var/www/html/admin"
+PIHOLE_GIT_URL="https://github.com/jacobsalmela/AdminLTE.git"
+PIHOLE_FILES_DIR="/var/www/html/admin"
+
 
 # Find the rows and columns
 rows=$(tput lines)
@@ -54,343 +59,339 @@ dhcpcdFile=/etc/dhcpcd.conf
 
 ####### FUNCTIONS ##########
 ###All credit for the below function goes to http://fitnr.com/showing-a-bash-spinner.html
-spinner()
-{
-    local pid=$1
-    local delay=0.001
-    local spinstr='|/-\'
-    while [ "$(ps a | awk '{print $1}' | grep $pid)" ]; do
-        local temp=${spinstr#?}
-        printf " [%c]  " "$spinstr"
-        local spinstr=$temp${spinstr%"$temp"}
-        sleep $delay
-        printf "\b\b\b\b\b\b"
-    done
-    printf "    \b\b\b\b"
+spinner(){
+	local pid=$1
+	local delay=0.001
+	local spinstr='/-\|'
+	while [ "$(ps a | awk '{print $1}' | grep $pid)" ]; do
+	local temp=${spinstr#?}
+	printf " [%c]  " "$spinstr"
+	local spinstr=$temp${spinstr%"$temp"}
+	sleep $delay
+	printf "\b\b\b\b\b\b"
+	done
+	printf "    \b\b\b\b"
 }
 
 
-backupLegacyPihole()
-{
-if [[ -f /etc/dnsmasq.d/adList.conf ]];then
-	echo "Original Pi-hole detected.  Initiating sub space transport"
-	$SUDO mkdir -p /etc/pihole/original/
-	$SUDO mv /etc/dnsmasq.d/adList.conf /etc/pihole/original/adList.conf.$(date "+%Y-%m-%d")
-	$SUDO mv /etc/dnsmasq.conf /etc/pihole/original/dnsmasq.conf.$(date "+%Y-%m-%d")
-	$SUDO mv /etc/resolv.conf /etc/pihole/original/resolv.conf.$(date "+%Y-%m-%d")
-	$SUDO mv /etc/lighttpd/lighttpd.conf /etc/pihole/original/lighttpd.conf.$(date "+%Y-%m-%d")
-	$SUDO mv /var/www/pihole/index.html /etc/pihole/original/index.html.$(date "+%Y-%m-%d")
-	$SUDO mv /usr/local/bin/gravity.sh /etc/pihole/original/gravity.sh.$(date "+%Y-%m-%d")
-else
-	:
-fi
+backupLegacyPihole(){
+	if [[ -f /etc/dnsmasq.d/adList.conf ]];then
+		echo "Original Pi-hole detected.  Initiating sub space transport"
+		$SUDO mkdir -p /etc/pihole/original/
+		$SUDO mv /etc/dnsmasq.d/adList.conf /etc/pihole/original/adList.conf.$(date "+%Y-%m-%d")
+		$SUDO mv /etc/dnsmasq.conf /etc/pihole/original/dnsmasq.conf.$(date "+%Y-%m-%d")
+		$SUDO mv /etc/resolv.conf /etc/pihole/original/resolv.conf.$(date "+%Y-%m-%d")
+		$SUDO mv /etc/lighttpd/lighttpd.conf /etc/pihole/original/lighttpd.conf.$(date "+%Y-%m-%d")
+		$SUDO mv /var/www/pihole/index.html /etc/pihole/original/index.html.$(date "+%Y-%m-%d")
+		$SUDO mv /usr/local/bin/gravity.sh /etc/pihole/original/gravity.sh.$(date "+%Y-%m-%d")
+	else
+		:
+	fi
 }
 
-welcomeDialogs()
-{
-# Display the welcome dialog
-whiptail --msgbox --backtitle "Welcome" --title "Pi-hole automated installer" "This installer will transform your Raspberry Pi into a network-wide ad blocker!" $r $c
-
-# Support for a part-time dev
-whiptail --msgbox --backtitle "Plea" --title "Free and open source" "The Pi-hole is free, but powered by your donations:  http://pi-hole.net/donate" $r $c
-
-# Explain the need for a static address
-whiptail --msgbox --backtitle "Initating network interface" --title "Static IP Needed" "The Pi-hole is a SERVER so it needs a STATIC IP ADDRESS to function properly.
-
-In the next section, you can choose to use your current network settings (DHCP) or to manually edit them." $r $c
-}
-
-chooseInterface()
-{
-# Turn the available interfaces into an array so it can be used with a whiptail dialog
-interfacesArray=()
-firstloop=1
-
-while read -r line
-do
-mode="OFF"
-if [[ $firstloop -eq 1 ]]; then
-  firstloop=0
-  mode="ON"
-fi
-interfacesArray+=("$line" "available" "$mode")
-done <<< "$availableInterfaces"
-
-# Find out how many interfaces are available to choose from
-interfaceCount=$(echo "$availableInterfaces" | wc -l)
-chooseInterfaceCmd=(whiptail --separate-output --radiolist "Choose An Interface" $r $c $interfaceCount)
-chooseInterfaceOptions=$("${chooseInterfaceCmd[@]}" "${interfacesArray[@]}" 2>&1 >/dev/tty)
-for desiredInterface in $chooseInterfaceOptions
-do
-	piholeInterface=$desiredInterface
-	echo "::: Using interface: $piholeInterface"
-	echo ${piholeInterface} > /tmp/piholeINT
-done
-}
-
-use4andor6()
-{
-# Let use select IPv4 and/or IPv6
-cmd=(whiptail --separate-output --checklist "Select Protocols" $r $c 2)
-options=(IPv4 "Block ads over IPv4" on
-         IPv6 "Block ads over IPv6" off)
-choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-for choice in $choices
-do
-    case $choice in
-        IPv4)useIPv4=true;;
-        IPv6)useIPv6=true;;
-    esac
-done    
-    if [ $useIPv4 ] && [ ! $useIPv6 ]; then
-     	getStaticIPv4Settings
-			setStaticIPv4	
-			echo "::: Using IPv4 on $IPv4addr" 
-			echo "::: IPv6 will NOT be used."			
-    fi
-    if [ ! $useIPv4 ] && [ $useIPv6 ]; then
-    	useIPv6dialog
-    	echo "::: IPv4 will NOT be used."
-    	echo "::: Using IPv6 on $piholeIPv6"
-    fi
-    if [ $useIPv4 ] && [  $useIPv6 ]; then    	
-    	getStaticIPv4Settings
-			setStaticIPv4
-			useIPv6dialog	
-			echo "::: Using IPv4 on $IPv4addr"
-    	echo "::: Using IPv6 on $piholeIPv6"
-    fi
-    if [ ! $useIPv4 ] && [ ! $useIPv6 ]; then
-    	echo "::: Cannot continue, neither IPv4 or IPv6 selected"
-    	echo "::: Exiting"
-    	exit 1
-    fi
+welcomeDialogs(){
+	# Display the welcome dialog
+	whiptail --msgbox --backtitle "Welcome" --title "Pi-hole automated installer" "This installer will transform your Raspberry Pi into a network-wide ad blocker!" $r $c
 	
+	# Support for a part-time dev
+	whiptail --msgbox --backtitle "Plea" --title "Free and open source" "The Pi-hole is free, but powered by your donations:  http://pi-hole.net/donate" $r $c
+	
+	# Explain the need for a static address
+	whiptail --msgbox --backtitle "Initating network interface" --title "Static IP Needed" "The Pi-hole is a SERVER so it needs a STATIC IP ADDRESS to function properly.	
+	In the next section, you can choose to use your current network settings (DHCP) or to manually edit them." $r $c
 }
 
-useIPv6dialog()
-{
-piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
-whiptail --msgbox --backtitle "IPv6..." --title "IPv6 Supported" "$piholeIPv6 will be used to block ads." $r $c
-$SUDO mkdir -p /etc/pihole/
-$SUDO touch /etc/pihole/.useIPv6
-}
-
-getStaticIPv4Settings()
-{
-# Ask if the user wants to use DHCP settings as their static IP
-if (whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --yesno "Do you want to use your current network settings as a static address?
-
-								IP address:    $IPv4addr
-								Gateway:       $IPv4gw" $r $c) then
-	# If they choose yes, let the user know that the IP address will not be available via DHCP and may cause a conflict.
-	whiptail --msgbox --backtitle "IP information" --title "FYI: IP Conflict" "It is possible your router could still try to assign this IP to a device, which would cause a conflict.  But in most cases the router is smart enough to not do that.
-
-	If you are worried, either manually set the address, or modify the DHCP reservation pool so it does not include the IP you want.
-
-	It is also possible to use a DHCP reservation, but if you are going to do that, you might as well set a static address." $r $c
-	# Nothing else to do since the variables are already set above
-else
-	# Otherwise, we need to ask the user to input their desired settings.
-	# Start by getting the IPv4 address (pre-filling it with info gathered from DHCP)
-	# Start a loop to let the user enter their information with the chance to go back and edit it if necessary
-	until [[ $ipSettingsCorrect = True ]]
+chooseInterface(){
+# Turn the available interfaces into an array so it can be used with a whiptail dialog
+	interfacesArray=()
+	firstloop=1
+	
+	while read -r line
 	do
-	# Ask for the IPv4 address
-	IPv4addr=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 address" --inputbox "Enter your desired IPv4 address" $r $c $IPv4addr 3>&1 1>&2 2>&3)
-	if [[ $? = 0 ]];then
-    	echo "Your static IPv4 address:    $IPv4addr"
-		# Ask for the gateway
-			IPv4gw=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 gateway (router)" --inputbox "Enter your desired IPv4 default gateway" $r $c $IPv4gw 3>&1 1>&2 2>&3)
+		mode="OFF"
+		if [[ $firstloop -eq 1 ]]; then
+			firstloop=0
+			mode="ON"
+		fi
+		interfacesArray+=("$line" "available" "$mode")
+	done <<< "$availableInterfaces"
+	
+	# Find out how many interfaces are available to choose from
+	interfaceCount=$(echo "$availableInterfaces" | wc -l)
+	chooseInterfaceCmd=(whiptail --separate-output --radiolist "Choose An Interface" $r $c $interfaceCount)
+	chooseInterfaceOptions=$("${chooseInterfaceCmd[@]}" "${interfacesArray[@]}" 2>&1 >/dev/tty)
+	
+	for desiredInterface in $chooseInterfaceOptions
+	do
+		piholeInterface=$desiredInterface
+		echo "::: Using interface: $piholeInterface"
+		echo ${piholeInterface} > /tmp/piholeINT
+	done
+}
+
+use4andor6(){
+	# Let use select IPv4 and/or IPv6
+	cmd=(whiptail --separate-output --checklist "Select Protocols" $r $c 2)
+	options=(IPv4 "Block ads over IPv4" on
+	IPv6 "Block ads over IPv6" off)
+	choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+	for choice in $choices
+	do
+		case $choice in
+		IPv4	)		useIPv4=true;;
+		IPv6	)		useIPv6=true;;
+		esac
+	done
+	if [ $useIPv4 ] && [ ! $useIPv6 ]; then
+		getStaticIPv4Settings
+		setStaticIPv4
+		echo "::: Using IPv4 on $IPv4addr"
+		echo "::: IPv6 will NOT be used."
+	fi
+	if [ ! $useIPv4 ] && [ $useIPv6 ]; then
+		useIPv6dialog
+		echo "::: IPv4 will NOT be used."
+		echo "::: Using IPv6 on $piholeIPv6"
+	fi
+	if [ $useIPv4 ] && [  $useIPv6 ]; then
+		getStaticIPv4Settings
+		setStaticIPv4
+		useIPv6dialog
+		echo "::: Using IPv4 on $IPv4addr"
+		echo "::: Using IPv6 on $piholeIPv6"
+	fi
+	if [ ! $useIPv4 ] && [ ! $useIPv6 ]; then
+		echo "::: Cannot continue, neither IPv4 or IPv6 selected"
+		echo "::: Exiting"
+		exit 1
+	fi
+}
+
+useIPv6dialog(){
+	piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
+	whiptail --msgbox --backtitle "IPv6..." --title "IPv6 Supported" "$piholeIPv6 will be used to block ads." $r $c
+	$SUDO mkdir -p /etc/pihole/
+	$SUDO touch /etc/pihole/.useIPv6
+}
+
+getStaticIPv4Settings(){
+	# Ask if the user wants to use DHCP settings as their static IP
+	if (whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --yesno "Do you want to use your current network settings as a static address?
+									IP address:    $IPv4addr
+									Gateway:       $IPv4gw" $r $c) then
+		# If they choose yes, let the user know that the IP address will not be available via DHCP and may cause a conflict.
+		whiptail --msgbox --backtitle "IP information" --title "FYI: IP Conflict" "It is possible your router could still try to assign this IP to a device, which would cause a conflict.  But in most cases the router is smart enough to not do that.
+		If you are worried, either manually set the address, or modify the DHCP reservation pool so it does not include the IP you want.
+		It is also possible to use a DHCP reservation, but if you are going to do that, you might as well set a static address." $r $c
+		# Nothing else to do since the variables are already set above
+	else
+		# Otherwise, we need to ask the user to input their desired settings.
+		# Start by getting the IPv4 address (pre-filling it with info gathered from DHCP)
+		# Start a loop to let the user enter their information with the chance to go back and edit it if necessary
+		until [[ $ipSettingsCorrect = True ]]
+		do
+			# Ask for the IPv4 address
+			IPv4addr=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 address" --inputbox "Enter your desired IPv4 address" $r $c $IPv4addr 3>&1 1>&2 2>&3)
 			if [[ $? = 0 ]];then
-				echo "Your static IPv4 gateway:    $IPv4gw"
-				# Give the user a chance to review their settings before moving on
-				if (whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --yesno "Are these settings correct?
-					IP address:    $IPv4addr
-					Gateway:       $IPv4gw" $r $c)then
-					# If the settings are correct, then we need to set the piholeIP
-					# Saving it to a temporary file us to retrieve it later when we run the gravity.sh script
-					echo ${IPv4addr%/*} > /tmp/piholeIP
-					echo $piholeInterface > /tmp/piholeINT
-					# After that's done, the loop ends and we move on
-					ipSettingsCorrect=True
+				echo "Your static IPv4 address:    $IPv4addr"
+				# Ask for the gateway
+				IPv4gw=$(whiptail --backtitle "Calibrating network interface" --title "IPv4 gateway (router)" --inputbox "Enter your desired IPv4 default gateway" $r $c $IPv4gw 3>&1 1>&2 2>&3)
+				if [[ $? = 0 ]];then
+					echo "Your static IPv4 gateway:    $IPv4gw"
+					# Give the user a chance to review their settings before moving on
+					if (whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --yesno "Are these settings correct?
+							IP address:    $IPv4addr
+							Gateway:       $IPv4gw" $r $c)then
+							# If the settings are correct, then we need to set the piholeIP
+							# Saving it to a temporary file us to retrieve it later when we run the gravity.sh script
+							echo ${IPv4addr%/*} > /tmp/piholeIP
+							echo $piholeInterface > /tmp/piholeINT
+							# After that's done, the loop ends and we move on
+							ipSettingsCorrect=True
+					else
+						# If the settings are wrong, the loop continues
+						ipSettingsCorrect=False
+					fi
 				else
-					# If the settings are wrong, the loop continues
+					# Cancelling gateway settings window
 					ipSettingsCorrect=False
+					echo "User canceled."
+					exit
 				fi
 			else
-				# Cancelling gateway settings window
+				# Cancelling IPv4 settings window
 				ipSettingsCorrect=False
 				echo "User canceled."
 				exit
 			fi
-		else
-		# Cancelling IPv4 settings window
-		ipSettingsCorrect=False
-		echo "User canceled."
-		exit
+		done
+	# End the if statement for DHCP vs. static
 	fi
-done
-# End the if statement for DHCP vs. static
-fi
 }
 
 setDHCPCD(){
-# Append these lines to dhcpcd.conf to enable a static IP
-echo "interface $piholeInterface
-static ip_address=$IPv4addr
-static routers=$IPv4gw
-static domain_name_servers=$IPv4gw" | $SUDO tee -a $dhcpcdFile >/dev/null
+	#Append these lines to dhcpcd.conf to enable a static IP
+	echo "interface $piholeInterface
+	static ip_address=$IPv4addr
+	static routers=$IPv4gw
+	static domain_name_servers=$IPv4gw" | $SUDO tee -a $dhcpcdFile >/dev/null
 }
 
 setStaticIPv4(){
-if grep -q $IPv4addr $dhcpcdFile; then
-	# address already set, noop
-	:
-else
-	setDHCPCD
-	$SUDO ip addr replace dev $piholeInterface $IPv4addr
-	echo "Setting IP to $IPv4addr.  You may need to restart after the install is complete."
-fi
+	if grep -q $IPv4addr $dhcpcdFile; then
+		# address already set, noop
+		:
+	else
+		setDHCPCD
+		$SUDO ip addr replace dev $piholeInterface $IPv4addr
+		echo "Setting IP to $IPv4addr.  You may need to restart after the install is complete."
+	fi
 }
 
 installScripts(){
-$SUDO echo " "
-$SUDO echo "::: Installing scripts..."
-#$SUDO rm /usr/local/bin/{gravity,chronometer,whitelist,blacklist,piholeLogFlush,updateDashboard}.sh
-$SUDO curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh
-$SUDO curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh
-$SUDO curl -o /usr/local/bin/whitelist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/whitelist.sh
-$SUDO curl -o /usr/local/bin/blacklist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/blacklist.sh
-$SUDO curl -o /usr/local/bin/piholeLogFlush.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/piholeLogFlush.sh
-$SUDO curl -o /usr/local/bin/updateDashboard.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/updateDashboard.sh
-$SUDO chmod 755 /usr/local/bin/{gravity,chronometer,whitelist,blacklist,piholeLogFlush,updateDashboard}.sh
-$SUDO echo "::: ...done."
+	$SUDO echo " "
+	$SUDO echo "::: Installing scripts..."
+	$SUDO curl -o /usr/local/bin/gravity.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/gravity.sh
+	$SUDO curl -o /usr/local/bin/chronometer.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/chronometer.sh
+	$SUDO curl -o /usr/local/bin/whitelist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/whitelist.sh
+	$SUDO curl -o /usr/local/bin/blacklist.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/blacklist.sh
+	$SUDO curl -o /usr/local/bin/piholeLogFlush.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/piholeLogFlush.sh
+	$SUDO curl -o /usr/local/bin/updateDashboard.sh https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/Scripts/updateDashboard.sh
+	$SUDO chmod 755 /usr/local/bin/{gravity,chronometer,whitelist,blacklist,piholeLogFlush,updateDashboard}.sh
+	$SUDO echo "::: ...done."
 }
 
 installConfigs(){
-$SUDO echo " "
-$SUDO echo "::: Installing configs..."
-$SUDO mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
-$SUDO mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
-$SUDO curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf
-$SUDO curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf
-$SUDO sed -i "s/@INT@/$piholeInterface/" /etc/dnsmasq.conf
-$SUDO echo "::: ...done."
+	$SUDO echo " "
+	$SUDO echo "::: Installing configs..."
+	$SUDO mv /etc/dnsmasq.conf /etc/dnsmasq.conf.orig
+	$SUDO mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
+	$SUDO curl -o /etc/dnsmasq.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/dnsmasq.conf
+	$SUDO curl -o /etc/lighttpd/lighttpd.conf https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/lighttpd.conf
+	$SUDO sed -i "s/@INT@/$piholeInterface/" /etc/dnsmasq.conf
+	$SUDO echo "::: ...done."
 }
 
 stopServices(){
-$SUDO echo " "
-$SUDO echo "::: Stopping services..."
-$SUDO service dnsmasq stop || true
-$SUDO service lighttpd stop || true
-$SUDO echo "::: ...done."
+	$SUDO echo " "
+	$SUDO echo "::: Stopping services..."
+	$SUDO service dnsmasq stop || true
+	$SUDO service lighttpd stop || true
+	$SUDO echo "::: ...done."
 }
 
 installDependencies(){
-$SUDO echo " "
-$SUDO echo "::: Updating apt-get package list"
-$SUDO apt-get -qq update & spinner $!
-$SUDO echo "::: Upgrading apt-get packages"
-$SUDO apt-get -yqq upgrade & spinner $!
-$SUDO echo "::: ...done."
-$SUDO echo "::: installing dnsutils, bc, toilet, and figlet..."
-$SUDO apt-get -yqq install dnsutils bc toilet figlet & spinner $!
-$SUDO echo "::: ...done."
-$SUDO echo "::: Installing dnsmasq..."
-$SUDO apt-get -yqq install dnsmasq & spinner $!
-$SUDO echo "::: ...done."
-$SUDO echo "::: Installing lighttpd, php5-common, php5-cgi, and php5..."
-$SUDO apt-get -yqq install lighttpd php5-common php5-cgi php5 & spinner $!
-$SUDO echo "::: ...done."
-$SUDO echo "::: Installing git..."
-$SUDO apt-get -yqq install git & spinner $!
-$SUDO echo "::: ...done."
+	$SUDO echo " "
+	$SUDO echo "::: Updating apt-get package list"
+	$SUDO apt-get -qq update & spinner $!
+	$SUDO echo "::: Upgrading apt-get packages"
+	$SUDO apt-get -yqq upgrade & spinner $!
+	$SUDO echo "::: ...done."
+	$SUDO echo "::: installing dnsutils, bc, toilet, and figlet..."
+	$SUDO apt-get -yqq install dnsutils bc toilet figlet & spinner $!
+	$SUDO echo "::: ...done."
+	$SUDO echo "::: Installing dnsmasq..."
+	$SUDO apt-get -yqq install dnsmasq & spinner $!
+	$SUDO echo "::: ...done."
+	$SUDO echo "::: Installing lighttpd, php5-common, php5-cgi, and php5..."
+	$SUDO apt-get -yqq install lighttpd php5-common php5-cgi php5 & spinner $!
+	$SUDO echo "::: ...done."
+	$SUDO echo "::: Installing git..."
+	$SUDO apt-get -yqq install git & spinner $!
+	$SUDO echo "::: ...done."
 }
 
 installWebAdmin(){
-$SUDO echo " "
-$SUDO echo "::: Downloading and installing latest WebAdmin files..."
-if [ -d "/var/www/html/admin" ]; then	
-  $SUDO rm -rf /var/www/html/admin
-fi
-if [ -d "/var/www/html/AdminLTE-master" ]; then
-  $SUDO rm -rf /var/www/html/AdminLTE-master
-fi
-$SUDO wget -nv https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip & spinner $!
-$SUDO unzip -oq /var/www/master.zip -d /var/www/html/
-$SUDO mv /var/www/html/AdminLTE-master /var/www/html/admin
-$SUDO rm /var/www/master.zip 2>/dev/null
-$SUDO echo "::: ...Done."
-
-$SUDO echo "::: Creating log file and changing owner to dnsmasq..."
-if [ ! -f /var/log/pihole.log ]; then
-	$SUDO touch /var/log/pihole.log
-	$SUDO chmod 644 /var/log/pihole.log
-	$SUDO chown dnsmasq:root /var/log/pihole.log	
-else
-	$SUDO echo "::: No need to create, already exists!"
-fi
-$SUDO echo "::: ...done."
-
+	$SUDO echo " "
+	$SUDO echo "::: Downloading and installing latest WebAdmin files..."
+	if [ -d "/var/www/html/admin" ]; then
+		$SUDO rm -rf /var/www/html/admin
+	fi
+	if [ -d "/var/www/html/AdminLTE-master" ]; then
+		$SUDO rm -rf /var/www/html/AdminLTE-master
+	fi
+	$SUDO wget -nv https://github.com/jacobsalmela/AdminLTE/archive/master.zip -O /var/www/master.zip & spinner $!
+	$SUDO unzip -oq /var/www/master.zip -d /var/www/html/
+	$SUDO mv /var/www/html/AdminLTE-master /var/www/html/admin
+	$SUDO rm /var/www/master.zip 2>/dev/null
+	$SUDO echo "::: ...Done."
+	
+	$SUDO echo "::: Creating log file and changing owner to dnsmasq..."
+	if [ ! -f /var/log/pihole.log ]; then
+		$SUDO touch /var/log/pihole.log
+		$SUDO chmod 644 /var/log/pihole.log
+		$SUDO chown dnsmasq:root /var/log/pihole.log
+	else
+		$SUDO echo "::: No need to create, already exists!"
+	fi
+	$SUDO echo "::: ...done."
 }
 
 installPiholeWeb(){
-$SUDO echo " "
-$SUDO echo "::: Downloading and installing pihole custom index page..."
-if [ -d "/var/www/html/pihole" ]; then	
-  $SUDO echo "::: Existing page detected, not overwriting"
-else  
-	$SUDO mkdir /var/www/html/pihole
-	$SUDO mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
-	$SUDO curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html	
-fi
-$SUDO echo "::: ...done."
+	$SUDO echo " "
+	$SUDO echo "::: Downloading and installing pihole custom index page..."
+	if [ -d "/var/www/html/pihole" ]; then
+		$SUDO echo "::: Existing page detected, not overwriting"
+	else
+		$SUDO mkdir /var/www/html/pihole
+		$SUDO mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
+		$SUDO curl -o /var/www/html/pihole/index.html https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/index.html
+	fi
+	$SUDO echo "::: ...done."
 }
 
 installCron(){
-$SUDO echo " "
-$SUDO echo "::: Downloading latest Cron script..."
-$SUDO curl -o /etc/cron.d/pihole https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron
-$SUDO echo "::: ...done."
+	$SUDO echo " "
+	$SUDO echo "::: Downloading latest Cron script..."
+	$SUDO curl -o /etc/cron.d/pihole https://raw.githubusercontent.com/jacobsalmela/pi-hole/master/advanced/pihole.cron
+	$SUDO echo "::: ...done."
 }
 
-runGravity()
-{
-$SUDO echo " "
-$SUDO echo "::: Preparing to run gravity.sh to refresh hosts..."
-if ls /etc/pihole/list* 1> /dev/null 2>&1; then
-    echo "::: Cleaning up previous install (preserving whitelist/blacklist)"
-    $SUDO rm /etc/pihole/list.*
-fi
-#Don't run as SUDO, this was causing issues
-/usr/local/bin/gravity.sh
-$SUDO echo "::: ...done."
+runGravity(){
+	$SUDO echo " "
+	$SUDO echo "::: Preparing to run gravity.sh to refresh hosts..."
+	if ls /etc/pihole/list* 1> /dev/null 2>&1; then
+		echo "::: Cleaning up previous install (preserving whitelist/blacklist)"
+		$SUDO rm /etc/pihole/list.*
+	fi
+	#Don't run as SUDO, this was causing issues
+	/usr/local/bin/gravity.sh
+	$SUDO echo "::: ...done."
+}
+
+checkForAndInstallDependencies(){
+	if [ -d "/var/www/html/admin" ]; then
+		#Likely an existing install, no need to apt-get update
+		echo "::: Previous installation detected"
+	else
+		echo "::: First time install, updating package list"
+		$SUDO apt-get -qq update & spinner $!
+		echo "::: Upgrading installed apt-get packages"
+		$SUDO apt-get -yqq upgrade & spinner $!
+	fi
 }
 
 
-installPihole()
-{
-installDependencies
-stopServices
-$SUDO chown www-data:www-data /var/www/html
-$SUDO chmod 775 /var/www/html
-$SUDO usermod -a -G www-data pi
-$SUDO lighty-enable-mod fastcgi fastcgi-php
-installScripts
-installConfigs
-installWebAdmin
-installPiholeWeb
-installCron
-runGravity
-
+installPihole(){
+	installDependencies
+	stopServices
+	$SUDO chown www-data:www-data /var/www/html
+	$SUDO chmod 775 /var/www/html
+	$SUDO usermod -a -G www-data pi
+	$SUDO lighty-enable-mod fastcgi fastcgi-php
+	installScripts
+	installConfigs
+	installWebAdmin
+	installPiholeWeb
+	installCron
+	runGravity
 }
 
 displayFinalMessage(){
-	whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Configure your devices to use the Pi-hole as their DNS server using:
+whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Configure your devices to use the Pi-hole as their DNS server using:
 
-						$IPv4addr
-						$piholeIPv6
+$IPv4addr
+$piholeIPv6
 
 If you set a new IP address, you should restart the Pi.
 
@@ -403,13 +404,12 @@ welcomeDialogs
 
 # Just back up the original Pi-hole right away since it won't take long and it gets it out of the way
 backupLegacyPihole
-
 # Find interfaces and let the user choose one
 chooseInterface
-
 # Let the user decide if they want to block ads over IPv4 and/or IPv6
 use4andor6
 
+checkForAndInstallDependencies
 
 # Install and log everything to a file
 installPihole | tee $tmpLog

--- a/gravity.sh
+++ b/gravity.sh
@@ -11,6 +11,7 @@
 # (at your option) any later version.
 
 # Run this script as root or under sudo
+echo ":::"
 if [[ $EUID -eq 0 ]];then
 	echo "::: You are root."
 else

--- a/gravity.sh
+++ b/gravity.sh
@@ -12,7 +12,7 @@
 
 # Run this script as root or under sudo
 if [[ $EUID -eq 0 ]];then
-	echo "You are root."
+	echo "::: You are root."
 else
 	echo "::: sudo will be used."
   # Check if it is actually installed
@@ -72,14 +72,30 @@ eyeOfTheNeedle=$basename.4.wormhole.txt
 
 # After setting defaults, check if there's local overrides
 if [[ -r $piholeDir/pihole.conf ]];then
-    echo "** Local calibration requested..."
+    echo "::: Local calibration requested..."
         . $piholeDir/pihole.conf
 fi
 
+
+spinner(){
+        local pid=$1
+        local delay=0.001
+        local spinstr='/-\|'
+
+        spin='-\|/'
+        i=0
+        while kill -0 $pid 2>/dev/null
+        do
+                i=$(( (i+1) %4 ))
+                printf "\b${spin:$i:1}"
+                sleep .1
+        done
+        printf "\b"
+}
 ###########################
 # collapse - begin formation of pihole
 function gravity_collapse() {
-	echo "** Neutrino emissions detected..."
+	echo -n "::: Neutrino emissions detected..."
 
 	# Create the pihole resource directory if it doesn't exist.  Future files will be stored here
 	if [[ -d $piholeDir ]];then
@@ -87,10 +103,12 @@ function gravity_collapse() {
         # Will update later, needed for existing installs, new installs should
         # create this directory as non-root
         $SUDO chmod 777 $piholeDir
-        find "$piholeDir" -type f -exec $SUDO chmod 666 {} \;
+        find "$piholeDir" -type f -exec $SUDO chmod 666 {} \; & spinner $!
+        echo "."
 	else
-        echo "** Creating pihole directory..."
-        mkdir $piholeDir
+        echo -n "::: Creating pihole directory..."
+        mkdir $piholeDir & spinner $!
+        echo " done!"
 	fi
 }
 
@@ -103,10 +121,10 @@ function gravity_patternCheck() {
 		# and stored as is. They can be processed for content after they
 		# have been saved.
 		cp $patternBuffer $saveLocation
-		echo "List updated, transport successful..."
+		echo " List updated, transport successful!"
 	else
 		# curl didn't download any host files, probably because of the date check
-		echo "No changes detected, transport skipped..."
+		echo " No changes detected, transport skipped!"
 	fi
 }
 
@@ -125,9 +143,9 @@ function gravity_transport() {
 	fi
 
 	# Silently curl url
-	curl -s $cmd_ext $heisenbergCompensator -A "$agent" $url > $patternBuffer
+	curl -s $cmd_ext $heisenbergCompensator -A "$agent" $url > $patternBuffer 
 	# Check for list updates
-	gravity_patternCheck $patternBuffer
+	gravity_patternCheck $patternBuffer 
 
 	# Cleanup
 	rm -f $patternBuffer
@@ -135,7 +153,7 @@ function gravity_transport() {
 
 # spinup - main gravity function
 function gravity_spinup() {
-
+  echo "::: "
 	# Loop through domain list.  Download each one and remove commented lines (lines beginning with '# 'or '/') and	 		# blank lines
 	for ((i = 0; i < "${#sources[@]}"; i++))
 	do
@@ -149,7 +167,7 @@ function gravity_spinup() {
 
         agent="Mozilla/10.0"
 
-        echo -n "  Getting $domain list: "
+        echo -n "::: Getting $domain list..."
 
         # Use a case statement to download lists that need special cURL commands
         # to complete properly and reset the user agent when required
@@ -172,50 +190,69 @@ function gravity_spinup() {
 
 # Schwarzchild - aggregate domains to one list and add blacklisted domains
 function gravity_Schwarzchild() {
-
+  echo "::: "
 	# Find all active domains and compile them into one file and remove CRs
-	echo "** Aggregating list of domains..."
-	truncate -s 0 $piholeDir/$matterandlight
+	echo -n "::: Aggregating list of domains..."
+	truncate -s 0 $piholeDir/$matterandlight & spinner $! 
 	for i in "${activeDomains[@]}"
 	do
    		cat $i |tr -d '\r' >> $piholeDir/$matterandlight
 	done
+	echo " done!"
+	
 }
 
 
 function gravity_Blacklist(){
 	# Append blacklist entries if they exist
-	blacklist.sh -f -nr -q
+	echo -n "::: Running blacklist script to update HOSTS file...."
+	blacklist.sh -f -nr -q > /dev/null & spinner $!
+	
+	numBlacklisted=$(wc -l < "/etc/pihole/blacklist.txt")
+	plural=; [[ "$numBlacklisted" != "1" ]] && plural=s
+  echo " $numBlacklisted domain${plural} blacklisted!"
+  
+	
 }
 
 
 function gravity_Whitelist() {
+  echo ":::"
 	# Prevent our sources from being pulled into the hole
 	plural=; [[ "${sources[@]}" != "1" ]] && plural=s
-	echo "** Whitelisting ${#sources[@]} ad list source${plural}..."
+	echo -n "::: Adding ${#sources[@]} ad list source${plural} to the whitelist..."
 	
 	urls=()
 	for url in ${sources[@]}
 	do
         tmp=$(echo "$url" | awk -F '/' '{print $3}')
         urls=("${urls[@]}" $tmp)
-	done
+	done & spinner $!
+	echo " done!"
 	
-	whitelist.sh -f -nr -q ${urls[@]}
-
+	echo -n "::: Running whitelist script to update HOSTS file...."
+	whitelist.sh -f -nr -q ${urls[@]} > /dev/null & spinner $!
+		
+	numWhitelisted=$(wc -l < "/etc/pihole/whitelist.txt")
+	plural=; [[ "$numWhitelisted" != "1" ]] && plural=s
+  echo " $numWhitelisted domain${plural} whitelisted!"
+  
+  
 		
 }
 
 function gravity_unique() {
 	# Sort and remove duplicates
-	sort -u  $piholeDir/$supernova > $piholeDir/$eventHorizon
+	echo -n "::: Removing duplicate domains...."
+	sort -u  $piholeDir/$supernova > $piholeDir/$eventHorizon  & spinner $!
+	echo " done!"
 	numberOf=$(wc -l < $piholeDir/$eventHorizon)
-	echo "** $numberOf unique domains trapped in the event horizon."
+	echo "::: $numberOf unique domains trapped in the event horizon."
 }
 
 function gravity_hostFormat() {
-	# Format domain list as "192.168.x.x domain.com"
-	echo "** Formatting domains into a HOSTS file..."
+  # Format domain list as "192.168.x.x domain.com"
+	echo "::: Formatting domains into a HOSTS file..."
   # If there is a value in the $piholeIPv6, then IPv6 will be used, so the awk command modified to create a line for both protocols
   if [[ -n $piholeIPv6 ]];then
     cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' > $piholeDir/$accretionDisc
@@ -248,26 +285,31 @@ function gravity_advanced() {
 	# Most of the lists downloaded are already in hosts file format but the spacing/formating is not contigious
 	# This helps with that and makes it easier to read
 	# It also helps with debugging so each stage of the script can be researched more in depth
-	awk '($1 !~ /^#/) { if (NF>1) {print $2} else {print $1}}' $piholeDir/$matterandlight | sed -nr -e 's/\.{2,}/./g' -e '/\./p' >  $piholeDir/$supernova
-
+	echo -n "::: Formatting list of domains to remove comments...."
+	awk '($1 !~ /^#/) { if (NF>1) {print $2} else {print $1}}' $piholeDir/$matterandlight | sed -nr -e 's/\.{2,}/./g' -e '/\./p' >  $piholeDir/$supernova & spinner $!
+  echo " done!"
+  
 	numberOf=$(wc -l < $piholeDir/$supernova)
-	echo "** $numberOf domains being pulled in by gravity..."
-
+	echo "::: $numberOf domains being pulled in by gravity..."
+    
 	gravity_unique
+  
 }
 
 function gravity_reload() {
 	# Reload hosts file
-	echo "** Refresh lists in dnsmasq..."
+	echo ":::"
+	echo -n "::: Refresh lists in dnsmasq..."
 	dnsmasqPid=$(pidof dnsmasq)
 
 	if [[ $dnsmasqPid ]]; then
 		# service already running - reload config
-		$SUDO kill -HUP $dnsmasqPid
+		$SUDO kill -HUP $dnsmasqPid & spinner $!
 	else
 		# service not running, start it up
-		$SUDO service dnsmasq start
+		$SUDO service dnsmasq start & spinner $!
 	fi
+	echo " done!"
 }
 
 


### PR DESCRIPTION
This install script is a lot more intelligent than the last, which makes it safer to use as an update script.

The git repos for both pi-hole and the web interface are now cloned on initial install. Subsequent runs of `basic-install.sh` perform a `git pull` on each repo to get the latest updates, and then distribute the files to where they need to be.

An additional check at the beginning of the script checks to the last date that apt-get update was run, and will skip updating apt-get if it has already been run today. The rest of the script will carry on as normal.

Other scripts outputs changed to match install script.

TODO:
- [x] `basic-install.sh`
  - [X] Grab base files from github to `/etc/.pihole` (or update)
  - [X] Grab Web Admin files from github to `/var/www/html/admin` (or update)
  - [X] Check if dependencies are already installed before trying to install
  - [X] Make output easier to read
  - [x] ~~Implement `dnsmasq.conf` naming as suggested in #235~~ going to leave this to @ChadBHowell 
  - [X] Perform date check before running `apt-get update`/`apt-get upgrade`
- [x] `gravity.sh`
  - [x] Tidy up output to match install.sh
- [x] `whitelist.sh`
  - [x] faster whitelisting (I have a plan!)
- [x] `blacklist.sh`
  - [x] Tidy up output to match all of the above

An idea of how the output looks at moment:
![image](https://cloud.githubusercontent.com/assets/1998970/12534352/0a9da548-c24d-11e5-9298-4b580695fb8b.png)
