### PR TITLE
add mimetype for .svg

### DIFF
--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -46,7 +46,8 @@ mimetype.assign   = ( ".png"  => "image/png",
                       ".css" => "text/css; charset=utf-8",
                       ".js" => "application/javascript",
                       ".json" => "application/json",
-                      ".txt"  => "text/plain" )
+                      ".txt"  => "text/plain",
+                      ".svg"  => "image/svg+xml" )
 
 # default listening port for IPv6 falls back to the IPv4 port
 #include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port


### PR DESCRIPTION
@pi-hole/gravity

Chrome does not display .svg-images without the correct mimetype