### PR TITLE
Fix for Proxmox LXC

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -43,7 +43,7 @@ IPv4dev=$(ip route get 8.8.8.8 | awk '{for(i=1;i<=NF;i++)if($i~/dev/)print $(i+1
 IPv4addr=$(ip -o -f inet addr show dev "$IPv4dev" | awk '{print $4}' | awk 'END {print}')
 IPv4gw=$(ip route get 8.8.8.8 | awk '{print $3}')
 
-availableInterfaces=$(ip -o link | awk '{print $2}' | grep -v "lo" | cut -d':' -f1)
+availableInterfaces=$(ip -o link | awk '{print $2}' | grep -v "lo" | cut -d':' -f1 | cut -d'@' -f1)
 dhcpcdFile=/etc/dhcpcd.conf
 
 ######## FIRST CHECK ########


### PR DESCRIPTION
Fixes #455.

Changes proposed in this pull request:

- 

- 

- 

@pi-hole/gravity

On a proxmox LXC, the installer sets link to eth0@if13 instead of eth0. This change by @ShoGinn fixes that problem, correctly setting the link to eth0 and creating a flawless install.