### PR TITLE
Have `curl` auto-redirect

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -152,7 +152,7 @@ function gravity_transport() {
 	fi
 
 	# Silently curl url
-	curl -s $cmd_ext $heisenbergCompensator -A "$agent" $url > $patternBuffer
+	curl -s -L $cmd_ext $heisenbergCompensator -A "$agent" $url > $patternBuffer
 	# Check for list updates
 	gravity_patternCheck "$patternBuffer"
 	# Cleanup


### PR DESCRIPTION
Fixes # Non-Listed

Add -L location redirection detection flag to curl

@pi-hole/gravity

This should solve the redirection issue if a list is moved.