### PR TITLE
Added nginx as an optional server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Once installed, [configure your router to have **DHCP clients use the Pi as thei
 - [Minibian Pi-hole](http://munkjensen.net/wiki/index.php/See_my_Pi-Hole#Minibian_Pi-hole)
 
 ## Coverage
+- [The Defrag Show - MSDN/Channel 9](https://channel9.msdn.com/Shows/The-Defrag-Show/Defrag-Endoscope-USB-Camera-The-Final-HoloLens-Vote-Adblock-Pi-and-more?WT.mc_id=dlvr_twitter_ch9#time=20m39s)
 - [MacObserver Podcast 585](http://www.macobserver.com/tmo/podcast/macgeekgab-585)
 - [Medium: Block All Ads For $53](https://medium.com/@robleathern/block-ads-on-all-home-devices-for-53-18-a5f1ec139693#.gj1xpgr5d)
 - [MakeUseOf: Adblock Everywhere, The Pi-hole Way](http://www.makeuseof.com/tag/adblock-everywhere-raspberry-pi-hole-way/)

--- a/advanced/nginx-pi-hole.conf
+++ b/advanced/nginx-pi-hole.conf
@@ -2,11 +2,11 @@ server {
     listen 80;
     listen [::]:80;
     root /var/www/html;
+    index index.php index.html index.nginx-debian.html;
 
     error_page 404 /pihole/index.html;
 
     location ~ ^/admin/ {
-        index index.php;
         add_header X-Pi-hole "The Pi-hole Web interface is working!";
 
         location ~ .php$ {
@@ -18,6 +18,6 @@ server {
     }
 
     location / {
-        add_header X-Pi-hole "A black hole for Internet advertisements.";
+        add_header X-Pi-hole "A black hole for Internet advertisements." always;
     }
 }

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -182,7 +182,7 @@ use4andor6(){
 useIPv6dialog(){
 	piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
 	whiptail --msgbox --backtitle "IPv6..." --title "IPv6 Supported" "$piholeIPv6 will be used to block ads." $r $c
-	$SUDO mkdir -p /etc/pihole/
+	
 	$SUDO touch /etc/pihole/.useIPv6
 }
 
@@ -448,7 +448,7 @@ runGravity(){
 installPihole(){
 	checkForDependencies # done
 	stopServices
-	
+	$SUDO mkdir -p /etc/pihole/
 	$SUDO chown www-data:www-data /var/www/html
 	$SUDO chmod 775 /var/www/html
 	$SUDO usermod -a -G www-data pi

--- a/block hulu ads/nginx-pi-hole.conf
+++ b/block hulu ads/nginx-pi-hole.conf
@@ -2,11 +2,11 @@ server {
     listen 80;
     listen [::]:80;
     root /var/www/html;
+    index index.php index.html index.nginx-debian.html;
 
     error_page 404 /pihole/index.html;
 
     location ~ ^/admin/ {
-        index index.php;
         add_header X-Pi-hole "The Pi-hole Web interface is working!";
 
         location ~ .php$ {
@@ -18,7 +18,7 @@ server {
     }
 
     location / {
-        add_header X-Pi-hole "A black hole for Internet advertisements.";
+        add_header X-Pi-hole "A black hole for Internet advertisements." always;
     }
 }
 


### PR DESCRIPTION
Why? For the glory of satan of course...
Also, many people tends to use their PIs for multiple purposes. As mail
servers, webpage hosting etc. Usually in that cases nginx is used as far
more powerful alternative to lighttpd, and fair more lighter than
apache. This patch allows them to unleash the power of pi-hole without
too much hacking.

Also, I'm the one of those people, and needed it ;).