### PR TITLE
Change comment to hash

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -324,7 +324,7 @@ It is also possible to use a DHCP reservation, but if you are going to do that, 
 
 setDHCPCD() {
 	# Append these lines to dhcpcd.conf to enable a static IP
-	echo "::: interface $piholeInterface
+	echo "## interface $piholeInterface
 	static ip_address=$IPv4addr
 	static routers=$IPv4gw
 	static domain_name_servers=$IPv4gw" | $SUDO tee -a /etc/dhcpcd.conf >/dev/null


### PR DESCRIPTION
Fixes #563.

Changes proposed in this pull request:

Modify comment indicator in dhcpcd.conf

@pi-hole/gravity

Change format of comment to hash/octothorpe to clearly delineate that it's a comment. Looks better than `:::` which causes confusion.