### PR TITLE
Add cron to apt-get dependencies

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -67,7 +67,7 @@ if [ -x "$(command -v apt-get)" ];then
 	PKG_INSTALL="$PKG_MANAGER --yes --quiet install"
 	PKG_COUNT="$PKG_MANAGER -s -o Debug::NoLocking=true upgrade | grep -c ^Inst"
 	INSTALLER_DEPS=( apt-utils whiptail dhcpcd5)
-	PIHOLE_DEPS=( dnsutils bc dnsmasq lighttpd php5-common php5-cgi php5 git curl unzip wget sudo netcat )
+	PIHOLE_DEPS=( dnsutils bc dnsmasq lighttpd php5-common php5-cgi php5 git curl unzip wget sudo netcat cron )
 	LIGHTTPD_USER="www-data"
 	LIGHTTPD_GROUP="www-data"
 	LIGHTTPD_CFG="lighttpd.conf.debian"


### PR DESCRIPTION
Addresses #669

Changes proposed in this pull request:

- Add `cron` to the debian-family dependency check

@pi-hole/gravity

