### PR TITLE
Added hosts-blocklists lists

### DIFF
--- a/adlists.default
+++ b/adlists.default
@@ -48,3 +48,6 @@ https://raw.githubusercontent.com/quidsup/notrack/master/trackers.txt
 #https://raw.githubusercontent.com/reek/anti-adblock-killer/master/anti-adblock-killer-filters.txt
 #http://spam404bl.com/spam404scamlist.txt
 #http://malwaredomains.lehigh.edu/files/domains.txt
+# Following two lists should be used simultaneously: (readme https://github.com/notracking/hosts-blocklists/)
+#https://raw.github.com/notracking/hosts-blocklists/master/hostnames.txt
+#https://raw.github.com/notracking/hosts-blocklists/master/domains.txt


### PR DESCRIPTION
@pi-hole/gravity

The hosts-blocklist is a semi-automatically updated list, based on various well known public sources, for more details read: https://github.com/notracking/hosts-blocklists/

Please be aware that one file is for domain blocking and the other file for hostname based blocking, these lists are complimentary and should therefore be used simultaneously.