### PR TITLE
Remove bare php package from dependencies

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -74,7 +74,7 @@ if [ -x "$(command -v apt-get)" ];then
 	PKG_INSTALL="$PKG_MANAGER --yes --quiet install"
 	PKG_COUNT="$PKG_MANAGER -s -o Debug::NoLocking=true upgrade | grep -c ^Inst"
 	INSTALLER_DEPS=( apt-utils whiptail dhcpcd5)
-	PIHOLE_DEPS=( dnsutils bc dnsmasq lighttpd ${phpVer}-common ${phpVer}-cgi ${phpVer} git curl unzip wget sudo netcat cron iproute2 )
+	PIHOLE_DEPS=( dnsutils bc dnsmasq lighttpd ${phpVer}-common ${phpVer}-cgi git curl unzip wget sudo netcat cron iproute2 )
 	LIGHTTPD_USER="www-data"
 	LIGHTTPD_GROUP="www-data"
 	LIGHTTPD_CFG="lighttpd.conf.debian"


### PR DESCRIPTION
Fixes #INTERNAL .

Changes proposed in this pull request:

- Remove `php5` from dependencies list

@pi-hole/gravity

`php5` package can trigger install of Apache2. Without this package in deps, PHP is still installed and operational.