### PR TITLE
Optionally block the BBC Breaking News banner

### DIFF
--- a/adlists.default
+++ b/adlists.default
@@ -39,6 +39,9 @@ http://hosts-file.net/ad_servers.txt
 # Quidsup's tracker list
 https://raw.githubusercontent.com/quidsup/notrack/master/trackers.txt
 
+# Block the BBC News website Breaking News banner
+#https://raw.githubusercontent.com/BreakingTheNews/BreakingTheNews.github.io/master/hosts
+
 
 # Untested Lists:
 #https://raw.githubusercontent.com/reek/anti-adblock-killer/master/anti-adblock-killer-filters.txt


### PR DESCRIPTION
Changes proposed in this pull request:

-  Optionally block the [BBC News website](http://www.bbc.co.uk/news) Breaking News banner by black-holing `polling.bbc.co.uk`

@pihole/gravity
