### PR TITLE
Removing functionality that serves blank web page.

### DIFF
--- a/advanced/Scripts/blacklist.sh
+++ b/advanced/Scripts/blacklist.sh
@@ -27,12 +27,8 @@ versbose=true
 domList=()
 domToRemoveList=()
 
-piholeIPv6file=/etc/pihole/.useIPv6
-
-# Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
-IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-piholeIPCIDR=$(ip -o -f inet addr show dev "$IPv4dev" | awk '{print $4}' | awk 'END {print}')
-piholeIP=${piholeIPCIDR%/*}
+piholeIP="0.0.0.0"
+piholeIPv6="::"
 
 modifyHost=false
 
@@ -41,13 +37,6 @@ if [[ -r $piholeDir/pihole.conf ]];then
     echo "::: Local calibration requested..."
         . $piholeDir/pihole.conf
 fi
-
-
-if [[ -f $piholeIPv6file ]];then
-    # If the file exists, then the user previously chose to use IPv6 in the automated installer
-    piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
-fi
-
 
 function helpFunc()
 {

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -27,12 +27,8 @@ versbose=true
 domList=()
 domToRemoveList=()
 
-piholeIPv6file=/etc/pihole/.useIPv6
-
-# Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
-IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-piholeIPCIDR=$(ip -o -f inet addr show dev "$IPv4dev" | awk '{print $4}' | awk 'END {print}')
-piholeIP=${piholeIPCIDR%/*}
+piholeIP="0.0.0.0"
+piholeIPv6="::"
 
 modifyHost=false
 
@@ -41,12 +37,6 @@ if [[ -r $piholeDir/pihole.conf ]];then
     echo "::: Local calibration requested..."
         . $piholeDir/pihole.conf
 fi
-
-if [[ -f $piholeIPv6file ]];then
-    # If the file exists, then the user previously chose to use IPv6 in the automated installer
-    piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
-fi
-
 
 function helpFunc()
 {
@@ -133,20 +123,19 @@ function ModifyHostFile(){
 	 if $addmode; then
 	    #remove domains in  from hosts file
 	    if [[ -r $whitelist ]];then
-        # Remove whitelist entries
-				numberOf=$(cat $whitelist | sed '/^\s*$/d' | wc -l)
-        plural=; [[ "$numberOf" != "1" ]] && plural=s
-        echo ":::"
-        echo -n "::: Modifying HOSTS file to whitelist $numberOf domain${plural}..."
-        awk -F':' '{print $1}' $whitelist | while read -r line; do echo "$piholeIP $line"; done > /etc/pihole/whitelist.tmp
-        awk -F':' '{print $1}' $whitelist | while read -r line; do echo "$piholeIPv6 $line"; done >> /etc/pihole/whitelist.tmp
-        echo "l" >> /etc/pihole/whitelist.tmp
-        grep -F -x -v -f $piholeDir/whitelist.tmp $adList > $piholeDir/gravity.tmp
-        rm $adList
-        mv $piholeDir/gravity.tmp $adList
-        rm $piholeDir/whitelist.tmp
-        echo " done!"
-
+            # Remove whitelist entries
+			numberOf=$(cat $whitelist | sed '/^\s*$/d' | wc -l)
+	        plural=; [[ "$numberOf" != "1" ]] && plural=s
+	        echo ":::"
+	        echo -n "::: Modifying HOSTS file to whitelist $numberOf domain${plural}..."
+	        awk -F':' '{print $1}' $whitelist | while read -r line; do echo "$piholeIP $line"; done > /etc/pihole/whitelist.tmp
+	        awk -F':' '{print $1}' $whitelist | while read -r line; do echo "$piholeIPv6 $line"; done >> /etc/pihole/whitelist.tmp
+	        echo "l" >> /etc/pihole/whitelist.tmp
+	        grep -F -x -v -f $piholeDir/whitelist.tmp $adList > $piholeDir/gravity.tmp
+	        rm $adList
+	        mv $piholeDir/gravity.tmp $adList
+	        rm $piholeDir/whitelist.tmp
+	        echo " done!"
 	  	fi
 	  else
 	    #we need to add the removed domains to the hosts file
@@ -195,7 +184,7 @@ do
     "-d" | "--delmode"   ) addmode=false;;
     "-f" | "--force"     ) force=true;;
     "-q" | "--quiet"     ) versbose=false;;
-    "-h" | "--help"			 ) helpFunc;;
+    "-h" | "--help"		 ) helpFunc;;
     *                    ) HandleOther "$var";;
   esac
 done

--- a/gravity.sh
+++ b/gravity.sh
@@ -240,12 +240,12 @@ function gravity_hostFormat() {
 	if [[ -n $piholeIPv6 ]];then
 		# Add hostname and dummy domain to the top of gravity.list to make ping result return a friendlier looking domain! Also allows for an easy way to access the Pi-hole admin console (pi.hole/admin)
 		echo -e "127.0.0.1 $hostname\n::1 $hostname\n127.0.0.1 pi.hole\n::1 pi.hole" > $piholeDir/$accretionDisc
-		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' > $piholeDir/$accretionDisc
+		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' >> $piholeDir/$accretionDisc
 	else
 		# Otherwise, just create gravity.list as normal using IPv4
 		# Add hostname and dummy domain to the top of gravity.list to make ping result return a friendlier looking domain! Also allows for an easy way to access the Pi-hole admin console (pi.hole/admin)
 		echo -e "127.0.0.1 $hostname\n127.0.0.1 pi.hole" > $piholeDir/$accretionDisc
-		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' > $piholeDir/$accretionDisc
+		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' >> $piholeDir/$accretionDisc
 	fi
 
 	# Copy the file over as /etc/pihole/gravity.list so dnsmasq can use it

--- a/gravity.sh
+++ b/gravity.sh
@@ -40,19 +40,14 @@ if [[ -f $piholeIPv6file ]];then
 fi
 
 # Variables for various stages of downloading and formatting the list
-## Nate 3/26/2016 - Commented unused variables
 basename=pihole
 piholeDir=/etc/$basename
 adList=$piholeDir/gravity.list
-#blacklist=$piholeDir/blacklist.txt
-#whitelist=$piholeDir/whitelist.txt
-#latentWhitelist=$piholeDir/latentWhitelist.txt
 justDomainsExtension=domains
 matterandlight=$basename.0.matterandlight.txt
 supernova=$basename.1.supernova.txt
 eventHorizon=$basename.2.eventHorizon.txt
 accretionDisc=$basename.3.accretionDisc.txt
-#eyeOfTheNeedle=$basename.4.wormhole.txt
 
 # After setting defaults, check if there's local overrides
 if [[ -r $piholeDir/pihole.conf ]];then

--- a/gravity.sh
+++ b/gravity.sh
@@ -249,17 +249,12 @@ function gravity_unique() {
 function gravity_hostFormat() {
 	# Format domain list as "192.168.x.x domain.com"
 	echo "::: Formatting domains into a HOSTS file..."
-	hostname=$(</etc/hostname)
 	# If there is a value in the $piholeIPv6, then IPv6 will be used, so the awk command modified to create a line for both protocols
 	if [[ -n $piholeIPv6 ]];then
-		# Add hostname and dummy domain to the top of gravity.list to make ping result return a friendlier looking domain! Also allows for an easy way to access the Pi-hole admin console (pi.hole/admin)
-		echo -e "$piholeIP $hostname\n$piholeIPv6 $hostname\n$piholeIP pi.hole\n$piholeIPv6 pi.hole" > $piholeDir/$accretionDisc
-		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' >> $piholeDir/$accretionDisc
+		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' > $piholeDir/$accretionDisc
 	else
 		# Otherwise, just create gravity.list as normal using IPv4
-		# Add hostname and dummy domain to the top of gravity.list to make ping result return a friendlier looking domain! Also allows for an easy way to access the Pi-hole admin console (pi.hole/admin)
-		echo -e "$piholeIP $hostname\n$piholeIP pi.hole" > $piholeDir/$accretionDisc
-		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' >> $piholeDir/$accretionDisc
+		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' > $piholeDir/$accretionDisc
 	fi
 
 	# Copy the file over as /etc/pihole/gravity.list so dnsmasq can use it

--- a/gravity.sh
+++ b/gravity.sh
@@ -26,25 +26,14 @@ else
 	fi
 fi
 
-piholeIPfile=/tmp/piholeIP
-piholeIPv6file=/etc/pihole/.useIPv6
 
 adListFile=/etc/pihole/adlists.list
 adListDefault=/etc/pihole/adlists.default
 whitelistScript=/opt/pihole/whitelist.sh
 blacklistScript=/opt/pihole/blacklist.sh
 
-if [[ -f $piholeIPfile ]];then
-    # If the file exists, it means it was exported from the installation script and we should use that value instead of detecting it in this script
-    piholeIP=$(cat $piholeIPfile)
-    rm $piholeIPfile
-else
-    # Otherwise, the IP address can be taken directly from the machine, which will happen when the script is run by the user and not the installation script
-    IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1)}')
-    piholeIPCIDR=$(ip -o -f inet addr show dev "$IPv4dev" | awk '{print $4}' | awk 'END {print}')
-    piholeIP=${piholeIPCIDR%/*}
-fi
-
+piholeIP="0.0.0.0"
+piholeIPv6file=/etc/pihole/.useIPv6
 if [[ -f $piholeIPv6file ]];then
     # If the file exists, then the user previously chose to use IPv6 in the automated installer
     piholeIPv6="::"

--- a/gravity.sh
+++ b/gravity.sh
@@ -239,12 +239,12 @@ function gravity_hostFormat() {
 	# If there is a value in the $piholeIPv6, then IPv6 will be used, so the awk command modified to create a line for both protocols
 	if [[ -n $piholeIPv6 ]];then
 		# Add hostname and dummy domain to the top of gravity.list to make ping result return a friendlier looking domain! Also allows for an easy way to access the Pi-hole admin console (pi.hole/admin)
-		echo -e "127.0.0.1 $hostname\n::1 $hostname\n127.0.0.1 pi.hole\n::1 pi.hole" > $piholeDir/$accretionDisc
+		echo -e "$piholeIP $hostname\n$piholeIPv6 $hostname\n$piholeIP pi.hole\n$piholeIPv6 pi.hole" > $piholeDir/$accretionDisc
 		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' >> $piholeDir/$accretionDisc
 	else
 		# Otherwise, just create gravity.list as normal using IPv4
 		# Add hostname and dummy domain to the top of gravity.list to make ping result return a friendlier looking domain! Also allows for an easy way to access the Pi-hole admin console (pi.hole/admin)
-		echo -e "127.0.0.1 $hostname\n127.0.0.1 pi.hole" > $piholeDir/$accretionDisc
+		echo -e "$piholeIP $hostname\n$piholeIP pi.hole" > $piholeDir/$accretionDisc
 		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' >> $piholeDir/$accretionDisc
 	fi
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -47,7 +47,7 @@ fi
 
 if [[ -f $piholeIPv6file ]];then
     # If the file exists, then the user previously chose to use IPv6 in the automated installer
-    piholeIPv6=$(ip -6 route get 2001:4860:4860::8888 | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
+    piholeIPv6="::"
 fi
 
 # Variables for various stages of downloading and formatting the list

--- a/gravity.sh
+++ b/gravity.sh
@@ -238,9 +238,13 @@ function gravity_hostFormat() {
 	echo "::: Formatting domains into a HOSTS file..."
 	# If there is a value in the $piholeIPv6, then IPv6 will be used, so the awk command modified to create a line for both protocols
 	if [[ -n $piholeIPv6 ]];then
+		# Add hostname and dummy domain to the top of gravity.list to make ping result return a friendlier looking domain! Also allows for an easy way to access the Pi-hole admin console (pi.hole/admin)
+		echo -e "127.0.0.1 $hostname\n::1 $hostname\n127.0.0.1 pi.hole\n::1 pi.hole" > $piholeDir/$accretionDisc
 		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' > $piholeDir/$accretionDisc
 	else
 		# Otherwise, just create gravity.list as normal using IPv4
+		# Add hostname and dummy domain to the top of gravity.list to make ping result return a friendlier looking domain! Also allows for an easy way to access the Pi-hole admin console (pi.hole/admin)
+		echo -e "127.0.0.1 $hostname\n127.0.0.1 pi.hole" > $piholeDir/$accretionDisc
 		cat $piholeDir/$eventHorizon | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' > $piholeDir/$accretionDisc
 	fi
 


### PR DESCRIPTION
**DO NOT MERGE UNTIL PROMOFAUX SAYS SO. K?**

The purpose of this pull is to change the way pi-hole works, slightly. The main differences will be:

- `gravity.list` to redirect to `0.0.0.0`(IPv4) or `::` (for IPv6)
- Pi-hole will now no longer return a blank page in place of an ad, it will return nothing.
- Web Admin UI will now be moved to a port (default to be decided - but user configurable)
- when pinging a blocked domain, it will not resolve (this is a good thing!)
- It will no longer appear that we're manipulating the `hostname` (we weren't, but I can see how you might think we were)
- Hopefully some of the issues brought up [here](https://github.com/pi-hole/AdminLTE/issues/39) by @fedora-core can be bypassed using this method (as there will be no page served when naughty ad provider provides a link to `adcompany.com/admin/whitelist.php`
- with the above in mind, that means we can get on with adding neat features to the web admin page.



@pi-hole/gravity

