### PR TITLE
Update adlists.default

### DIFF
--- a/adlists.default
+++ b/adlists.default
@@ -42,6 +42,8 @@ https://raw.githubusercontent.com/quidsup/notrack/master/trackers.txt
 
 
 # Untested Lists:
+#https://raw.github.com/notracking/hosts-blocklists/master/hostnames.txt
+#https://raw.github.com/notracking/hosts-blocklists/master/domains.txt
 #https://raw.githubusercontent.com/reek/anti-adblock-killer/master/anti-adblock-killer-filters.txt
 #http://spam404bl.com/spam404scamlist.txt
 #http://malwaredomains.lehigh.edu/files/domains.txt


### PR DESCRIPTION
@pihole/gravity

Suggestions to add to your list default list. 2 Files, one domain name based and a large hostname based filter set.
For more details see: https://github.com/notracking/hosts-blocklists