### PR TITLE
Upload log to sprunge.us

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -330,8 +330,16 @@ function dumpPiHoleLog {
 
 # Anything to be done after capturing of pihole.log terminates
 function finalWork {
-	echo "::: Finshed debugging!" 
-	echo "::: Debug log can be found at : /var/log/pihole_debug.log"
+	echo "::: Finshed debugging!"
+	SPRUNGE=$(cat /var/log/pihole_debug.log | curl --silent --connect-timeout 5 -F 'sprunge=<-' http://sprunge.us)
+
+	# Check if sprunge.us is reachable. When it's not, point to local log instead
+	if [ -n "$SPRUNGE" ]
+	then
+		echo "::: Debug log can be found at : $SPRUNGE"
+	else
+		echo "::: Debug log can be found at : /var/log/pihole_debug.log"
+	fi
 }
 trap finalWork EXIT
 


### PR DESCRIPTION
Automatically upload log file to sprunge.us
=================================

When the user is online, the log file will be uploaded to sprunge.us for easy sharing.
If their are connectivity issues and the user can not connect to sprunge, then they will
be presented the log in their log folder.

Hopefully, I think I got it right this time. Thanks for pointing out I was pulling to the master branch. I didn't know I could change it on github's website.
