### PR TITLE
[Ready] Wheezy fix

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -75,9 +75,6 @@ fi
 
 if [ -x "$(command -v apt-get)" ]; then
 	#Debian Family
-	#Decide if php should be `php5` or just `php` (Fixes issues with Ubuntu 16.04 LTS)
-	phpVer="php5"
-	apt-get install --dry-run php5 > /dev/null 2>&1 || phpVer="php"
 	#############################################
 	PKG_MANAGER="apt-get"
 	PKG_CACHE="/var/lib/apt/lists/"
@@ -86,8 +83,15 @@ if [ -x "$(command -v apt-get)" ]; then
 	PKG_INSTALL="${PKG_MANAGER} --yes --fix-missing install"
 	# grep -c will return 1 retVal on 0 matches, block this throwing the set -e with an OR TRUE
 	PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
+	# #########################################
+	# fixes for dependancy differences 
+	# Debian 7 doesn't have iproute2 use iproute
+	${PKG_MANAGER} install --dry-run iproute2 > /dev/null 2>&1 && IPROUTE_PKG="iproute2" || IPROUTE_PKG="iproute"
+	# Ubuntu 16.04 LTS php / php5 fix
+	${PKG_MANAGER} install --dry-run php5 > /dev/null 2>&1 && phpVer="php5" || phpVer="php"
+	# #########################################
 	INSTALLER_DEPS=( apt-utils whiptail git dhcpcd5)
-	PIHOLE_DEPS=( dnsutils bc dnsmasq lighttpd ${phpVer}-common ${phpVer}-cgi curl unzip wget sudo netcat cron iproute2 )
+	PIHOLE_DEPS=( dnsutils bc dnsmasq lighttpd ${phpVer}-common ${phpVer}-cgi curl unzip wget sudo netcat cron ${IPROUTE_PKG} )
 	LIGHTTPD_USER="www-data"
 	LIGHTTPD_GROUP="www-data"
 	LIGHTTPD_CFG="lighttpd.conf.debian"


### PR DESCRIPTION
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

**By submitting this pull request, I confirm the following (please check boxes, eg [X]):**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [ ] 1 (very unfamiliar)
- [ ] 2
- [ ] 3
- [ ] 4
- [ ] 5
- [ ] 6
- [X] 7
- [ ] 8
- [ ] 9
- [ ] 10 (very familiar)

---

This detects if iproute2 is not available and switches to iproute.  Fix allows installation and full function now that #861 has been merged.  Cleaned up the other package check to have the same syntax.