### PR TITLE
Store password as hash

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -664,7 +664,7 @@ setPassword() {
 	
 	if [ $? = 0 ]; then
 		# Entered password
-		echo $pass > /etc/pihole/password.txt
+		echo -n "$pass" | sha256sum | awk '{print $1}' > /etc/pihole/password.txt
 	else
 		echo "::: Cancel selected, exiting...."
 		exit 1


### PR DESCRIPTION
Should fix any security holes associated with storing a plaintext password and checking passwords through the web interface. See [#53](https://github.com/pi-hole/AdminLTE/pull/60) for the web side of things.

Changes proposed in this pull request:

- Store hashed password using sha256 instead of plaintext.

@pi-hole/gravity 