### PR TITLE
fixed non execution of helpFunc

### DIFF
--- a/advanced/Scripts/blacklist.sh
+++ b/advanced/Scripts/blacklist.sh
@@ -10,9 +10,6 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-if [[ $# = 0 ]]; then
-	helpFunc
-fi
 
 #globals
 basename=pihole
@@ -64,6 +61,11 @@ function helpFunc()
 	echo ":::  -l, --list				Display your blacklisted domains"
 	exit 1
 }
+
+if [[ $# = 0 ]]; then
+	helpFunc
+fi
+
 
 function HandleOther(){
   #check validity of domain

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -10,9 +10,6 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-if [[ $# = 0 ]]; then
-	helpFunc
-fi
 
 #globals
 basename=pihole
@@ -63,6 +60,11 @@ function helpFunc()
 	echo ":::  -l, --list				Display your whitelisted domains"
 	exit 1
 }
+
+if [[ $# = 0 ]]; then
+	helpFunc
+fi
+
 
 function HandleOther(){
   #check validity of domain


### PR DESCRIPTION
This PR fixes the issue which caused the helpFunc to not execute.

Following was the error noted while executing the above scripts.

pihole  -w
/opt/pihole/whitelist.sh: line 14: helpFunc: command not found

pihole  -b
/opt/pihole/blacklist.sh: line 14: helpFunc: command not found


@pi-hole/gravity
