### PR TITLE
Fix bash warning.

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -926,7 +926,7 @@ fi
 
 # Start the installer
 # Verify there is enough disk space for the install
-if [ $1 = "--i_do_not_follow_recommendations" ]; then
+if [ "$1" == "--i_do_not_follow_recommendations" ]; then
     echo "::: ----i_do_not_follow_recommendations passed to script"
     echo "::: skipping free disk space verification!"
 else


### PR DESCRIPTION
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

**By submitting this pull request, I confirm the following (please check boxes, eg [X]):**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 1 (very unfamiliar)
- [ ] 2
- [ ] 3
- [ ] 4
- [ ] 5
- [ ] 6
- [ ] 7
- [ ] 8
- [ ] 9
- [ ] 10 (very familiar)

---
Just noticed the bash warning
```
pi@raspberrypi:~ $ curl -L https://install.pi-hole.net | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0:::
::: sudo will be used for the install.
100 34419  100 34419    0     0  16230      0  0:00:02  0:00:02 --:--:-- 38116
::: Updating existing install
bash: line 929: [: =: unary operator expected
::: Verifying free disk space...
:::
```

I believe it was introduced by https://github.com/pi-hole/pi-hole/pull/743
