### PR TITLE
Choice of web server (lighttpd vs manual configuration)

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -760,7 +760,10 @@ displayFinalMessage
 echo -n "::: Restarting services..."
 # Start services
 $SUDO service dnsmasq restart
-$SUDO service lighttpd start
+if [[ "$webServer" = "lighttpd" ]]
+then
+	$SUDO service lighttpd start
+fi
 echo " done."
 
 echo ":::"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -306,7 +306,7 @@ setStaticIPv4() {
 
 function chooseWebServer() {
 	# Allow the user to choose the web server they wish to use.
-	chooseWebServerCmd=(whiptail --separate-output --radiolist "Pi-hole will automatically configure the lighttpd web server for you.  Alternatively, if you prefer, pi-hole can use a web server that you have previously manually configured yourself.\n\n(If you are unsure, choose lighttpd.)" $r $c 2)
+	chooseWebServerCmd=(whiptail --separate-output --radiolist "Pi-hole will automatically configure the lighttpd web server for you.\n\nAlternatively, if you prefer, pi-hole can use a web server that you have previously manually configured yourself.\n\n(If you are unsure, choose lighttpd.)" $r $c 2)
 	chooseWebServerOptions=(lighttpd "" on
 							Manual "" off)
 	webServer=$("${chooseWebServerCmd[@]}" "${chooseWebServerOptions[@]}" 2>&1 >/dev/tty)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -306,10 +306,14 @@ setStaticIPv4() {
 
 function chooseWebServer() {
 	# Allow the user to choose the web server they wish to use.
-	chooseWebServerCmd=(whiptail --separate-output --radiolist "pi-hole will automatically configure the lighttpd web server for you.  Alternatively, if you prefer, pi-hole can use a web server that you have previously manually configured yourself.\n\n(If you are unsure, choose lighttpd.)" $r $c 2)
+	chooseWebServerCmd=(whiptail --separate-output --radiolist "Pi-hole will automatically configure the lighttpd web server for you.  Alternatively, if you prefer, pi-hole can use a web server that you have previously manually configured yourself.\n\n(If you are unsure, choose lighttpd.)" $r $c 2)
 	chooseWebServerOptions=(lighttpd "" on
 							Manual "" off)
 	webServer=$("${chooseWebServerCmd[@]}" "${chooseWebServerOptions[@]}" 2>&1 >/dev/tty)
+	if [[ ! ($? = 0) ]]; then
+		echo "::: Cancel selected, exiting...."
+		exit 1
+	fi
 	case $webServer in
 		lighttpd)
 			echo "::: Using lighttpd web server."
@@ -317,7 +321,7 @@ function chooseWebServer() {
 			;;
 		Manual)
 			echo "::: Using manual web server configuration."
-			webRoot=$(whiptail --backtitle "Web Root" --title "Web Root" --inputbox "Enter the root path of the website you have manually configured for the pi-hole." $r $c "/var/www/html" 3>&1 1>&2 2>&3)
+			webRoot=$(whiptail --backtitle "Web Root" --title "Web Root" --inputbox "Enter the root path of the website you have manually configured for Pi-hole." $r $c "/var/www/html" 3>&1 1>&2 2>&3)
 			;;
 	esac
 	webInterfaceDir="${webRoot}/admin"
@@ -560,6 +564,7 @@ checkForDependencies() {
     echo "::: Checking dependencies:"
 
 	dependencies=( dnsutils bc toilet figlet dnsmasq php5-common php5-cgi php5 git curl unzip wget )
+	# Add lighttpd to the list if required.
 	if [[ "$webServer" = "lighttpd" ]]
 	then
 		dependencies=( "${dependencies[@]}" "lighttpd" )

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -305,7 +305,8 @@ setStaticIPv4() {
 }
 
 function chooseWebServer() {
-	chooseWebServerCmd=(whiptail --separate-output --radiolist "pi-hole can automatically configure the lighttpd web server for you.  Alternatively you can manually configure a web server yourself." $r $c 2)
+	# Allow the user to choose the web server they wish to use.
+	chooseWebServerCmd=(whiptail --separate-output --radiolist "pi-hole will automatically configure the lighttpd web server for you.  Alternatively, if you prefer, pi-hole can use a web server that you have previously manually configured yourself.\n\n(If you are unsure, choose lighttpd.)" $r $c 2)
 	chooseWebServerOptions=(lighttpd "" on
 							Manual "" off)
 	webServer=$("${chooseWebServerCmd[@]}" "${chooseWebServerOptions[@]}" 2>&1 >/dev/tty)
@@ -316,7 +317,7 @@ function chooseWebServer() {
 			;;
 		Manual)
 			echo "::: Using manual web server configuration."
-			webRoot=$(whiptail --backtitle "Web Root" --title "Web Root" --inputbox "Enter your website root path." $r $c "/var/www/html" 3>&1 1>&2 2>&3)
+			webRoot=$(whiptail --backtitle "Web Root" --title "Web Root" --inputbox "Enter the root path of the website you have manually configured for the pi-hole." $r $c "/var/www/html" 3>&1 1>&2 2>&3)
 			;;
 	esac
 	webInterfaceDir="${webRoot}/admin"


### PR DESCRIPTION
Changes proposed in this pull request:
- Allows the user to choose between Pi-hole using and automatically configuring lighttpd, and installing to another web server the user has manually configured.
- If the user chooses Manual, it prompts them for their web root (default /var/www/html), and it skips further lighttpd related steps.

@pihole/gravity
