### PR TITLE
uptime -p doesn't work on older versions

### DIFF
--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -88,7 +88,8 @@ function normalChrono(){
 		echo "        $(ifconfig eth0 | awk '/inet addr/ {print $2}' | cut -d':' -f2)"
 		echo ""
 		uptime | cut -d' ' -f11-
-		uptime -p
+		#uptime -p	#Doesn't work on all versions of uptime
+		uptime | awk -F'( |,|:)+' '{if ($7=="min") m=$6; else {if ($7~/^day/) {d=$6;h=$8;m=$9} else {h=$6;m=$7}}} {print d+0,"days,",h+0,"hours,",m+0,"minutes."}'
 		echo "-------------------------------"
 		# Uncomment to continually read the log file and display the current domain being blocked
 		#tail -f /var/log/pihole.log | awk '/\/etc\/pihole\/gravity.list/ {if ($7 != "address" && $7 != "name" && $7 != "/etc/pihole/gravity.list") print $7; else;}'


### PR DESCRIPTION
Fixes pull request #328 

Changes proposed in this pull request:

uptime -p doesn't work in version 3.3.3 (which is in wheezy)

this new command works with 3.3.3 and was taken from here: http://stackoverflow.com/questions/28353409/bash-format-uptime-to-show-days-hours-minutes

