### PR TITLE
[test] fix known bug with older lighttpd syntax 

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -52,10 +52,11 @@ $HTTP["url"] =~ "^/admin/" {
     )
 }
 
+# Rewite js requests, must be out of $HTTP block due to bug #2526
+url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
+
 # If the URL does not start with /admin, then it is a query for an ad domain
 $HTTP["url"] =~ "^(?!/admin)/.*" {
     # Create a response header for debugging using curl -I
     setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-    # rewrite only js requests
-    url.rewrite = ("(.*).js" => "pihole/index.js")
 }

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -69,10 +69,11 @@ $HTTP["url"] =~ "^/admin/" {
 	setenv.add-response-header = ( "X-Pi-hole" => "The Pi-hole Web interface is working!" )
 }
 
+# Rewite js requests, must be out of $HTTP block due to bug #2526
+url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
+
 # If the URL does not start with /admin, then it is a query for an ad domain
 $HTTP["url"] =~ "^(?!/admin)/.*" {
 	# Create a response header for debugging using curl -I
 	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-        # rewrite only js requests
-        url.rewrite = ("(.*).js" => "pihole/index.js")
 }


### PR DESCRIPTION
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

**By submitting this pull request, I confirm the following (please check boxes, eg [X]):**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [ ] 1 (very unfamiliar)
- [ ] 2
- [ ] 3
- [ ] 4
- [ ] 5
- [ ] 6
- [X] 7
- [ ] 8
- [ ] 9
- [ ] 10 (very familiar)

---

I cherry-picked these from my development since they are low-risk changes.

As shown in #850 this moves the url.rewrite out of the HTTP block.  This code is tested to work on old and new versions of lighttpd.  