### PR TITLE
Missing permissions when writing to piholeIP

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -236,7 +236,7 @@ getStaticIPv4Settings() {
 If you are worried, either manually set the address, or modify the DHCP reservation pool so it does not include the IP you want.
 It is also possible to use a DHCP reservation, but if you are going to do that, you might as well set a static address." $r $c
 		#piholeIP is saved to a permanent file so gravity.sh can use it when updating
-		echo "${IPv4addr%/*}" > /etc/pihole/piholeIP
+		$SUDO echo "${IPv4addr%/*}" > /etc/pihole/piholeIP
 		# Nothing else to do since the variables are already set above
 	else
 		# Otherwise, we need to ask the user to input their desired settings.
@@ -258,8 +258,8 @@ It is also possible to use a DHCP reservation, but if you are going to do that, 
 					Gateway:       $IPv4gw" $r $c)then
 					# If the settings are correct, then we need to set the piholeIP
 					# Saving it to a temporary file us to retrieve it later when we run the gravity.sh script. piholeIP is saved to a permanent file so gravity.sh can use it when updating
-					echo "${IPv4addr%/*}" > /etc/pihole/piholeIP
-					echo "$piholeInterface" > /tmp/piholeINT
+					$SUDO echo "${IPv4addr%/*}" > /etc/pihole/piholeIP
+					$SUDO echo "$piholeInterface" > /tmp/piholeINT
 					# After that's done, the loop ends and we move on
 					ipSettingsCorrect=True
 				else


### PR DESCRIPTION
Changes proposed in this pull request:

- Fix `bash: line 239: /etc/pihole/piholeIP: Permission denied` in the install script, caused by the echo command not having permission to write to that directory.

@pi-hole/gravity
