### PR TITLE
gravityDB

### DIFF
--- a/advanced/Scripts/gravity_parse.py
+++ b/advanced/Scripts/gravity_parse.py
@@ -43,31 +43,7 @@
 
 import sqlite3
 
-#-----------------------------------------------------------------------------
-# Functions
-#-----------------------------------------------------------------------------
-def create_tables():
-
-    qt = 'DROP TABLE IF EXISTS gravity'
-    c.execute(qt)
-    conn.commit()
-
-    qt = '''
-    CREATE TABLE IF NOT EXISTS gravity (
-        idx integer primary key autoincrement,
-        domain text
-    )
-    '''
-    c.execute(qt)
-    conn.commit()
-
-#-----------------------------------------------------------------------------
-# Main
-#-----------------------------------------------------------------------------
-
 logfile = '/etc/pihole/pihole.2.eventHorizon.txt'
-
-counts = {'lc': 0}
 
 # Create the SQLite connection
 conn = sqlite3.connect('/etc/pihole/pihole.db')
@@ -75,18 +51,21 @@ conn = sqlite3.connect('/etc/pihole/pihole.db')
 with conn:
     c = conn.cursor()
 
-    create_tables()
+    c.execute('DROP TABLE IF EXISTS gravity')
+
+    qt = '''
+    CREATE TABLE IF NOT EXISTS gravity (
+        idx INTEGER PRIMARY KEY ASC,
+        domain text
+    )
+    '''
+    c.execute(qt)
 
     # enable WAL mode
     c.execute('PRAGMA journal_mode=WAL;')
 
     # Parse the log file.
-    for line in open(logfile):
-        line = line.rstrip()
-        counts['lc'] += 1
-
-    if (counts['lc'] % 10000) == 0:
-        conn.commit()
-
-    sql = "INSERT INTO gravity (domain) VALUES (?)"
-    c.execute(sql, (line,))
+    with open(logfile) as f:
+        for line in f:
+            sql = "INSERT INTO gravity (domain) VALUES (?)"
+            c.execute(sql, (line,))

--- a/advanced/Scripts/gravity_parse.py
+++ b/advanced/Scripts/gravity_parse.py
@@ -71,19 +71,16 @@ counts = {'lc': 0}
 
 # Create the SQLite connection
 conn = sqlite3.connect('/etc/pihole/pihole.db')
-conn.text_factory = str  # I don't like it as a fix, but it works for now
-c = conn.cursor()
 
-create_tables()
+with conn:
+    c = conn.cursor()
 
-sql = "DELETE FROM gravity"
-c.execute(sql)
-conn.commit()
+    create_tables()
 
-# Parse the log file.
-for line in open(logfile):
-    line = line.rstrip()
-    counts['lc'] += 1
+    # Parse the log file.
+    for line in open(logfile):
+        line = line.rstrip()
+        counts['lc'] += 1
 
     if (counts['lc'] % 10000) == 0:
         conn.commit()

--- a/advanced/Scripts/gravity_parse.py
+++ b/advanced/Scripts/gravity_parse.py
@@ -77,6 +77,9 @@ with conn:
 
     create_tables()
 
+    # enable WAL mode
+    c.execute('PRAGMA journal_mode=WAL;')
+
     # Parse the log file.
     for line in open(logfile):
         line = line.rstrip()
@@ -87,5 +90,3 @@ with conn:
 
     sql = "INSERT INTO gravity (domain) VALUES (?)"
     c.execute(sql, (line,))
-
-conn.commit()

--- a/advanced/Scripts/gravity_parse.py
+++ b/advanced/Scripts/gravity_parse.py
@@ -43,16 +43,20 @@
 
 import sqlite3
 
+# Logfile containing unique list of all domains on downloaded lists.
 logfile = '/etc/pihole/pihole.2.eventHorizon.txt'
 
 # Create the SQLite connection
 conn = sqlite3.connect('/etc/pihole/pihole.db')
 
+# Python auto-handle commits, no need to call for commits manually
 with conn:
     c = conn.cursor()
 
+    # Lists have just been downloaded, clear out the existing data
     c.execute('DROP TABLE IF EXISTS gravity')
 
+    # Ready new table for list of domains
     qt = '''
     CREATE TABLE IF NOT EXISTS gravity (
         idx INTEGER PRIMARY KEY ASC,
@@ -64,7 +68,7 @@ with conn:
     # enable WAL mode
     c.execute('PRAGMA journal_mode=WAL;')
 
-    # Parse the log file.
+    # Parse the log file into the database
     with open(logfile) as f:
         for line in f:
             sql = "INSERT INTO gravity (domain) VALUES (?)"


### PR DESCRIPTION
See commit comments. Runs in about 20 seconds on a Zero, but eliminates some locked file contentions. You still can't delete a table while this is running, but that should not be an issue. Uses WAL and SHM files for transactions. Around 0.77 utilization, so the process is diskbound and not processor bound.