### PR TITLE
Fixes IPv6 surviving a reinstall

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -148,6 +148,12 @@ chooseInterface() {
 	
 }
 
+cleanupIPv6() {
+	# Removes IPv6 indicator file if we are not using IPv6
+	if [ -f "/etc/pihole/.useIPv6" ] && [ ! $useIPv6 ]; then
+		rm /etc/pihole/.useIPv6
+	fi
+}
 
 use4andor6() {
 	# Let use select IPv4 and/or IPv6
@@ -187,6 +193,7 @@ use4andor6() {
 			echo "::: Exiting"
 			exit 1
 		fi
+		cleanupIPv6
 	else
 		echo "::: Cancel selected. Exiting..."
 		exit 1


### PR DESCRIPTION
Checks for and removes the .useIPv6 file if it exists and the user chose to not use IPv6.