### PR TITLE
Add force clear to gravity

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -340,6 +340,23 @@ function gravity_reload() {
 	echo " done!"
 }
 
+
+for var in "$@"
+do
+  case "$var" in
+    "-f" | "--force"     ) force=true;;
+    "-h" | "--help"      ) helpFunc;;
+  esac
+done
+
+#Overwrite adlists.default from /etc/.pihole in case any changes have been made. Changes should be saved in /etc/adlists.list
+
+if $force; then
+	echo -n "::: Deleting exising list cache..."
+	$SUDO rm /etc/pihole/list.*
+	echo " done!"
+fi
+
 $SUDO cp /etc/.pihole/adlists.default /etc/pihole/adlists.default
 gravity_collapse
 gravity_spinup

--- a/gravity.sh
+++ b/gravity.sh
@@ -27,6 +27,18 @@ else
 	fi
 fi
 
+function helpFunc()
+{
+	echo "::: Pull in domains from adlists"
+	echo ":::"
+	echo "::: Usage: pihole -g"
+	echo ":::"
+	echo "::: Options:"
+	echo ":::  -f, --force				Force lists to be downloaded, even if they don't need updating."
+	echo ":::  -h, --help				Show this help dialog"
+	exit 1
+}
+
 piholeIPfile=/etc/pihole/piholeIP
 piholeIPv6file=/etc/pihole/.useIPv6
 


### PR DESCRIPTION
Feature request [on reddit](https://www.reddit.com/r/pihole/comments/4xz8y6/only_70k_domains_blocked_down_from_100k_any_ideas/d6kcctq?context=3)

Changes proposed in this pull request:

- Adds `-f` switch to gravity, which clears out the list cache files (`list.*`) and downloads each list from scratch.

@pi-hole/gravity
