### PR TITLE
pihole Controller fixes

### DIFF
--- a/advanced/Scripts/blacklist.sh
+++ b/advanced/Scripts/blacklist.sh
@@ -11,16 +11,7 @@
 # (at your option) any later version.
 
 if [[ $# = 0 ]]; then
-    echo "::: Immediately blacklists one or more domains in the hosts file"
-    echo ":::"
-    echo "::: Usage: sudo pihole.sh -b domain1 [domain2 ...]"
-    echo ":::"
-    echo "::: Options:"
-    echo ":::  -d, --delmode		Remove domains from the blacklist"
-    echo ":::  -nr, --noreload		Update blacklist without refreshing dnsmasq"
-    echo ":::  -f, --force			Force updating of the hosts files, even if there are no changes"
-    echo ":::  -q, --quiet			output is less verbose"
-    exit 1
+	helpFunc
 fi
 
 #globals
@@ -57,6 +48,21 @@ if [[ -f $piholeIPv6file ]];then
     piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
 fi
 
+
+function helpFunc()
+{
+	  echo "::: Immediately blacklists one or more domains in the hosts file"
+    echo ":::"
+    echo "::: Usage: sudo pihole.sh -b domain1 [domain2 ...]"
+    echo ":::"
+    echo "::: Options:"
+    echo ":::  -d, --delmode		Remove domains from the blacklist"
+    echo ":::  -nr, --noreload		Update blacklist without refreshing dnsmasq"
+    echo ":::  -f, --force			Force updating of the hosts files, even if there are no changes"
+    echo ":::  -q, --quiet			output is less verbose"
+    echo ":::  -h, --help			Show this help dialog"
+    exit 1
+}
 
 function HandleOther(){
   #check validity of domain
@@ -175,7 +181,8 @@ do
     "-nr"| "--noreload"  ) reload=false;;
     "-d" | "--delmode"   ) addmode=false;;
     "-f" | "--force"     ) force=true;;
-    "-q" | "--quiet"     ) versbose=false;;  			
+    "-q" | "--quiet"     ) versbose=false;;
+    "-h" | "--help"			 ) helpFunc;;
     *                    ) HandleOther "$var";;
   esac
 done

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -11,16 +11,7 @@
 # (at your option) any later version.
 
 if [[ $# = 0 ]]; then
-    echo "::: Immediately whitelists one or more domains in the hosts file"
-    echo ":::"
-    echo "::: Usage: sudo pihole.sh -w domain1 [domain2 ...]"
-    echo ":::"
-    echo "::: Options:"
-    echo ":::  -d, --delmode		Remove domains from the whitelist"
-    echo ":::  -nr, --noreload		Update Whitelist without refreshing dnsmasq"
-    echo ":::  -f, --force			Force updating of the hosts files, even if there are no changes"
-    echo ":::  -q, --quiet			output is less verbose"
-    exit 1
+	helpFunc
 fi
 
 #globals
@@ -56,6 +47,21 @@ if [[ -f $piholeIPv6file ]];then
     piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
 fi
 
+
+function helpFunc()
+{
+	  echo "::: Immediately whitelists one or more domains in the hosts file"
+    echo ":::"
+    echo "::: Usage: sudo pihole.sh -w domain1 [domain2 ...]"
+    echo ":::"
+    echo "::: Options:"
+    echo ":::  -d, --delmode		Remove domains from the whitelist"
+    echo ":::  -nr, --noreload		Update Whitelist without refreshing dnsmasq"
+    echo ":::  -f, --force			Force updating of the hosts files, even if there are no changes"
+    echo ":::  -q, --quiet			output is less verbose"
+    echo ":::  -h, --help			Show this help dialog"
+    exit 1
+}
 
 function HandleOther(){
   #check validity of domain
@@ -188,7 +194,8 @@ do
     "-nr"| "--noreload"  ) reload=false;;
     "-d" | "--delmode"   ) addmode=false;;
     "-f" | "--force"     ) force=true;;
-    "-q" | "--quiet"     ) versbose=false;;  			
+    "-q" | "--quiet"     ) versbose=false;;
+    "-h" | "--help"			 ) helpFunc;;
     *                    ) HandleOther "$var";;
   esac
 done

--- a/pihole
+++ b/pihole
@@ -11,9 +11,9 @@
 # (at your option) any later version.
 
 # Must be root to use this tool
-if [[ $EUID -eq 0 ]];then
+if [[ ! $EUID -eq 0 ]];then
 	#echo "::: You are root."
-else
+#else
 	#echo "::: Sudo will be used for this tool."
   # Check if it is actually installed
   # If it isn't, exit because the pihole cannot be invoked without privileges.

--- a/pihole
+++ b/pihole
@@ -63,7 +63,8 @@ function setupLCDFunction {
 }
 
 function chronometerFunc {
-	$SUDO /opt/pihole/chronometer.sh
+	shift
+	$SUDO /opt/pihole/chronometer.sh "$@"
 	exit 1
 }
 
@@ -106,7 +107,7 @@ case "$1" in
 "-u" | "updateDashboard"	) updateDashboardFunc;;
 "-g" | "updateGravity"		) updateGravityFunc;;
 "-s" | "setupLCD"			) setupLCDFunction;;
-"-c" | "chronometer"		) chronometerFunc;;
+"-c" | "chronometer"		) chronometerFunc "$@";;
 "-h" | "help"				) helpFunc;;
 "uninstall"					) uninstallFunc;;
 *                    		) helpFunc;;

--- a/pihole
+++ b/pihole
@@ -12,9 +12,9 @@
 
 # Must be root to use this tool
 if [[ $EUID -eq 0 ]];then
-	echo "::: You are root."
+	#echo "::: You are root."
 else
-	echo "::: Sudo will be used for this tool."
+	#echo "::: Sudo will be used for this tool."
   # Check if it is actually installed
   # If it isn't, exit because the pihole cannot be invoked without privileges.
   if [[ $(dpkg-query -s sudo) ]];then


### PR DESCRIPTION
Fixes #439 .

Changes proposed in this pull request:

- Add -h switch to `whitelist.sh` and `blacklist.sh`

- Allows switch to be passed to `chronometer.sh` through `pihole`

- Removes output "You are root" / "You are sudo", as it gets doubled up when the secondary scripts are run anyway. 

@pi-hole/gravity
