### PR TITLE
Remove trailing slash on os-release check

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -69,7 +69,7 @@ function distroCheck {
 	echo "######## Distribution Section #########" >> $DEBUG_LOG
 	echo "#######################################" >> $DEBUG_LOG
 	
-	TMP=$(cat /etc/*release/ || echo "Failed to find release")
+	TMP=$(cat /etc/*release || echo "Failed to find release")
 	echo "Distribution Version: $TMP" >> $DEBUG_LOG
 }
 	


### PR DESCRIPTION
Fixes #CLOSED .

Changes proposed in this pull request:

- Remove trailing slash that would cause an os-check to always fail out.

@pi-hole/gravity
