### PR TITLE
Add the newer pihole command tags to the bash auto complete!

### DIFF
--- a/advanced/bash-completion/pihole
+++ b/advanced/bash-completion/pihole
@@ -4,7 +4,7 @@ _pihole()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="whitelist blacklist debug flush updateDashboard updateGravity setupLCD chronometer uninstall help"
+    opts="blacklist chronometer debug flush help query setupLCD uninstall updateDashboard updateGravity updatePihole version whitelist"
 
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
     return 0


### PR DESCRIPTION
Reorders the `pihole` bash completion options to be alpabetical.

Adds options missed from recent updates to `pihole` command
@pi-hole/gravity

