### PR TITLE
Make the output of pihole -q a bit clearer. Bye Bye nifty one-liner!

### DIFF
--- a/pihole
+++ b/pihole
@@ -72,7 +72,16 @@ function setupLCDFunction {
 
 function queryFunc {
     domain=$2
-    for list in /etc/pihole/list.*;do echo $list;grep ${domain} $list;done
+    for list in /etc/pihole/list.*
+    do
+        count=$(grep ${domain} $list | wc -l)
+
+        if [[ ${count} > 0 ]]; then
+            echo "::: ${list} (${count} results)"
+            grep ${domain} ${list}
+            echo ""
+        fi
+    done
     exit 1
 }
 

--- a/pihole
+++ b/pihole
@@ -75,12 +75,11 @@ function queryFunc {
     for list in /etc/pihole/list.*
     do
         count=$(grep ${domain} $list | wc -l)
-
+        echo "::: ${list} (${count} results)"
         if [[ ${count} > 0 ]]; then
-            echo "::: ${list} (${count} results)"
             grep ${domain} ${list}
-            echo ""
         fi
+        echo ""
     done
     exit 1
 }


### PR DESCRIPTION
e.g:

``` bash
pi@raspberrypi:~ $ pihole -q doubleclick.com
::: /etc/pihole/list.0.raw.githubusercontent.com.domains (4 results)
0.0.0.0 doubleclick.com
0.0.0.0 www2.doubleclick.com
0.0.0.0 www3.doubleclick.com
0.0.0.0 www.doubleclick.com

::: /etc/pihole/list.2.sysctl.org.domains (4 results)
127.0.0.1        doubleclick.com
127.0.0.1        www.doubleclick.com
127.0.0.1        www2.doubleclick.com
127.0.0.1        www3.doubleclick.com

::: /etc/pihole/list.5.s3.amazonaws.com.domains (1 results)
doubleclick.com

::: /etc/pihole/list.6.hosts-file.net.domains (11 results)
127.0.0.1       doubleclick.com
127.0.0.1       ftp.doubleclick.com
127.0.0.1       m.doubleclick.com
127.0.0.1       mediavisor.doubleclick.com
127.0.0.1       reports.doubleclick.com
127.0.0.1       search.doubleclick.com
127.0.0.1       static.doubleclick.com
127.0.0.1       studio.doubleclick.com
127.0.0.1       www.doubleclick.com
127.0.0.1       www2.doubleclick.com
127.0.0.1       www3.doubleclick.com

```

@pi-hole/gravity

