### PR TITLE
fix template team link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ Changes proposed in this pull request:
 
 - 
 
-@pihole/gravity
+@pi-hole/gravity


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds `-` in team link, as seen below.

@pi-hole/gravity 
