### PR TITLE
Make sure web interface can't be loaded into a frame

### DIFF
--- a/advanced/lighttpd.conf
+++ b/advanced/lighttpd.conf
@@ -46,11 +46,16 @@ include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
 	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Frame-Options" => "DENY" )
+    setenv.add-response-header = (
+        "X-Pi-hole" => "The Pi-hole Web interface is working!",
+        "X-Frame-Options" => "DENY"
+    )
 }
 
 # If the URL does not start with /admin, then it is a query for an ad domain
 $HTTP["url"] =~ "^(?!/admin)/.*" {
+    # Create a response header for debugging using curl -I
+    setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
     # rewrite only js requests
     url.rewrite = ("(.*).js" => "pihole/index.js")
 }

--- a/advanced/lighttpd.conf
+++ b/advanced/lighttpd.conf
@@ -46,13 +46,11 @@ include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
 	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "The Pi-hole Web interface is working!" )
+	setenv.add-response-header = ( "X-Frame-Options" => "DENY" )
 }
 
 # If the URL does not start with /admin, then it is a query for an ad domain
 $HTTP["url"] =~ "^(?!/admin)/.*" {
-	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-        # rewrite only js requests
-        url.rewrite = ("(.*).js" => "pihole/index.js")	
+    # rewrite only js requests
+    url.rewrite = ("(.*).js" => "pihole/index.js")
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `X-Frame-Options` to make sure the interface doesn't get loaded as an ad (protects the admin functions)

@pi-hole/gravity