### PR TITLE
Hot fix/install script

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -300,11 +300,12 @@ checkForDependencies(){
  		# if so, advise the user to run apt-get update/upgrade at their own discretion
  		
  		today=$(date "+%b %e")
- 		
+ 		echo ":::"
  		echo -n "::: Checking apt-get for upgraded packages...."
  		updatesToInstall=$(sudo apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst) & spinner $!
  		echo " done!"
 		
+		echo ":::"
 		if [ $updatesToInstall > 0 ]; then
 			echo "::: There are $updatesToInstall updates availible for your pi!"
 			echo "::: Please consider running 'sudo apt-get update', followed by 'sudo apt-get upgrade'"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -305,7 +305,7 @@ checkForDependencies(){
  		updatesToInstall=$(sudo apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst) & spinner $!
  		echo " done!"
 		
-		if [ updatesToInstall > 0 ]; then
+		if [ $updatesToInstall > 0 ]; then
 			echo "::: There are $updatesToInstall updates availible for your pi!"
 			echo "::: Please consider running 'sudo apt-get update', followed by 'sudo apt-get upgrade'"
 			echo "::: after pi-hole has finished installing."

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -310,7 +310,16 @@ checkForDependencies(){
 			echo "::: Please consider running 'sudo apt-get update', followed by 'sudo apt-get upgrade'"
 			echo "::: after pi-hole has finished installing."
 			echo ":::"
-			echo "::: Continuing with pi-hole installation..."
+			#add in a prompt to give users the option to quit installation or continue
+			echo -n "::: Would you like to continue with the pi-hole installation? (Y/n):"
+			read answer
+			
+			case "$answer" in
+    		[yY][eE][sS]|[yY]  )  echo "::: Continuing!;;
+   		  *                  )  echo "::: Quitting install, please run 'curl -L install.pi-hole.net | bash' after updating packages!"
+              								exit 0;;
+			esac 			
+			
 		else
 		  echo "::: Your pi is up to date! Continuing with pi-hole installation..."
 		fi    

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -293,24 +293,27 @@ stopServices(){
 }
 
 checkForDependencies(){
- 		echo ":::" 		
- 		#Check to see if apt-get update has already been run today
- 		timestamp=$(stat -c %Y /var/cache/apt/)
- 		timestampAsDate=$(date -d @$timestamp "+%b %e")
+ 		
+ 		#Running apt-get update/upgrade with minimal output can cause some issues with
+ 		#requiring user input (e.g password for phpmyadmin see #218)
+ 		#We'll change the logic up here, to check to see if there are any updates availible and
+ 		# if so, advise the user to run apt-get update/upgrade at their own discretion
+ 		
  		today=$(date "+%b %e")
  		
- 		if [ ! "$today" == "$timestampAsDate" ]; then 		
-	    #update package lists
-	    echo -n "::: Updating package list before install...."
-	    $SUDO apt-get -qq update > /dev/null & spinner $!
-	    echo " done!"
-	    echo -n "::: Upgrading installed apt-get packages...."
-	    $SUDO apt-get -y -qq upgrade > /dev/null & spinner $!
-	    echo " done!"
-    else
-    	echo "::: Apt-get update already run today, any more would be overkill..."    
-    fi
-    
+ 		echo -n "::: Checking apt-get for upgraded packages...."
+ 		updatesToInstall=$(sudo apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst) & spinner $!
+ 		echo " done!"
+		
+		if [ updatesToInstall > 0 ]; then
+			echo "::: There are $updatesToInstall updates availible for your pi!"
+			echo "::: Please consider running 'sudo apt-get update', followed by 'sudo apt-get upgrade'"
+			echo "::: after pi-hole has finished installing.
+			echo ":::"
+			echo "::: Continuing with pi-hole installation..."
+		else
+		  echo "::: Your pi is up to date! Continuing with pi-hole installation..."
+		fi    
     
     echo ":::" 
     echo "::: Checking dependencies:"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -315,7 +315,7 @@ checkForDependencies(){
 			read answer
 			
 			case "$answer" in
-    		[yY][eE][sS]|[yY]  )  echo "::: Continuing!;;
+    		[yY][eE][sS]|[yY]  )  echo "::: Continuing!";;
    		  *                  )  echo "::: Quitting install, please run 'curl -L install.pi-hole.net | bash' after updating packages!"
               								exit 0;;
 			esac 			

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -308,7 +308,7 @@ checkForDependencies(){
 		if [ updatesToInstall > 0 ]; then
 			echo "::: There are $updatesToInstall updates availible for your pi!"
 			echo "::: Please consider running 'sudo apt-get update', followed by 'sudo apt-get upgrade'"
-			echo "::: after pi-hole has finished installing.
+			echo "::: after pi-hole has finished installing."
 			echo ":::"
 			echo "::: Continuing with pi-hole installation..."
 		else


### PR DESCRIPTION
Checks to see if there are any packages that need updating. If there are, offers the user a choice to cancel pi-hole installation and run `apt-get update` `apt-get upgrade` or continue with installation.

This addresses an issue brought up in #218 where the installer would hang if `apt-get upgrade` (which we were suppressing the output of, so as not to mess up the output of the install script) required user input.