### PR TITLE
Adding my docker project

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Once installed, [configure your router to have **DHCP clients use the Pi as thei
 - [unRaid-hole](https://github.com/spants/unraidtemplates/blob/master/Spants/unRaid-hole.xml#L13)--[Repo and more info](http://lime-technology.com/forum/index.php?PHPSESSID=c0eae3e5ef7e521f7866034a3336489d&topic=38486.0)
 - [Pi-hole on/off button](http://thetimmy.silvernight.org/pages/endisbutton/)
 - [Minibian Pi-hole](http://munkjensen.net/wiki/index.php/See_my_Pi-Hole#Minibian_Pi-hole)
+- [Docker Pi-hole x86](https://hub.docker.com/r/diginc/pi-hole/)
 
 ## Coverage
 - [Splunk: Pi-hole Visualizser](https://splunkbase.splunk.com/app/3023/)


### PR DESCRIPTION
Hi, I'm not sure if there has been much thought about dockerizing this project.  I went ahead and made the x86 version and was toying with the idea of [ARM for pi compatibility](https://github.com/diginc/docker-pi-hole/issues/2).

I can answer any questions about what does/doesn't work in the docker and replicating existing functionality (I may have missed stuff, I haven't ran this on a pi yet).  For example, the updating of the pi-hole/AdminLTE code: this could be done by git like the bash scripts do now, but I didn't install git into the docker containers because the docker image just needs to be re-built with the latest code - people `docker pull` that image changeset, `docker rm` the old container, and run the new container base image.  docker volume mounts of important logs/configs make data persist this ephemeral pattern.