### PR TITLE
Use of sudo, pihole user, permissions.

### DIFF
--- a/advanced/Scripts/blacklist.sh
+++ b/advanced/Scripts/blacklist.sh
@@ -37,8 +37,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $@"
-		sudo -u pihole "$@"
+		echo "::: Running sudo -u pihole $0 $@"
+		sudo -u pihole "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo."

--- a/advanced/Scripts/blacklist.sh
+++ b/advanced/Scripts/blacklist.sh
@@ -23,28 +23,9 @@ if [[ $# = 0 ]]; then
     exit 1
 fi
 
-# Check if pihole user, and if not then rerun with sudo.
-echo ":::"
-runninguser=$(whoami)
-if [[ "$runninguser" = "pihole"  ]];then
-	echo "::: You are pihole user."
-	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
-	# rather than rerunning as sudo. Just in case it turns up by accident, 
-	# explicitly set the $SUDO variable to an empty string.
-	SUDO=""
-else
-	echo "::: sudo will be used."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $0 $@"
-		sudo -u pihole "$0" "$@"
-		exit $?
-	else
-		echo "::: Please install sudo."
-	exit 1
-	fi
-fi
+source /usr/local/include/pihole/piholeInclude
+
+rerun_pihole "$0" "$@"
 
 #globals
 blacklist=/etc/pihole/blacklist.txt

--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -24,8 +24,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $@"
-		sudo -u pihole "$@"
+		echo "::: Running sudo -u pihole $0 $@"
+		sudo -u pihole "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo."

--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -10,6 +10,28 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
+# Check if pihole user, and if not then rerun with sudo.
+echo ":::"
+runninguser=$(whoami)
+if [[ "$runninguser" = "pihole"  ]];then
+	echo "::: You are pihole user."
+	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
+	# rather than rerunning as sudo. Just in case it turns up by accident, 
+	# explicitly set the $SUDO variable to an empty string.
+	SUDO=""
+else
+	echo "::: sudo will be used."
+	# Check if it is actually installed
+	# If it isn't, exit because the install cannot complete
+	if [[ $(dpkg-query -s sudo) ]];then
+		echo "::: Running sudo -u pihole $@"
+		sudo -u pihole "$@"
+		exit $?
+	else
+		echo "::: Please install sudo."
+	exit 1
+	fi
+fi
 
 #Functions##############################################################################################################
 piLog="/var/log/pihole.log"

--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -10,28 +10,9 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-# Check if pihole user, and if not then rerun with sudo.
-echo ":::"
-runninguser=$(whoami)
-if [[ "$runninguser" = "pihole"  ]];then
-	echo "::: You are pihole user."
-	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
-	# rather than rerunning as sudo. Just in case it turns up by accident, 
-	# explicitly set the $SUDO variable to an empty string.
-	SUDO=""
-else
-	echo "::: sudo will be used."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $0 $@"
-		sudo -u pihole "$0" "$@"
-		exit $?
-	else
-		echo "::: Please install sudo."
-	exit 1
-	fi
-fi
+source /usr/local/include/pihole/piholeInclude
+
+rerun_pihole "$0" "$@"
 
 #Functions##############################################################################################################
 piLog="/var/log/pihole.log"

--- a/advanced/Scripts/piholeInclude
+++ b/advanced/Scripts/piholeInclude
@@ -17,7 +17,7 @@ SUDO=""
 
 function rerun_root() {
 	# Check if root, and if not then rerun with sudo.
-	# The parent script should pass its $0 and $@ to this function's $1 and $2
+	# The parent script should pass its $0 and $@ to this function.
 	echo ":::"
 	if [[ $EUID -eq 0 ]];then
 		echo "::: You are root."
@@ -26,8 +26,8 @@ function rerun_root() {
 		# Check if it is actually installed
 		# If it isn't, exit because the install cannot complete
 		if [[ $(dpkg-query -s sudo) ]];then
-			echo "::: Running sudo $1 $2"
-			sudo "$1" "$2"
+			echo "::: Running sudo $@"
+			sudo "$@"
 			exit $?
 		else
 			echo "::: Please install sudo."
@@ -38,7 +38,7 @@ function rerun_root() {
 
 function rerun_pihole() {
 	# Check if pihole user, and if not then rerun with sudo.
-	# The parent script should pass its $0 and $@ to this function's $1 and $2
+	# The parent script should pass its $0 and $@ to this function.
 	echo ":::"
 	runninguser=$(whoami)
 	if [[ "$runninguser" = "pihole"  ]];then
@@ -48,8 +48,8 @@ function rerun_pihole() {
 		# Check if it is actually installed
 		# If it isn't, exit because the install cannot complete
 		if [[ $(dpkg-query -s sudo) ]];then
-			echo "::: Running sudo -u pihole $1 $2"
-			sudo -u pihole "$1" "$2"
+			echo "::: Running sudo -u pihole $@"
+			sudo -u pihole "$@"
 			exit $?
 		else
 			echo "::: Please install sudo."

--- a/advanced/Scripts/piholeInclude
+++ b/advanced/Scripts/piholeInclude
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2015, 2016 by Jacob Salmela
+# Network-wide ad blocking via your Raspberry Pi
+# http://pi-hole.net
+# Include for other pihole scripts.
+#
+# Pi-hole is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+
+# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
+# rather than rerunning with sudo. Just in case it turns up by accident, 
+# explicitly set the $SUDO variable to an empty string.
+SUDO=""
+
+function rerun_root() {
+	# Check if root, and if not then rerun with sudo.
+	# The parent script should pass its $0 and $@ to this function's $1 and $2
+	echo ":::"
+	if [[ $EUID -eq 0 ]];then
+		echo "::: You are root."
+	else
+		echo "::: sudo will be used."
+		# Check if it is actually installed
+		# If it isn't, exit because the install cannot complete
+		if [[ $(dpkg-query -s sudo) ]];then
+			echo "::: Running sudo $1 $2"
+			sudo "$1" "$2"
+			exit $?
+		else
+			echo "::: Please install sudo."
+		exit 1
+		fi
+	fi
+}
+
+function rerun_pihole() {
+	# Check if pihole user, and if not then rerun with sudo.
+	# The parent script should pass its $0 and $@ to this function's $1 and $2
+	echo ":::"
+	runninguser=$(whoami)
+	if [[ "$runninguser" = "pihole"  ]];then
+		echo "::: You are pihole user."
+	else
+		echo "::: sudo will be used."
+		# Check if it is actually installed
+		# If it isn't, exit because the install cannot complete
+		if [[ $(dpkg-query -s sudo) ]];then
+			echo "::: Running sudo -u pihole $1 $2"
+			sudo -u pihole "$1" "$2"
+			exit $?
+		else
+			echo "::: Please install sudo."
+		exit 1
+		fi
+	fi
+}
+

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -24,8 +24,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $@"
-		sudo -u pihole "$@"
+		echo "::: Running sudo -u pihole $0 $@"
+		sudo -u pihole "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo."

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -10,27 +10,8 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-# Check if pihole user, and if not then rerun with sudo.
-echo ":::"
-runninguser=$(whoami)
-if [[ "$runninguser" = "pihole"  ]];then
-	echo "::: You are pihole user."
-	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
-	# rather than rerunning as sudo. Just in case it turns up by accident, 
-	# explicitly set the $SUDO variable to an empty string.
-	SUDO=""
-else
-	echo "::: sudo will be used."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $0 $@"
-		sudo -u pihole "$0" "$@"
-		exit $?
-	else
-		echo "::: Please install sudo."
-	exit 1
-	fi
-fi
+source /usr/local/include/pihole/piholeInclude
+
+rerun_root "$0" "$@"
 
 truncate -s 0 /var/log/pihole.log

--- a/advanced/Scripts/piholeReloadServices.sh
+++ b/advanced/Scripts/piholeReloadServices.sh
@@ -3,18 +3,17 @@
 # (c) 2015, 2016 by Jacob Salmela
 # Network-wide ad blocking via your Raspberry Pi
 # http://pi-hole.net
-# Flushes /var/log/pihole.log
+# Restarts pihole services
 #
 # Pi-hole is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-# Check if pihole user, and if not then rerun with sudo.
+# Check if root, and if not then rerun with sudo.
 echo ":::"
-runninguser=$(whoami)
-if [[ "$runninguser" = "pihole"  ]];then
-	echo "::: You are pihole user."
+if [[ $EUID -eq 0 ]];then
+	echo "::: You are root."
 	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
 	# rather than rerunning as sudo. Just in case it turns up by accident, 
 	# explicitly set the $SUDO variable to an empty string.
@@ -24,13 +23,38 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $@"
-		sudo -u pihole "$@"
+		echo "::: Running sudo $@"
+		sudo "$@"
 		exit $?
 	else
-		echo "::: Please install sudo."
+		echo "::: Please install sudo or run this script as root."
 	exit 1
 	fi
 fi
 
-truncate -s 0 /var/log/pihole.log
+
+spinner(){
+        local pid=$1
+        local delay=0.001
+        local spinstr='/-\|'
+
+        spin='-\|/'
+        i=0
+        while kill -0 $pid 2>/dev/null
+        do
+                i=$(( (i+1) %4 ))
+                printf "\b${spin:$i:1}"
+                sleep .1
+        done
+        printf "\b"
+}
+
+dnsmasqPid=$(pidof dnsmasq)
+
+if [[ $dnsmasqPid ]]; then
+	# service already running - reload config
+	$SUDO kill -HUP $dnsmasqPid & spinner $!
+else
+	# service not running, start it up
+	$SUDO service dnsmasq start & spinner $!
+fi

--- a/advanced/Scripts/piholeReloadServices.sh
+++ b/advanced/Scripts/piholeReloadServices.sh
@@ -10,27 +10,9 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-# Check if root, and if not then rerun with sudo.
-echo ":::"
-if [[ $EUID -eq 0 ]];then
-	echo "::: You are root."
-	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
-	# rather than rerunning as sudo. Just in case it turns up by accident, 
-	# explicitly set the $SUDO variable to an empty string.
-	SUDO=""
-else
-	echo "::: sudo will be used."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo $0 $@"
-		sudo "$0" "$@"
-		exit $?
-	else
-		echo "::: Please install sudo or run this script as root."
-	exit 1
-	fi
-fi
+source /usr/local/include/pihole/piholeInclude
+
+rerun_root "$0" "$@"
 
 
 spinner(){

--- a/advanced/Scripts/piholeReloadServices.sh
+++ b/advanced/Scripts/piholeReloadServices.sh
@@ -23,8 +23,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo $@"
-		sudo "$@"
+		echo "::: Running sudo $0 $@"
+		sudo "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo or run this script as root."

--- a/advanced/Scripts/piholeSetPermissions.sh
+++ b/advanced/Scripts/piholeSetPermissions.sh
@@ -3,18 +3,17 @@
 # (c) 2015, 2016 by Jacob Salmela
 # Network-wide ad blocking via your Raspberry Pi
 # http://pi-hole.net
-# Flushes /var/log/pihole.log
+# Sets permissions to pihole files and directories
 #
 # Pi-hole is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-# Check if pihole user, and if not then rerun with sudo.
+# Check if root, and if not then rerun with sudo.
 echo ":::"
-runninguser=$(whoami)
-if [[ "$runninguser" = "pihole"  ]];then
-	echo "::: You are pihole user."
+if [[ $EUID -eq 0 ]];then
+	echo "::: You are root."
 	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
 	# rather than rerunning as sudo. Just in case it turns up by accident, 
 	# explicitly set the $SUDO variable to an empty string.
@@ -24,13 +23,14 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $@"
-		sudo -u pihole "$@"
+		echo "::: Running sudo $@"
+		sudo "$@"
 		exit $?
 	else
-		echo "::: Please install sudo."
+		echo "::: Please install sudo or run this script as root."
 	exit 1
 	fi
 fi
 
-truncate -s 0 /var/log/pihole.log
+chown --recursive root:pihole /etc/pihole
+chmod --recursive ug=rwX,o=rX /etc/pihole

--- a/advanced/Scripts/piholeSetPermissions.sh
+++ b/advanced/Scripts/piholeSetPermissions.sh
@@ -10,27 +10,9 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-# Check if root, and if not then rerun with sudo.
-echo ":::"
-if [[ $EUID -eq 0 ]];then
-	echo "::: You are root."
-	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
-	# rather than rerunning as sudo. Just in case it turns up by accident, 
-	# explicitly set the $SUDO variable to an empty string.
-	SUDO=""
-else
-	echo "::: sudo will be used."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo $0 $@"
-		sudo "$0" "$@"
-		exit $?
-	else
-		echo "::: Please install sudo or run this script as root."
-	exit 1
-	fi
-fi
+source /usr/local/include/pihole/piholeInclude
+
+rerun_root "$0" "$@"
 
 chown --recursive root:pihole /etc/pihole
 chmod --recursive ug=rwX,o=rX /etc/pihole

--- a/advanced/Scripts/piholeSetPermissions.sh
+++ b/advanced/Scripts/piholeSetPermissions.sh
@@ -23,8 +23,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo $@"
-		sudo "$@"
+		echo "::: Running sudo $0 $@"
+		sudo "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo or run this script as root."

--- a/advanced/Scripts/setupLCD.sh
+++ b/advanced/Scripts/setupLCD.sh
@@ -15,21 +15,6 @@ source /usr/local/include/pihole/piholeInclude
 rerun_root "$0" "$@"
 
 ############ FUNCTIONS ###########
-# Run this script as root or under sudo
-echo ":::"
-if [[ $EUID -eq 0 ]];then
-	echo "::: You are root."
-else
-	echo "::: sudo will be used."
-  # Check if it is actually installed
-  # If it isn't, exit because the install cannot complete
-  if [[ $(dpkg-query -s sudo) ]];then
-		export SUDO="sudo"
-  else
-		echo "::: Please install sudo or run this script as root."
-    exit 1
-  fi
-fi
 
 # Borrowed from adafruit-pitft-helper < borrowed from raspi-config
 # https://github.com/adafruit/Adafruit-PiTFT-Helper/blob/master/adafruit-pitft-helper#L324-L334

--- a/advanced/Scripts/setupLCD.sh
+++ b/advanced/Scripts/setupLCD.sh
@@ -10,27 +10,9 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-# Check if root, and if not then rerun with sudo.
-echo ":::"
-if [[ $EUID -eq 0 ]];then
-	echo "::: You are root."
-	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
-	# rather than rerunning as sudo. Just in case it turns up by accident, 
-	# explicitly set the $SUDO variable to an empty string.
-	SUDO=""
-else
-	echo "::: sudo will be used."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo $0 $@"
-		sudo "$0" "$@"
-		exit $?
-	else
-		echo "::: Please install sudo or run this script as root."
-	exit 1
-	fi
-fi
+source /usr/local/include/pihole/piholeInclude
+
+rerun_root "$0" "$@"
 
 ############ FUNCTIONS ###########
 # Run this script as root or under sudo

--- a/advanced/Scripts/setupLCD.sh
+++ b/advanced/Scripts/setupLCD.sh
@@ -23,8 +23,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo $@"
-		sudo "$@"
+		echo "::: Running sudo $0 $@"
+		sudo "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo or run this script as root."

--- a/advanced/Scripts/setupLCD.sh
+++ b/advanced/Scripts/setupLCD.sh
@@ -10,6 +10,28 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
+# Check if root, and if not then rerun with sudo.
+echo ":::"
+if [[ $EUID -eq 0 ]];then
+	echo "::: You are root."
+	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
+	# rather than rerunning as sudo. Just in case it turns up by accident, 
+	# explicitly set the $SUDO variable to an empty string.
+	SUDO=""
+else
+	echo "::: sudo will be used."
+	# Check if it is actually installed
+	# If it isn't, exit because the install cannot complete
+	if [[ $(dpkg-query -s sudo) ]];then
+		echo "::: Running sudo $@"
+		sudo "$@"
+		exit $?
+	else
+		echo "::: Please install sudo or run this script as root."
+	exit 1
+	fi
+fi
+
 ############ FUNCTIONS ###########
 # Run this script as root or under sudo
 echo ":::"
@@ -45,11 +67,11 @@ getInitSys() {
 autoLoginPiToConsole() {
   if [ -e /etc/init.d/lightdm ]; then
     if [ $SYSTEMD -eq 1 ]; then
-      $SUDO systemctl set-default multi-user.target
-      $SUDO ln -fs /etc/systemd/system/autologin@.service /etc/systemd/system/getty.target.wants/getty@tty1.service
+      systemctl set-default multi-user.target
+      ln -fs /etc/systemd/system/autologin@.service /etc/systemd/system/getty.target.wants/getty@tty1.service
     else
-      $SUDO update-rc.d lightdm disable 2
-      $SUDO sed /etc/inittab -i -e "s/1:2345:respawn:\/sbin\/getty --noclear 38400 tty1/1:2345:respawn:\/bin\/login -f pi tty1 <\/dev\/tty1 >\/dev\/tty1 2>&1/"
+      update-rc.d lightdm disable 2
+      sed /etc/inittab -i -e "s/1:2345:respawn:\/sbin\/getty --noclear 38400 tty1/1:2345:respawn:\/bin\/login -f pi tty1 <\/dev\/tty1 >\/dev\/tty1 2>&1/"
       fi
   fi
 }
@@ -62,27 +84,27 @@ autoLoginPiToConsole
 # Set chronomter to run automatically when pi logs in
 echo /usr/local/bin/chronometer.sh >> /home/pi/.bashrc
 # OR
-#$SUDO echo /usr/local/bin/chronometer.sh >> /etc/profile
+#echo /usr/local/bin/chronometer.sh >> /etc/profile
 
 # Set up the LCD screen based on Adafruits instuctions:
 # https://learn.adafruit.com/adafruit-pitft-28-inch-resistive-touchscreen-display-raspberry-pi/easy-install
-curl -SLs https://apt.adafruit.com/add-pin | $SUDO bash
-$SUDO apt-get -y install raspberrypi-bootloader
-$SUDO apt-get -y install adafruit-pitft-helper
-$SUDO adafruit-pitft-helper -t 28r
+curl -SLs https://apt.adafruit.com/add-pin | bash
+apt-get -y install raspberrypi-bootloader
+apt-get -y install adafruit-pitft-helper
+adafruit-pitft-helper -t 28r
 
 # Download the cmdline.txt file that prevents the screen from going blank after a period of time
-$SUDO mv /boot/cmdline.txt /boot/cmdline.orig
-$SUDO curl -o /boot/cmdline.txt https://raw.githubusercontent.com/pi-hole/pi-hole/master/advanced/cmdline.txt
+mv /boot/cmdline.txt /boot/cmdline.orig
+curl -o /boot/cmdline.txt https://raw.githubusercontent.com/pi-hole/pi-hole/master/advanced/cmdline.txt
 
 # Back up the original file and download the new one
-$SUDO mv /etc/default/console-setup /etc/default/console-setup.orig
-$SUDO curl -o /etc/default/console-setup https://raw.githubusercontent.com/pi-hole/pi-hole/master/advanced/console-setup
+mv /etc/default/console-setup /etc/default/console-setup.orig
+curl -o /etc/default/console-setup https://raw.githubusercontent.com/pi-hole/pi-hole/master/advanced/console-setup
 
 # Instantly apply the font change to the LCD screen
-$SUDO setupcon
+setupcon
 
-$SUDO reboot
+reboot
 
 # Start showing the stats on the screen by running the command on another tty:
 # http://unix.stackexchange.com/questions/170063/start-a-process-on-a-different-tty

--- a/advanced/Scripts/updateDashboard.sh
+++ b/advanced/Scripts/updateDashboard.sh
@@ -10,6 +10,10 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
+source /usr/local/include/pihole/piholeInclude
+
+rerun_pihole "$0" "$@"
+
 WEB_INTERFACE_GIT_URL="https://github.com/pi-hole/AdminLTE.git"
 WEB_INTERFACE_DIR="/var/www/html/admin"
 
@@ -22,12 +26,6 @@ main() {
 }
 
 prerequisites() {
-
-    # must be root to update
-    if [[ $EUID -ne 0 ]]; then
-        sudo bash "$0" "$@"
-        exit $?
-    fi
 
     # web interface must already exist. this is a (lazy)
     # check to make sure pihole is actually installed.

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -37,8 +37,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $@"
-		sudo -u pihole "$@"
+		echo "::: Running sudo -u pihole $0 $@"
+		sudo -u pihole "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo."

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -23,6 +23,29 @@ if [[ $# = 0 ]]; then
     exit 1
 fi
 
+# Check if pihole user, and if not then rerun with sudo.
+echo ":::"
+runninguser=$(whoami)
+if [[ "$runninguser" = "pihole"  ]];then
+	echo "::: You are pihole user."
+	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
+	# rather than rerunning as sudo. Just in case it turns up by accident, 
+	# explicitly set the $SUDO variable to an empty string.
+	SUDO=""
+else
+	echo "::: sudo will be used."
+	# Check if it is actually installed
+	# If it isn't, exit because the install cannot complete
+	if [[ $(dpkg-query -s sudo) ]];then
+		echo "::: Running sudo -u pihole $@"
+		sudo -u pihole "$@"
+		exit $?
+	else
+		echo "::: Please install sudo."
+	exit 1
+	fi
+fi
+
 #globals
 whitelist=/etc/pihole/whitelist.txt
 adList=/etc/pihole/gravity.list
@@ -162,15 +185,11 @@ function Reload() {
 	# Reload hosts file
 	echo ":::"
 	echo -n "::: Refresh lists in dnsmasq..."
-	dnsmasqPid=$(pidof dnsmasq)
 
-	if [[ $dnsmasqPid ]]; then
-		# service already running - reload config
-		sudo kill -HUP $dnsmasqPid
-	else
-		# service not running, start it up
-		sudo service dnsmasq start
-	fi
+	# Reloading services requires root.
+	# The installer should have created a file in sudoers.d to allow pihole user
+	# to run piholeReloadServices.sh as root with sudo without a password
+	sudo --non-interactive /usr/local/bin/piholeReloadServices.sh
 	echo " done!"
 }
 

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -23,28 +23,9 @@ if [[ $# = 0 ]]; then
     exit 1
 fi
 
-# Check if pihole user, and if not then rerun with sudo.
-echo ":::"
-runninguser=$(whoami)
-if [[ "$runninguser" = "pihole"  ]];then
-	echo "::: You are pihole user."
-	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
-	# rather than rerunning as sudo. Just in case it turns up by accident, 
-	# explicitly set the $SUDO variable to an empty string.
-	SUDO=""
-else
-	echo "::: sudo will be used."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $0 $@"
-		sudo -u pihole "$0" "$@"
-		exit $?
-	else
-		echo "::: Please install sudo."
-	exit 1
-	fi
-fi
+source /usr/local/include/pihole/piholeInclude
+
+rerun_pihole "$0" "$@"
 
 #globals
 whitelist=/etc/pihole/whitelist.txt

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -16,6 +16,28 @@
 #
 # curl -L install.pi-hole.net | bash
 
+######## ROOT #########
+# Check if root, and if not then rerun with sudo.
+echo ":::"
+if [[ $EUID -eq 0 ]];then
+	echo "::: You are root."
+	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
+	# rather than rerunning as sudo. Just in case it turns up by accident, 
+	# explicitly set the $SUDO variable to an empty string.
+	SUDO=""
+else
+	echo "::: sudo will be used."
+	# Check if it is actually installed
+	# If it isn't, exit because the install cannot complete
+	if [[ $(dpkg-query -s sudo) ]];then
+		echo "::: Running sudo $@"
+		sudo "$@"
+		exit $?
+	else
+		echo "::: Please install sudo or run this script as root."
+	exit 1
+	fi
+fi
 
 ######## VARIABLES #########
 
@@ -47,22 +69,6 @@ availableInterfaces=$(ip -o link | awk '{print $2}' | grep -v "lo" | cut -d':' -
 dhcpcdFile=/etc/dhcpcd.conf
 
 ######## FIRST CHECK ########
-# Must be root to install
-echo ":::"
-if [[ $EUID -eq 0 ]];then
-	echo "::: You are root."
-else
-	echo "::: sudo will be used for the install."
-	# Check if it is actually installed
-	# If it isn't, exit because the install cannot complete
-	if [[ $(dpkg-query -s sudo) ]];then
-		export SUDO="sudo"
-	else
-		echo "::: Please install sudo or run this as root."
-		exit 1
-	fi
-fi
-
 
 if [ -d "/etc/pihole" ]; then
 		# Likely an existing install
@@ -78,7 +84,7 @@ spinner() {
 
 	spin='-\|/'
 	i=0
-	while $SUDO kill -0 $pid 2>/dev/null
+	while kill -0 $pid 2>/dev/null
 	do
 		i=$(( (i+1) %4 ))
 		printf "\b${spin:$i:1}"
@@ -91,13 +97,13 @@ backupLegacyPihole() {
 	# This function detects and backups the pi-hole v1 files.  It will not do anything to the current version files.
 	if [[ -f /etc/dnsmasq.d/adList.conf ]];then
 		echo "::: Original Pi-hole detected.  Initiating sub space transport"
-		$SUDO mkdir -p /etc/pihole/original/
-		$SUDO mv /etc/dnsmasq.d/adList.conf /etc/pihole/original/adList.conf.$(date "+%Y-%m-%d")
-		$SUDO mv /etc/dnsmasq.conf /etc/pihole/original/dnsmasq.conf.$(date "+%Y-%m-%d")
-		$SUDO mv /etc/resolv.conf /etc/pihole/original/resolv.conf.$(date "+%Y-%m-%d")
-		$SUDO mv /etc/lighttpd/lighttpd.conf /etc/pihole/original/lighttpd.conf.$(date "+%Y-%m-%d")
-		$SUDO mv /var/www/pihole/index.html /etc/pihole/original/index.html.$(date "+%Y-%m-%d")
-		$SUDO mv /usr/local/bin/gravity.sh /etc/pihole/original/gravity.sh.$(date "+%Y-%m-%d")
+		mkdir -p /etc/pihole/original/
+		mv /etc/dnsmasq.d/adList.conf /etc/pihole/original/adList.conf.$(date "+%Y-%m-%d")
+		mv /etc/dnsmasq.conf /etc/pihole/original/dnsmasq.conf.$(date "+%Y-%m-%d")
+		mv /etc/resolv.conf /etc/pihole/original/resolv.conf.$(date "+%Y-%m-%d")
+		mv /etc/lighttpd/lighttpd.conf /etc/pihole/original/lighttpd.conf.$(date "+%Y-%m-%d")
+		mv /var/www/pihole/index.html /etc/pihole/original/index.html.$(date "+%Y-%m-%d")
+		mv /usr/local/bin/gravity.sh /etc/pihole/original/gravity.sh.$(date "+%Y-%m-%d")
 	else
 		:
 	fi
@@ -224,7 +230,7 @@ useIPv6dialog() {
 	piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
 	whiptail --msgbox --backtitle "IPv6..." --title "IPv6 Supported" "$piholeIPv6 will be used to block ads." $r $c
 
-	$SUDO touch /etc/pihole/.useIPv6
+	touch /etc/pihole/.useIPv6
 }
 
 getStaticIPv4Settings() {
@@ -287,7 +293,7 @@ setDHCPCD() {
 	echo "::: interface $piholeInterface
 	static ip_address=$IPv4addr
 	static routers=$IPv4gw
-	static domain_name_servers=$IPv4gw" | $SUDO tee -a $dhcpcdFile >/dev/null
+	static domain_name_servers=$IPv4gw" | tee -a $dhcpcdFile >/dev/null
 }
 
 setStaticIPv4() {
@@ -297,7 +303,7 @@ setStaticIPv4() {
 		:
 	else
 		setDHCPCD
-		$SUDO ip addr replace dev $piholeInterface $IPv4addr
+		ip addr replace dev $piholeInterface $IPv4addr
 		echo ":::"
 		echo "::: Setting IP to $IPv4addr.  You may need to restart after the install is complete."
 		echo ":::"
@@ -437,66 +443,66 @@ versionCheckDNSmasq(){
       if grep -q $dnsSearch $dnsFile1; then
           echo " it is from a previous pi-hole install."
           echo -n ":::    Backing up dnsmasq.conf to dnsmasq.conf.orig..."
-          $SUDO mv -f $dnsFile1 $dnsFile2
+          mv -f $dnsFile1 $dnsFile2
           echo " done."
           echo -n ":::    Restoring default dnsmasq.conf..."
-          $SUDO cp $defaultFile $dnsFile1
+          cp $defaultFile $dnsFile1
           echo " done."
       else
         echo " it is not a pi-hole file, leaving alone!"        
       fi
   else
       echo -n ":::    No dnsmasq.conf found.. restoring default dnsmasq.conf..."
-      $SUDO cp $defaultFile $dnsFile1
+      cp $defaultFile $dnsFile1
       echo " done."
   fi
   
   echo -n ":::    Copying 01-pihole.conf to /etc/dnsmasq.d/01-pihole.conf..."
-  $SUDO cp $newFileToInstall $newFileFinalLocation
+  cp $newFileToInstall $newFileFinalLocation
   echo " done."
-  $SUDO sed -i "s/@INT@/$piholeInterface/" $newFileFinalLocation
+  sed -i "s/@INT@/$piholeInterface/" $newFileFinalLocation
   if [[ "$piholeDNS1" != "" ]]; then
-    $SUDO sed -i "s/@DNS1@/$piholeDNS1/" $newFileFinalLocation
+    sed -i "s/@DNS1@/$piholeDNS1/" $newFileFinalLocation
   else
-    $SUDO sed -i '/^server=@DNS1@/d' $newFileFinalLocation
+    sed -i '/^server=@DNS1@/d' $newFileFinalLocation
   fi
   if [[ "$piholeDNS2" != "" ]]; then
-    $SUDO sed -i "s/@DNS2@/$piholeDNS2/" $newFileFinalLocation
+    sed -i "s/@DNS2@/$piholeDNS2/" $newFileFinalLocation
   else
-    $SUDO sed -i '/^server=@DNS2@/d' $newFileFinalLocation
+    sed -i '/^server=@DNS2@/d' $newFileFinalLocation
   fi
 }
 
 installScripts() {
 	# Install the scripts from /etc/.pihole to their various locations
-	$SUDO echo ":::"
-	$SUDO echo -n "::: Installing scripts..."
-	$SUDO cp /etc/.pihole/gravity.sh /usr/local/bin/gravity.sh
-	$SUDO cp /etc/.pihole/advanced/Scripts/chronometer.sh /usr/local/bin/chronometer.sh
-	$SUDO cp /etc/.pihole/advanced/Scripts/whitelist.sh /usr/local/bin/whitelist.sh
-	$SUDO cp /etc/.pihole/advanced/Scripts/blacklist.sh /usr/local/bin/blacklist.sh
-	$SUDO cp /etc/.pihole/advanced/Scripts/piholeLogFlush.sh /usr/local/bin/piholeLogFlush.sh
-	$SUDO cp /etc/.pihole/advanced/Scripts/updateDashboard.sh /usr/local/bin/updateDashboard.sh
-	$SUDO chmod 755 /usr/local/bin/{gravity,chronometer,whitelist,blacklist,piholeLogFlush,updateDashboard}.sh
-	$SUDO echo " done."
+	echo ":::"
+	echo -n "::: Installing scripts..."
+	cp /etc/.pihole/gravity.sh /usr/local/bin/gravity.sh
+	cp /etc/.pihole/advanced/Scripts/chronometer.sh /usr/local/bin/chronometer.sh
+	cp /etc/.pihole/advanced/Scripts/whitelist.sh /usr/local/bin/whitelist.sh
+	cp /etc/.pihole/advanced/Scripts/blacklist.sh /usr/local/bin/blacklist.sh
+	cp /etc/.pihole/advanced/Scripts/piholeLogFlush.sh /usr/local/bin/piholeLogFlush.sh
+	cp /etc/.pihole/advanced/Scripts/updateDashboard.sh /usr/local/bin/updateDashboard.sh
+	chmod 755 /usr/local/bin/{gravity,chronometer,whitelist,blacklist,piholeLogFlush,updateDashboard}.sh
+	echo " done."
 }
 
 installConfigs() {
 	# Install the configs from /etc/.pihole to their various locations
-	$SUDO echo ":::"
-	$SUDO echo "::: Installing configs..."
+	echo ":::"
+	echo "::: Installing configs..."
 	versionCheckDNSmasq
-	$SUDO mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
-	$SUDO cp /etc/.pihole/advanced/lighttpd.conf /etc/lighttpd/lighttpd.conf
+	mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
+	cp /etc/.pihole/advanced/lighttpd.conf /etc/lighttpd/lighttpd.conf
 }
 
 stopServices() {
 	# Stop dnsmasq and lighttpd
-	$SUDO echo ":::"
-	$SUDO echo -n "::: Stopping services..."
-	#$SUDO service dnsmasq stop & spinner $! || true
-	$SUDO service lighttpd stop & spinner $! || true
-	$SUDO echo " done."
+	echo ":::"
+	echo -n "::: Stopping services..."
+	#service dnsmasq stop & spinner $! || true
+	service lighttpd stop & spinner $! || true
+	echo " done."
 }
 
 checkForDependencies() {
@@ -516,12 +522,12 @@ checkForDependencies() {
 	    #update package lists
 	    echo ":::"
 	    echo -n "::: apt-get update has not been run today. Running now..."
-	    $SUDO apt-get -qq update & spinner $!
+	    apt-get -qq update & spinner $!
 	    echo " done!"
 	  fi
 		echo ":::"
 		echo -n "::: Checking apt-get for upgraded packages...."
-		updatesToInstall=$($SUDO apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst)
+		updatesToInstall=$(apt-get -s -o Debug::NoLocking=true upgrade | grep -c ^Inst)
 		echo " done!"
 		echo ":::"
 		if [[ $updatesToInstall -eq "0" ]]; then
@@ -541,7 +547,7 @@ checkForDependencies() {
 		echo -n ":::    Checking for $i..."
 		if [ $(dpkg-query -W -f='${Status}' $i 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
 			echo -n " Not found! Installing...."
-			$SUDO apt-get -y -qq install $i > /dev/null & spinner $!
+			apt-get -y -qq install $i > /dev/null & spinner $!
 			echo " done!"
 		else
 			echo " already installed!"
@@ -582,8 +588,8 @@ is_repo() {
 make_repo() {
     # Remove the non-repod interface and clone the interface
     echo -n ":::    Cloning $2 into $1..."
-    $SUDO rm -rf $1
-    $SUDO git clone -q "$2" "$1" > /dev/null & spinner $!
+    rm -rf $1
+    git clone -q "$2" "$1" > /dev/null & spinner $!
     echo " done!"
 }
 
@@ -591,7 +597,7 @@ update_repo() {
     # Pull the latest commits
     echo -n ":::     Updating repo in $1..."
     cd "$1"
-    $SUDO git pull -q > /dev/null & spinner $!
+    git pull -q > /dev/null & spinner $!
     echo " done!"
 }
 
@@ -599,46 +605,46 @@ update_repo() {
 CreateLogFile() {
 	# Create logfiles if necessary
 	echo ":::"
-	$SUDO  echo -n "::: Creating log file and changing owner to dnsmasq..."
+	echo -n "::: Creating log file and changing owner to dnsmasq..."
 	if [ ! -f /var/log/pihole.log ]; then
-		$SUDO touch /var/log/pihole.log
-		$SUDO chmod 644 /var/log/pihole.log
-		$SUDO chown dnsmasq:root /var/log/pihole.log
-		$SUDO echo " done!"
+		touch /var/log/pihole.log
+		chmod 644 /var/log/pihole.log
+		chown dnsmasq:root /var/log/pihole.log
+		echo " done!"
 	else
-		$SUDO  echo " already exists!"
+		echo " already exists!"
 	fi
 }
 
 installPiholeWeb() {
 	# Install the web interface
-	$SUDO echo ":::"
-	$SUDO echo -n "::: Installing pihole custom index page..."
+	echo ":::"
+	echo -n "::: Installing pihole custom index page..."
 	if [ -d "/var/www/html/pihole" ]; then
-		$SUDO echo " Existing page detected, not overwriting"
+		echo " Existing page detected, not overwriting"
 	else
-		$SUDO mkdir /var/www/html/pihole
-		$SUDO mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
-		$SUDO cp /etc/.pihole/advanced/index.html /var/www/html/pihole/index.html
-		$SUDO echo " done!"
+		mkdir /var/www/html/pihole
+		mv /var/www/html/index.lighttpd.html /var/www/html/index.lighttpd.orig
+		cp /etc/.pihole/advanced/index.html /var/www/html/pihole/index.html
+		echo " done!"
 	fi
 }
 
 installCron() {
 	# Install the cron job
-	$SUDO echo ":::"
-	$SUDO echo -n "::: Installing latest Cron script..."
-	$SUDO cp /etc/.pihole/advanced/pihole.cron /etc/cron.d/pihole
-	$SUDO echo " done!"
+	echo ":::"
+	echo -n "::: Installing latest Cron script..."
+	cp /etc/.pihole/advanced/pihole.cron /etc/cron.d/pihole
+	echo " done!"
 }
 
 runGravity() {
 	# Rub gravity.sh to build blacklists
-	$SUDO echo ":::"
-	$SUDO echo "::: Preparing to run gravity.sh to refresh hosts..."	
+	echo ":::"
+	echo "::: Preparing to run gravity.sh to refresh hosts..."	
 	if ls /etc/pihole/list* 1> /dev/null 2>&1; then
 		echo "::: Cleaning up previous install (preserving whitelist/blacklist)"		
-		$SUDO rm /etc/pihole/list.*
+		rm /etc/pihole/list.*
 	fi
 	#Don't run as SUDO, this was causing issues
 	echo "::: Running gravity.sh"
@@ -654,7 +660,7 @@ setUser(){
 		echo "::: User 'pihole' already exists"
 	else
         echo "::: User 'pihole' doesn't exist.  Creating..."
-		$SUDO useradd -r -s /usr/sbin/nologin pihole
+		useradd -r -s /usr/sbin/nologin pihole
 	fi
 }
 
@@ -663,11 +669,11 @@ installPihole() {
 	checkForDependencies # done
 	stopServices
 	setUser
-	$SUDO mkdir -p /etc/pihole/
-	$SUDO chown www-data:www-data /var/www/html
-	$SUDO chmod 775 /var/www/html
-	$SUDO usermod -a -G www-data pihole
-	$SUDO lighty-enable-mod fastcgi fastcgi-php > /dev/null
+	mkdir -p /etc/pihole/
+	chown www-data:www-data /var/www/html
+	chmod 775 /var/www/html
+	usermod -a -G www-data pihole
+	lighty-enable-mod fastcgi fastcgi-php > /dev/null
 
 	getGitFiles
 	installScripts
@@ -692,7 +698,7 @@ The install log is in /etc/pihole." $r $c
 
 ######## SCRIPT ############
 # Start the installer
-$SUDO mkdir -p /etc/pihole/
+mkdir -p /etc/pihole/
 welcomeDialogs
 
 # Verify there is enough disk space for the install
@@ -712,14 +718,14 @@ setDNS
 installPihole | tee $tmpLog
 
 # Move the log file into /etc/pihole for storage
-$SUDO mv $tmpLog $instalLogLoc
+mv $tmpLog $instalLogLoc
 
 displayFinalMessage
 
 echo -n "::: Restarting services..."
 # Start services
-$SUDO service dnsmasq restart
-$SUDO service lighttpd start
+service dnsmasq restart
+service lighttpd start
 echo " done."
 
 echo ":::"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -30,8 +30,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo $@"
-		sudo "$@"
+		echo "::: Running sudo $0 $@"
+		sudo "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo or run this script as root."

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -677,7 +677,7 @@ installSudoersFile() {
 	# Install the file in /etc/sudoers.d that defines what commands
 	# and scripts the pihole user can elevate to root with sudo.
 	sudoersFile='/etc/sudoers.d/pihole'
-	sudoersContent="pihole	ALL=(ALL:ALL) NOPASSWD: /usr/local/bin/piholeReloadServices.sh /usr/local/bin/piholeSetPermissions.sh"
+	sudoersContent="pihole	ALL=(ALL:ALL) NOPASSWD: /usr/local/bin/piholeReloadServices.sh, /usr/local/bin/piholeSetPermissions.sh"
 	echo "$sudoersContent" > "$sudoersFile"
 	# chmod as per /etc/sudoers.d/README
 	chmod 0440 "$sudoersFile"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -493,6 +493,9 @@ installScripts() {
 	cp /etc/.pihole/advanced/Scripts/piholeLogFlush.sh /usr/local/bin/piholeLogFlush.sh
 	cp /etc/.pihole/advanced/Scripts/updateDashboard.sh /usr/local/bin/updateDashboard.sh
 	chmod 755 /usr/local/bin/{gravity,chronometer,whitelist,blacklist,piholeReloadServices,piholeSetPermissions,piholeLogFlush,updateDashboard}.sh
+	
+	mkdir -p /usr/local/include/pihole
+	cp /etc/.pihole/advanced/Scripts/piholeInclude /usr/local/include/pihole/piholeInclude
 	echo " done."
 }
 

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -80,4 +80,5 @@ rm /usr/local/bin/whitelist.sh
 rm /usr/local/bin/piholeReloadServices.sh
 rm /usr/local/bin/piholeSetPermissions.sh
 rm /usr/local/bin/piholeLogFlush.sh
+rm /usr/local/bin/updateDashboard.sh
 rm -rf /etc/pihole/

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -71,10 +71,13 @@ fi
 
 echo "Removing config files and scripts..."
 rm /etc/dnsmasq.conf
+rm /etc/sudoers.d/pihole
 rm -rf /etc/lighttpd/
 rm /var/log/pihole.log
 rm /usr/local/bin/gravity.sh
 rm /usr/local/bin/chronometer.sh
 rm /usr/local/bin/whitelist.sh
+rm /usr/local/bin/piholeReloadServices.sh
+rm /usr/local/bin/piholeSetPermissions.sh
 rm /usr/local/bin/piholeLogFlush.sh
 rm -rf /etc/pihole/

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -23,8 +23,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo $@"
-		sudo "$@"
+		echo "::: Running sudo $0 $@"
+		sudo "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo or run this script as root."

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -82,3 +82,4 @@ rm /usr/local/bin/piholeSetPermissions.sh
 rm /usr/local/bin/piholeLogFlush.sh
 rm /usr/local/bin/updateDashboard.sh
 rm -rf /etc/pihole/
+rm -rf /usr/local/include/pihole

--- a/gravity.sh
+++ b/gravity.sh
@@ -24,8 +24,8 @@ else
 	# Check if it is actually installed
 	# If it isn't, exit because the install cannot complete
 	if [[ $(dpkg-query -s sudo) ]];then
-		echo "::: Running sudo -u pihole $@"
-		sudo -u pihole "$@"
+		echo "::: Running sudo -u pihole $0 $@"
+		sudo -u pihole "$0" "$@"
 		exit $?
 	else
 		echo "::: Please install sudo."

--- a/gravity.sh
+++ b/gravity.sh
@@ -10,20 +10,27 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-# Run this script as root or under sudo
+# Check if pihole user, and if not then rerun with sudo.
 echo ":::"
-if [[ $EUID -eq 0 ]];then
-	echo "::: You are root."
+runninguser=$(whoami)
+if [[ "$runninguser" = "pihole"  ]];then
+	echo "::: You are pihole user."
+	# Older versions of Pi-hole set $SUDO="sudo" and prefixed commands with it,
+	# rather than rerunning as sudo. Just in case it turns up by accident, 
+	# explicitly set the $SUDO variable to an empty string.
+	SUDO=""
 else
 	echo "::: sudo will be used."
-  # Check if it is actually installed
-  # If it isn't, exit because the install cannot complete
-  if [[ $(dpkg-query -s sudo) ]];then
-		export SUDO="sudo"
-  else
-		echo "::: Please install sudo or run this script as root."
-    exit 1
-  fi
+	# Check if it is actually installed
+	# If it isn't, exit because the install cannot complete
+	if [[ $(dpkg-query -s sudo) ]];then
+		echo "::: Running sudo -u pihole $@"
+		sudo -u pihole "$@"
+		exit $?
+	else
+		echo "::: Please install sudo."
+	exit 1
+	fi
 fi
 
 piholeIPfile=/tmp/piholeIP
@@ -81,7 +88,7 @@ spinner(){
 
         spin='-\|/'
         i=0
-        while $SUDO kill -0 $pid 2>/dev/null
+        while kill -0 $pid 2>/dev/null
         do
                 i=$(( (i+1) %4 ))
                 printf "\b${spin:$i:1}"
@@ -125,17 +132,18 @@ function gravity_collapse() {
 
 	# Create the pihole resource directory if it doesn't exist.  Future files will be stored here
 	if [[ -d $piholeDir ]];then
-        # Temporary hack to allow non-root access to pihole directory
-        # Will update later, needed for existing installs, new installs should
-        # create this directory as non-root
-        $SUDO chmod 777 $piholeDir
-        find "$piholeDir" -type f -exec $SUDO chmod 666 {} \; & spinner $!
         echo "."
 	else
         echo -n "::: Creating pihole directory..."
         mkdir $piholeDir & spinner $!
         echo " done!"
 	fi
+	# Still not the best, but slightly more elegent hack than chmod 777.
+	# Run script to give the pihole group permissions to the pihole directory.
+	# This requires root.
+	# The installer should have created a file in sudoers.d to allow pihole user
+	# to run piholeSetPermissions.sh as root with sudo without a password
+	sudo --non-interactive /usr/local/bin/piholeSetPermissions.sh
 }
 
 # patternCheck - check to see if curl downloaded any new files.
@@ -331,27 +339,22 @@ function gravity_reload() {
 	#Clear no longer needed files...
 	echo ":::"
 	echo -n "::: Cleaning up un-needed files..."
-	$SUDO rm /etc/pihole/pihole.*
+	rm /etc/pihole/pihole.*
 	echo " done!"
 	
 	# Reload hosts file
 	echo ":::"
 	echo -n "::: Refresh lists in dnsmasq..."
-	dnsmasqPid=$(pidof dnsmasq)
-
-    find "$piholeDir" -type f -exec $SUDO chmod 666 {} \; & spinner $!
-
-	if [[ $dnsmasqPid ]]; then
-		# service already running - reload config
-		$SUDO kill -HUP $dnsmasqPid & spinner $!
-	else
-		# service not running, start it up
-		$SUDO service dnsmasq start & spinner $!
-	fi
+	
+	# Reloading services requires root.
+	# The installer should have created a file in sudoers.d to allow pihole user
+	# to run piholeReloadServices.sh as root with sudo without a password
+	sudo --non-interactive /usr/local/bin/piholeReloadServices.sh
+	
 	echo " done!"
 }
 
-$SUDO cp /etc/.pihole/adlists.default /etc/pihole/adlists.default
+cp /etc/.pihole/adlists.default /etc/pihole/adlists.default
 gravity_collapse
 gravity_spinup
 gravity_Schwarzchild


### PR DESCRIPTION
This pull request started as an attempt to simplify sudo usage in basic-install.sh.  It turns out this ties in with a LOT of things.  I've tried to keep it as small as possible, but it has become a bit of a monolith for which I do apologise.  Hope this is useful!
# Summary

This pull request:
- **Simplifies use of sudo.**  A few scripts have `$SUDO` every other line, when instead we can rerun the script as root at the start using `sudo "$0" "$@"`.  This results in faster scripts (each call to sudo adds over 0.1 seconds!), and IMO more maintainable scripts, at the cost of running the entire script as a single user.
- **Makes use of the pihole user.**  I saw from commits and comments that we have recently created a pihole user and wish to offload tasks to it, but so far not done much with it.  I am hoping that this request goes very far towards achieving that goal.  Some scripts now sudo to pihole, so we're not needlessly running as root, and don't have to worry about setting file permissions for any account other than pihole.
- **Sets less risky permissions.**  Issue #357 is about the chmod 777 that's used.  Still not perfect, but this pull request has a better way around it.
# Detail
## Sudo
- basic-install.sh, uninstall.sh, setupLCD.sh:

These now rerun themselves as **root** from the start.

These scripts heavily rely on root, with very little other than `echo` and `whiptail` not prefixed with `$SUDO`.  I'm a strong believer in least-privilege but I don't think it makes sense to maintain the error-prone complexity of using `$SUDO` with these scripts just so that a small number of relatively safe commands aren't running as root.  They're installers, it's not like they're run regularly.

updateDashboard.sh sort of comes under this list too - I haven't touched this script, but whoever pushed this in the first place already did the same `sudo "$0" "$@"` to rerun it as root.
- blacklist.sh, chronometer.sh, piholeLogFlush.sh, whitelist.sh

These now rerun themselves as **pihole** from the start.

These scripts are the opposite - they hardly ran anything as root, and we'd like to keep it that way.  They only need to do a couple of things as root: reload dnsmasq, and the chmod 777 hack.  See further below for how they elevate to run these tasks.

sudo here is run the normal way, in that it will prompt for a password if required.  This means no passwords for cron jobs, as they will either run as root (which can sudo to anything without a password) or as pihole (an if statement skips sudo if already running as the correct user).
## Sudoers

For those who don't know, we can edit the sudoers file to allow certain users (or groups) to run certain programs as root without entering a password.

Instead of modifying /etc/sudoers (dangerous!!!!), we can instead create a file in /etc/sudoers.d (much safer).  basic-install.sh now creates /etc/sudoers.d/pihole, with one entry:

`pihole  ALL=(ALL:ALL) NOPASSWD: /usr/local/bin/piholeReloadServices.sh, /usr/local/bin/piholeSetPermissions.sh`

This allows the pihole user (reminder: which now runs blacklist.sh, whitelist.sh, etc.) to non-interactively elevate to root to run two new scripts I have created.

The new scripts each run a root-requiring operation.  They are:
- piholeReloadServices.sh
  This script reloads or starts dnsmasq.
- piholeSetPermissions.sh
  This script implements an alternative to the chmod 777 hack in gravity.sh, explained further below.

Personally I don't think this is particularly elegant, but I do think it's the right choice for the project as it stands now.
## chmod 777 hack fix

On initial install, basic-install.sh now chowns /etc/pihole to root:pihole, and gives group rw permissions to the folder.

I don't know the history of the chmod 777 hack, as far as I can tell it's not needed for the current repo, so with the above we should be able to just remove it.  But comments in the script and issue #357 indicate it's for backwards compatibility with an older version.

piholeSetPermissions.sh now just runs chown and chmod again, and is called from gravity.sh instead of chmod 777.  So /etc/pihole is kept owned by root:pihole and user/group rw, other r.

(Side note: IMO we ideally ought to split off some of /etc/pihole to /var/lib/pihole, but now's not the time!)
# Known issues
- "You are root" appearing in the middle of scripts.
  
  For example: gravity.sh starts by sudoing to pihole ("You are pi hole user"), and a few lines later it runs piholeSetPermissions.sh ("You are root").
- Sudo's adding a line break messes up some formatting, particularly with multiple echos intending to span a single line (e.g. "Doing X...done")
- Permissions for /var/log/pihole.log need to be modified or piholeLogFlush.sh run as root.

@pihole/gravity
