### PR TITLE
Add check at the beginning of update script to check for existence of…

### DIFF
--- a/pihole
+++ b/pihole
@@ -49,6 +49,18 @@ function flushFunc {
 
 
 function updatePiholeFunc {
+
+    if [ ! -d "/etc/.pihole" ]; then #This is unlikely
+        echo "::: Critical Error: Pi-Hole repo missing from system!"
+        echo "::: Please re-run install script from https://github.com/pi-hole/pi-hole"
+        exit 1;
+    fi
+    if [ ! -d "/var/www/html/admin" ]; then #This is unlikely
+        echo "::: Critical Error: Pi-Hole repo missing from system!"
+        echo "::: Please re-run install script from https://github.com/pi-hole/pi-hole"
+        exit 1;
+    fi
+
     echo "::: Checking for updates..."
     piholeVersion=$(cd /etc/.pihole/ && git describe --tags --abbrev=0)
     piholeVersionLatest=$(curl -s https://api.github.com/repos/pi-hole/pi-hole/releases/latest | grep -Po '"tag_name":.*?[^\\]",' |  perl -pe 's/"tag_name": "//; s/^"//; s/",$//')


### PR DESCRIPTION
Fixes #[internal] .

Changes proposed in this pull request:

- Adds an additional check for the local repos before updating. I came across it because I deleted `/var/www/html/admin` and tried `pihole -up`, which didn't like it!

@pi-hole/gravity

… local repos. If not, redirect the user to run install command again.