### PR TITLE
Fixed missing `=` in equality comparison

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -926,7 +926,7 @@ fi
 
 # Start the installer
 # Verify there is enough disk space for the install
-if [ $1 = "--i_do_not_follow_recommendations" ]; then
+if [ $1 == "--i_do_not_follow_recommendations" ]; then
     echo "::: ----i_do_not_follow_recommendations passed to script"
     echo "::: skipping free disk space verification!"
 else


### PR DESCRIPTION
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

**By submitting this pull request, I confirm the following (please check boxes, eg [X]):**

- [ ] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [x] 1 (very unfamiliar)
- [ ] 2
- [ ] 3
- [ ] 4
- [ ] 5
- [ ] 6
- [ ] 7
- [ ] 8
- [ ] 9
- [ ] 10 (very familiar)

---
The following line was missing an equals sign (`=`) to complete the comparison operation:
```
if [ $1 = "--i_do_not_follow_recommendations" ]; then
```

