### PR TITLE
Fix URL for Windows 10 Telemetry list.

### DIFF
--- a/adlists.default
+++ b/adlists.default
@@ -30,8 +30,8 @@ http://hosts-file.net/ad_servers.txt
 # ADZHOSTS list. Has been known to block legitimate domains
 #http://optimate.dl.sourceforge.net/project/adzhosts/HOSTS.txt
 
-# Windows 10 telemetry list - warning this one may block windows update
-#https://raw.githubusercontent.com/crazy-max/HostsWindowsBlocker/master/hosts.txt
+# Windows 10 telemetry list
+#https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/hostsBlockWindowsSpy.txt
 
 # Securemecca.com list - Also blocks "adult" sites (pornography/gambling etc)
 #http://securemecca.com/Downloads/hosts.txt


### PR DESCRIPTION
Fixes the URL for the Windows 10 Telemetry list.

Developer of HostsWindowsBlocker renamed that project to WindowsSpyBlocker.
Also separated the domain list for Telemetry and Windows Update into to separate files. So Windows Update should not end up being blocked anymore.

Changes proposed in this pull request:
- adlist.default updated to the new URL of Windows 10 Telemetry Hosts list.

@pihole/gravity

