### PR TITLE
use an excluded extension for ifcfg backup

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -360,7 +360,7 @@ setStaticIPv4() {
 			IPADDR=$(echo "${IPv4_address}" | cut -f1 -d/)
 			CIDR=$(echo "${IPv4_address}" | cut -f2 -d/)
 			# Backup existing interface configuration:
-			cp "${IFCFG_FILE}" "${IFCFG_FILE}".backup-"$(date +%Y-%m-%d-%H%M%S)"
+			cp "${IFCFG_FILE}" "${IFCFG_FILE}".pihole.orig"
 			# Build Interface configuration file:
 			{
 			echo "# Configured via Pi-Hole installer"


### PR DESCRIPTION
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

**By submitting this pull request, I confirm the following (please check boxes, eg [X]):**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [ ] 1 (very unfamiliar)
- [ ] 2
- [ ] 3
- [ ] 4
- [ ] 5
- [ ] 6
- [x] 7
- [ ] 8
- [ ] 9
- [ ] 10 (very familiar)

---
_{replace this line with your pull request content}_

From sysconfig related documentation:
> The script literally does ifcfg-* with an exclude only for these extensions: .old, .orig, .rpmnew, .rpmorig, and .rpmsave.