### PR TITLE
Fixes gravity_transport variable interpretation.

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -186,7 +186,7 @@ function gravity_spinup() {
                 # Default is a simple request
                 *) cmd_ext=""
         esac
-        gravity_transport $url $cmd_ext $agent
+        gravity_transport "$url" "$cmd_ext" "$agent"
 	done
 }
 


### PR DESCRIPTION
Adding (") around Variables passed to function ensures
  spaces are handled and that missing arguments are
  accounted for.