### PR TITLE
IPv4 Choices

### DIFF
--- a/advanced/Scripts/blacklist.sh
+++ b/advanced/Scripts/blacklist.sh
@@ -34,13 +34,31 @@ domList=()
 domToRemoveList=()
 
 
-piholeIPfile=/tmp/piholeIP
+piholeINTfile=/etc/pihole/piholeINT
+piholeIPfile=/etc/pihole/piholeIP
 piholeIPv6file=/etc/pihole/.useIPv6
 
-# Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
-IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | awk 'END {print}')
-piholeIP=${piholeIPCIDR%/*}
+# Know which interface we are using.
+if [[ -f $piholeINTfile ]]; then
+    # This file should normally exist - it was saved as part of the install.
+    IPv4dev=$(cat $piholeINTfile)
+else
+    # If it doesn't, we err on the side of working with the majority of setups and detect the most likely interface.
+    IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
+    echo "::: Warning: ${piholeINTfile} is missing.  Using interface ${IPv4dev}."
+fi
+
+# Know which IPv4 address we are using.
+if [[ -f $piholeIPfile ]];then
+    # This file should normally exist - it was saved as part of the install.
+    piholeIP=$(cat $piholeIPfile)
+else
+    # If it doesn't, we err on the side of working with the majority of setups and detect the most likely IPv4 address,
+    # which is the first one we find belonging to the given interface.
+    piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | head -n 1)
+    piholeIP=${piholeIPCIDR%/*}
+    echo "::: Warning: ${piholeIPfile} is missing.  Using IPv4 address ${piholeIP}."
+fi
 
 modifyHost=false
 

--- a/advanced/Scripts/blacklist.sh
+++ b/advanced/Scripts/blacklist.sh
@@ -38,14 +38,16 @@ piholeINTfile=/etc/pihole/piholeINT
 piholeIPfile=/etc/pihole/piholeIP
 piholeIPv6file=/etc/pihole/.useIPv6
 
+echo ":::"
+
 # Know which interface we are using.
 if [[ -f $piholeINTfile ]]; then
     # This file should normally exist - it was saved as part of the install.
     IPv4dev=$(cat $piholeINTfile)
 else
     # If it doesn't, we err on the side of working with the majority of setups and detect the most likely interface.
+    echo "::: Warning: ${piholeINTfile} is missing.  Auto detecting interface."
     IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-    echo "::: Warning: ${piholeINTfile} is missing.  Using interface ${IPv4dev}."
 fi
 
 # Know which IPv4 address we are using.
@@ -55,10 +57,13 @@ if [[ -f $piholeIPfile ]];then
 else
     # If it doesn't, we err on the side of working with the majority of setups and detect the most likely IPv4 address,
     # which is the first one we find belonging to the given interface.
+    echo "::: Warning: ${piholeIPfile} is missing.  Auto detecting IP address."
     piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | head -n 1)
     piholeIP=${piholeIPCIDR%/*}
-    echo "::: Warning: ${piholeIPfile} is missing.  Using IPv4 address ${piholeIP}."
 fi
+
+echo "::: Large gravitational pull detected at ${piholeIP} (${IPv4dev})."
+echo ":::"
 
 modifyHost=false
 

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -33,13 +33,31 @@ versbose=true
 domList=()
 domToRemoveList=()
 
-piholeIPfile=/tmp/piholeIP
+piholeINTfile=/etc/pihole/piholeINT
+piholeIPfile=/etc/pihole/piholeIP
 piholeIPv6file=/etc/pihole/.useIPv6
 
-# Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
-IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | awk 'END {print}')
-piholeIP=${piholeIPCIDR%/*}
+# Know which interface we are using.
+if [[ -f $piholeINTfile ]]; then
+    # This file should normally exist - it was saved as part of the install.
+    IPv4dev=$(cat $piholeINTfile)
+else
+    # If it doesn't, we err on the side of working with the majority of setups and detect the most likely interface.
+    IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
+    echo "::: Warning: ${piholeINTfile} is missing.  Using interface ${IPv4dev}."
+fi
+
+# Know which IPv4 address we are using.
+if [[ -f $piholeIPfile ]];then
+    # This file should normally exist - it was saved as part of the install.
+    piholeIP=$(cat $piholeIPfile)
+else
+    # If it doesn't, we err on the side of working with the majority of setups and detect the most likely IPv4 address,
+    # which is the first one we find belonging to the given interface.
+    piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | head -n 1)
+    piholeIP=${piholeIPCIDR%/*}
+    echo "::: Warning: ${piholeIPfile} is missing.  Using IPv4 address ${piholeIP}."
+fi
 
 modifyHost=false
 

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -37,14 +37,16 @@ piholeINTfile=/etc/pihole/piholeINT
 piholeIPfile=/etc/pihole/piholeIP
 piholeIPv6file=/etc/pihole/.useIPv6
 
+echo ":::"
+
 # Know which interface we are using.
 if [[ -f $piholeINTfile ]]; then
     # This file should normally exist - it was saved as part of the install.
     IPv4dev=$(cat $piholeINTfile)
 else
     # If it doesn't, we err on the side of working with the majority of setups and detect the most likely interface.
+    echo "::: Warning: ${piholeINTfile} is missing.  Auto detecting interface."
     IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-    echo "::: Warning: ${piholeINTfile} is missing.  Using interface ${IPv4dev}."
 fi
 
 # Know which IPv4 address we are using.
@@ -54,10 +56,13 @@ if [[ -f $piholeIPfile ]];then
 else
     # If it doesn't, we err on the side of working with the majority of setups and detect the most likely IPv4 address,
     # which is the first one we find belonging to the given interface.
+    echo "::: Warning: ${piholeIPfile} is missing.  Auto detecting IP address."
     piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | head -n 1)
     piholeIP=${piholeIPCIDR%/*}
-    echo "::: Warning: ${piholeIPfile} is missing.  Using IPv4 address ${piholeIP}."
 fi
+
+echo "::: Large gravitational pull detected at ${piholeIP} (${IPv4dev})."
+echo ":::"
 
 modifyHost=false
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -192,9 +192,13 @@ use4andor6() {
 		done
 		
         if [ $useIPv4 ]; then
-			getStaticIPv4Settings
-			setStaticIPv4
-			echo "::: Using IPv4 on $IPv4addr"
+            if (whiptail --backtitle "IPv4" --title "Reconfigure IPv4" --yesno "Do you wish to reconfigure your IPv4 settings?  (If you have not changed these before on this Pi then choose yes.)
+                                        IPv4 address:    $IPv4addr
+                                        Gateway:         $IPv4gw" $r $c) then
+                getStaticIPv4Settings
+                setStaticIPv4
+            fi
+            echo "::: Using IPv4 on $IPv4addr"
         else
             echo "::: Using IPv6 on $piholeIPv6"
         fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -147,17 +147,17 @@ chooseInterface() {
 	interfaceCount=$(echo "$availableInterfaces" | wc -l)
 	chooseInterfaceCmd=(whiptail --separate-output --radiolist "Choose An Interface" $r $c $interfaceCount)
 	chooseInterfaceOptions=$("${chooseInterfaceCmd[@]}" "${interfacesArray[@]}" 2>&1 >/dev/tty)
-	if [[ ! ($? = 0) ]]; then
-		echo "::: Cancel selected, exiting...."
-		exit 1
-	fi
-	
-	for desiredInterface in $chooseInterfaceOptions
-	do
+	if [[ $? = 0 ]];then
+		for desiredInterface in $chooseInterfaceOptions
+		do
 		piholeInterface=$desiredInterface
 		echo "::: Using interface: $piholeInterface"
 		echo ${piholeInterface} > /tmp/piholeINT
-	done
+		done
+	else
+		echo "::: Cancel selected, exiting...."
+		exit 1
+	fi
 	
 }
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -173,8 +173,8 @@ chooseInterface() {
 			if [[ $firstloop -eq 1 ]]; then
 				firstloop=0
 				mode="ON"
-			IPv4Array+=("$line" "available" "$mode")
 			fi
+			IPv4Array+=("$line" "available" "$mode")
 		done <<< "$IPv4addresses"
 		
 		# Find out how many IP addresses are available to choose from

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -191,24 +191,21 @@ use4andor6() {
 			esac
 		done
 		
-		if [ $useIPv4 ] && [ ! $useIPv6 ]; then
+        if [ $useIPv4 ]; then
 			getStaticIPv4Settings
 			setStaticIPv4
 			echo "::: Using IPv4 on $IPv4addr"
-			echo "::: IPv6 will NOT be used."
-		fi
-		if [ ! $useIPv4 ] && [ $useIPv6 ]; then
-			useIPv6dialog
-			echo "::: IPv4 will NOT be used."
-			echo "::: Using IPv6 on $piholeIPv6"
-		fi
-		if [ $useIPv4 ] && [  $useIPv6 ]; then
-			getStaticIPv4Settings
-			setStaticIPv4
-			useIPv6dialog
-			echo "::: Using IPv4 on $IPv4addr"
-			echo "::: Using IPv6 on $piholeIPv6"
-		fi
+        else
+            echo "::: Using IPv6 on $piholeIPv6"
+        fi
+        
+        if [ $useIPv6 ]; then
+            useIPv6dialog
+            echo "::: Using IPv6 on $piholeIPv6"
+        else
+            echo "::: IPv6 will NOT be used."
+        fi
+        
 		if [ ! $useIPv4 ] && [ ! $useIPv6 ]; then
 			echo "::: Cannot continue, neither IPv4 or IPv6 selected"
 			echo "::: Exiting"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -43,7 +43,9 @@ IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1
 IPv4addr=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | awk 'END {print}')
 IPv4gw=$(ip route get 8.8.8.8 | awk '{print $3}')
 
-availableInterfaces=$(ip -o link | awk '{print $2}' | grep -v "lo" | cut -d':' -f1)
+# All interfaces, including interface "labels"
+# i.e. multiple IPs on one physical interface.
+availableInterfaces=$(ifconfig -a | sed 's/[ \t].*//;/^\(lo\|\)$/d')
 dhcpcdFile=/etc/dhcpcd.conf
 
 ######## FIRST CHECK ########

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -152,7 +152,6 @@ chooseInterface() {
 		do
 		piholeInterface=$desiredInterface
 		echo "::: Using interface: $piholeInterface"
-		echo ${piholeInterface} > /tmp/piholeINT
 		done
 	else
 		echo "::: Cancel selected, exiting...."
@@ -219,6 +218,9 @@ use4andor6() {
 										Gateway:         $IPv4gw" $r $c)
 			then
 				echo "::: Leaving IPv4 settings as is."
+				# Saving the IP and interface to a file for future use by other scripts (gravity.sh, whitelist.sh, etc.)
+				echo ${IPv4addr%/*} > /etc/pihole/piholeIP
+				echo $piholeInterface > /etc/pihole/piholeINT
 			else
 				getStaticIPv4Settings
 				setStaticIPv4
@@ -284,9 +286,9 @@ getStaticIPv4Settings() {
 							IP address:    $IPv4addr
 							Gateway:       $IPv4gw" $r $c)then
 							# If the settings are correct, then we need to set the piholeIP
-							# Saving it to a temporary file us to retrieve it later when we run the gravity.sh script
-							echo ${IPv4addr%/*} > /tmp/piholeIP
-							echo $piholeInterface > /tmp/piholeINT
+							# Saving the IP and interface to a file for future use by other scripts (gravity.sh, whitelist.sh, etc.)
+							echo ${IPv4addr%/*} > /etc/pihole/piholeIP
+							echo $piholeInterface > /etc/pihole/piholeINT
 							# After that's done, the loop ends and we move on
 							ipSettingsCorrect=True
 					else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -191,25 +191,25 @@ use4andor6() {
 			esac
 		done
 		
-        if [ $useIPv4 ]; then
-            if (whiptail --backtitle "IPv4" --title "Reconfigure IPv4" --yesno "Do you wish to reconfigure your IPv4 settings?  (If you have not changed these before on this Pi then choose yes.)
-                                        IPv4 address:    $IPv4addr
-                                        Gateway:         $IPv4gw" $r $c) then
-                getStaticIPv4Settings
-                setStaticIPv4
-            fi
-            echo "::: Using IPv4 on $IPv4addr"
-        else
-            echo "::: Using IPv6 on $piholeIPv6"
-        fi
-        
-        if [ $useIPv6 ]; then
-            useIPv6dialog
-            echo "::: Using IPv6 on $piholeIPv6"
-        else
-            echo "::: IPv6 will NOT be used."
-        fi
-        
+		if [ $useIPv4 ]; then
+			if (whiptail --backtitle "IPv4" --title "Reconfigure IPv4" --yesno "Do you wish to reconfigure your IPv4 settings?  (If you have not changed these before on this Pi then choose yes.)
+										IPv4 address:    $IPv4addr
+										Gateway:         $IPv4gw" $r $c) then
+				getStaticIPv4Settings
+				setStaticIPv4
+			fi
+			echo "::: Using IPv4 on $IPv4addr"
+		else
+			echo "::: Using IPv6 on $piholeIPv6"
+		fi
+		
+		if [ $useIPv6 ]; then
+			useIPv6dialog
+			echo "::: Using IPv6 on $piholeIPv6"
+		else
+			echo "::: IPv6 will NOT be used."
+		fi
+		
 		if [ ! $useIPv4 ] && [ ! $useIPv6 ]; then
 			echo "::: Cannot continue, neither IPv4 or IPv6 selected"
 			echo "::: Exiting"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -226,7 +226,7 @@ use4andor6() {
 			fi
 			echo "::: Using IPv4 on $IPv4addr"
 		else
-			echo "::: Using IPv6 on $piholeIPv6"
+			echo "::: IPv4 will NOT be used."
 		fi
 		
 		if [ $useIPv6 ]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -36,6 +36,9 @@ columns=$(tput cols)
 r=$(( rows / 2 ))
 c=$(( columns / 2 ))
 
+piholeINTfile=/etc/pihole/piholeINT
+piholeIPfile=/etc/pihole/piholeIP
+piholeIPv6file=/etc/pihole/.useIPv6
 
 availableInterfaces=$(ip -o link | awk '{print $2}' | grep -v "lo" | cut -d':' -f1)
 dhcpcdFile=/etc/dhcpcd.conf
@@ -219,8 +222,8 @@ use4andor6() {
 			then
 				echo "::: Leaving IPv4 settings as is."
 				# Saving the IP and interface to a file for future use by other scripts (gravity.sh, whitelist.sh, etc.)
-				echo ${IPv4addr%/*} > /etc/pihole/piholeIP
-				echo $piholeInterface > /etc/pihole/piholeINT
+				echo ${IPv4addr%/*} > "${piholeIPfile}"
+				echo $piholeInterface > "${piholeINTfile}"
 			else
 				getStaticIPv4Settings
 				setStaticIPv4
@@ -287,8 +290,8 @@ getStaticIPv4Settings() {
 							Gateway:       $IPv4gw" $r $c)then
 							# If the settings are correct, then we need to set the piholeIP
 							# Saving the IP and interface to a file for future use by other scripts (gravity.sh, whitelist.sh, etc.)
-							echo ${IPv4addr%/*} > /etc/pihole/piholeIP
-							echo $piholeInterface > /etc/pihole/piholeINT
+							echo ${IPv4addr%/*} > "${piholeIPfile}"
+							echo $piholeInterface > "${piholeINTfile}"
 							# After that's done, the loop ends and we move on
 							ipSettingsCorrect=True
 					else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -147,7 +147,7 @@ chooseInterface() {
 	interfaceCount=$(echo "$availableInterfaces" | wc -l)
 	chooseInterfaceCmd=(whiptail --separate-output --radiolist "Choose An Interface" $r $c $interfaceCount)
 	chooseInterfaceOptions=$("${chooseInterfaceCmd[@]}" "${interfacesArray[@]}" 2>&1 >/dev/tty)
-	if [[ ! ($? = 0) ]];then
+	if [[ ! ($? = 0) ]]; then
 		echo "::: Cancel selected, exiting...."
 		exit 1
 	fi
@@ -179,7 +179,7 @@ chooseInterface() {
 		
 		# Find out how many IP addresses are available to choose from
 		IPv4Count=$(echo "$IPv4addresses" | wc -l)
-		chooseIPv4Cmd=(whiptail --separate-output --radiolist "Choose an IPv4 address on this interface." $r $c $IPv4Count)
+		chooseIPv4Cmd=(whiptail --separate-output --radiolist "Choose an IPv4 address on this interface.\n\n(If you are unsure, leave it as the default.)" $r $c $IPv4Count)
 		IPv4addr=$("${chooseIPv4Cmd[@]}" "${IPv4Array[@]}" 2>&1 >/dev/tty)
 		
 		if [[ ! ($? = 0) ]];then
@@ -215,9 +215,12 @@ use4andor6() {
 		done
 		
 		if [ $useIPv4 ]; then
-			if (whiptail --backtitle "IPv4" --title "Reconfigure IPv4" --yesno "Do you wish to reconfigure your IPv4 settings?  (If you have not changed these before on this Pi then choose yes.)
+			if (whiptail --backtitle "IPv4" --title "Reconfigure IPv4" --yesno --defaultno "Have you already configured a static IPv4 address on your Raspberry Pi as desired?\n\n(If you are unsure, choose No.)  \n\nCurrent settings:
 										IPv4 address:    $IPv4addr
-										Gateway:         $IPv4gw" $r $c) then
+										Gateway:         $IPv4gw" $r $c)
+			then
+				echo "::: Leaving IPv4 settings as is."
+			else
 				getStaticIPv4Settings
 				setStaticIPv4
 			fi

--- a/gravity.sh
+++ b/gravity.sh
@@ -35,14 +35,16 @@ adListDefault=/etc/pihole/adlists.default
 whitelistScript=/usr/local/bin/whitelist.sh
 blacklistScript=/usr/local/bin/blacklist.sh
 
+echo ":::"
+
 # Know which interface we are using.
 if [[ -f $piholeINTfile ]]; then
     # This file should normally exist - it was saved as part of the install.
     IPv4dev=$(cat $piholeINTfile)
 else
     # If it doesn't, we err on the side of working with the majority of setups and detect the most likely interface.
+    echo "::: Warning: ${piholeINTfile} is missing.  Auto detecting interface."
     IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-    echo "::: Warning: ${piholeINTfile} is missing.  Using interface ${IPv4dev}."
 fi
 
 # Know which IPv4 address we are using.
@@ -52,10 +54,13 @@ if [[ -f $piholeIPfile ]];then
 else
     # If it doesn't, we err on the side of working with the majority of setups and detect the most likely IPv4 address,
     # which is the first one we find belonging to the given interface.
+    echo "::: Warning: ${piholeIPfile} is missing.  Auto detecting IP address."
     piholeIPCIDR=$(ip -o -f inet addr show dev $IPv4dev | awk '{print $4}' | head -n 1)
     piholeIP=${piholeIPCIDR%/*}
-    echo "::: Warning: ${piholeIPfile} is missing.  Using IPv4 address ${piholeIP}."
 fi
+
+echo "::: Large gravitational pull detected at ${piholeIP} (${IPv4dev})."
+echo ":::"
 
 if [[ -f $piholeIPv6file ]];then
     # If the file exists, then the user previously chose to use IPv6 in the automated installer


### PR DESCRIPTION
Changes proposed in this pull request:
- Ask the user if they have already configured a static IPv4 address, and if they choose yes then skip IPv4 configuration.  Default is no.
- Allow for interfaces that have multiple IPv4 addresses assigned; after the user selects an interface prompt for which IP address they wish to use.  This works with the iproute2 method with a single name for multiple IPs (e.g. "eth0" with 192.168.0.10 and 192.168.0.11).  It doesn't work with the deprecated ifconfig method with multiple aliases (e.g. "eth0" with 192.168.0.10, "eth0:0" with 192.168.0.11.).
- Simplified the main logic of the use4andor6 function to help enable the above.

@pihole/gravity
