### PR TITLE
add install whiptail before update_dialogs

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -892,6 +892,7 @@ if [[ -f ${setupVars} ]];then
   if [ "$1" == "pihole" ]; then
     useUpdateVars=true
   else
+    package_check_install "whiptail"
     update_dialogs
   fi
 fi


### PR DESCRIPTION
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

**By submitting this pull request, I confirm the following (please check boxes, eg [X]):**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 1 (very unfamiliar)
- [ ] 2
- [ ] 3
- [ ] 4
- [ ] 5
- [ ] 6
- [ ] 7
- [ ] 8
- [ ] 9
- [ ] 10 (very familiar)

---
The update_dialogs function depends on whiptail.
whiptail is already in the INSTALLER_DEPS array,
but it gets installed at a later point than here,
so we need to install it for the sake of update_dialogs first.