### PR TITLE
Only re-block whitelist deletions if in adlists

### DIFF
--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -175,20 +175,23 @@ function ModifyHostFile(){
 	    echo ":::"
 	    echo "::: Modifying HOSTS file to un-whitelist domains..."
 	    for rdom in "${domToRemoveList[@]}"
-	    do
-	    	if [[ -n $piholeIPv6 ]];then
-	    	  echo -n ":::    Un-whitelisting $rdom on IPv4 and IPv6..."
-	    	  echo "$rdom" | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' >> $adList
-	    	  echo " done!"
-	      else
-	        echo -n ":::    Un-whitelisting $rdom on IPv4"
-	      	echo "$rdom" | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' >>$adList
-	      	echo " done!"
-	      fi
-	      echo -n ":::        Removing $rdom from $whitelist..."
-	      echo "$rdom" | sed 's/\./\\./g' | xargs -I {} perl -i -ne'print unless /'{}'(?!.)/;' $whitelist
-	      echo " done!"
-	    done
+        do
+          if grep -q "$rdom" /etc/pihole/*.domains; then
+            echo ":::    AdLists contain $rdom, re-adding block"
+            if [[ -n $piholeIPv6 ]];then
+              echo -n ":::        Restoring block for $rdom on IPv4 and IPv6..."
+              echo "$rdom" | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' >> $adList
+              echo " done!"
+            else
+              echo -n ":::        Restoring block for $rdom on IPv4"
+              echo "$rdom" | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' >>$adList
+              echo " done!"
+            fi
+          fi
+          echo -n ":::    Removing $rdom from $whitelist..."
+          echo "$rdom" | sed 's/\./\\./g' | xargs -I {} perl -i -ne'print unless /'{}'(?!.)/;' $whitelist
+          echo " done!"
+        done
 	  fi
 }
 

--- a/advanced/Scripts/whitelist.sh
+++ b/advanced/Scripts/whitelist.sh
@@ -183,7 +183,7 @@ function ModifyHostFile(){
               echo "$rdom" | awk -v ipv4addr="$piholeIP" -v ipv6addr="$piholeIPv6" '{sub(/\r$/,""); print ipv4addr" "$0"\n"ipv6addr" "$0}' >> $adList
               echo " done!"
             else
-              echo -n ":::        Restoring block for $rdom on IPv4"
+              echo -n ":::        Restoring block for $rdom on IPv4..."
               echo "$rdom" | awk -v ipv4addr="$piholeIP" '{sub(/\r$/,""); print ipv4addr" "$0}' >>$adList
               echo " done!"
             fi


### PR DESCRIPTION
Fixes #581 and maybe others.

Changes proposed in this pull request:

- Prevent blocking benign/untracked domains deleted off whitelist
- Searches /etc/pihole/*.domain files for a previous block on the domain being un-whitelisted before re-blocking
- Change the wording to be a little clearer what un-whitelisting a adList blocked domain does (re-block)
- 2 Spaces instead of tabs

@pi-hole/gravity

Manual tests

```
root@b55bcecd295b:/etc/pihole# export test='zv1.november-lax.com'; pihole -w $test ; pihole -w -d $test ;
::: You are root.
::: Adding zv1.november-lax.com to /etc/pihole/whitelist.txt... done!
:::
::: Modifying HOSTS file to whitelist 9 domains... done!
:::
::: Refresh lists in dnsmasq... done!
::: You are root.
:::
::: Modifying HOSTS file to un-whitelist domains...
:::    AdLists contain zv1.november-lax.com, re-adding block
:::        Restoring block for zv1.november-lax.com on IPv4 done!
:::    Removing zv1.november-lax.com from /etc/pihole/whitelist.txt... done!
:::
::: Refresh lists in dnsmasq... done!
```

```
root@b55bcecd295b:/etc/pihole# export test='w.diginc.us'; pihole -w $test ; pihole -w -d $test ;
::: You are root.
::: Adding w.diginc.us to /etc/pihole/whitelist.txt... done!
:::
::: Modifying HOSTS file to whitelist 9 domains... done!
:::
::: Refresh lists in dnsmasq... done!
::: You are root.
:::
::: Modifying HOSTS file to un-whitelist domains...
:::    Removing w.diginc.us from /etc/pihole/whitelist.txt... done!
:::
::: Refresh lists in dnsmasq... done!

```