### PR TITLE
add gateway to interface configuration

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -359,6 +359,7 @@ setStaticIPv4() {
 			$SUDO echo "ONBOOT=yes" >> $IFCFG_FILE
 			$SUDO echo "IPADDR=$IPADDR" >> $IFCFG_FILE
 			$SUDO echo "PREFIX=$CIDR" >> $IFCFG_FILE
+			$SUDO echo "GATEWAY=$IPv4gw" >> $IFCFG_FILE
 			$SUDO echo "USERCTL=no" >> $IFCFG_FILE
 			$SUDO ip addr replace dev "$piholeInterface" "$IPv4addr"
 			if [ -x "$(command -v nmcli)" ];then


### PR DESCRIPTION
Fixes #586 .

Changes proposed in this pull request:

- Add missing gateway mentioned in issue #586.

Ensure gateway is specified when configuring static IP via pi-hole installer on Fedora/CentOS. 

@pi-hole/gravity