### PR TITLE
Repairs apt-get incorrect options

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -80,7 +80,7 @@ elif [ -x "$(command -v apt-get)" ];then
 	PKG_CACHE="/var/cache/apt"
 	UPDATE_PKG_CACHE="$PKG_MANAGER -qq update"
 	PKG_UPDATE="$PKG_MANAGER upgrade"
-	PKG_INSTALL="$PKG_MANAGER -y -qq install"
+	PKG_INSTALL="$PKG_MANAGER --yes --quiet install"
 	PKG_COUNT="$PKG_MANAGER -s -o Debug::NoLocking=true upgrade | grep -c ^Inst"
 	INSTALLER_DEPS=( apt-utils whiptail dhcpcd5)
 	PIHOLE_DEPS=( dnsutils bc dnsmasq lighttpd php5-common php5-cgi php5 git curl unzip wget sudo )


### PR DESCRIPTION
Fixes issue #512 

Expected output: 
---------------------
Seeing only  `:::    Checking for "PACKAGE NAME"... Not found!` and watching a rotating bar while
waiting to be alerted `...done!`.

Actual output: 
-----------------
First prompted `The mail frontend needs a installed 'sendmail', using pager` then the normal rotating bar and confirmation appears.

Problem:
-----------
The script uses the option `-y -qq` with apt-get. The man page for apt-get suggests not to use  these switches together as they may cause unexpected output (which they do). 

Solution:
-----------
The intended output of a non-verbose output can be obtained using `--yes --quiet` instead.
