### PR TITLE
Fix link for spam404scamlist.txt

### DIFF
--- a/adlists.default
+++ b/adlists.default
@@ -46,7 +46,7 @@ https://raw.githubusercontent.com/quidsup/notrack/master/trackers.txt
 
 # Untested Lists:
 #https://raw.githubusercontent.com/reek/anti-adblock-killer/master/anti-adblock-killer-filters.txt
-#http://spam404bl.com/spam404scamlist.txt
+#https://raw.githubusercontent.com/Dawsey21/Lists/master/main-blacklist.txt
 #http://malwaredomains.lehigh.edu/files/domains.txt
 # Following two lists should be used simultaneously: (readme https://github.com/notracking/hosts-blocklists/)
 #https://raw.github.com/notracking/hosts-blocklists/master/hostnames.txt


### PR DESCRIPTION
The redirect `http://spam404bl.com/spam404scamlist.txt` resolves to `https://raw.githubusercontent.com/spam404scamlist.txt/Dawsey21/Lists/master/main-blacklist.txt`, which is wrong.

Instead, use `https://raw.githubusercontent.com/Dawsey21/Lists/master/main-blacklist.txt`directly.

@pi-hole/gravity