### PR TITLE
Dependancy cleanup

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -91,7 +91,7 @@ if [ -x "$(command -v apt-get)" ]; then
 	${PKG_MANAGER} install --dry-run php5 > /dev/null 2>&1 && phpVer="php5" || phpVer="php"
 	# #########################################
 	INSTALLER_DEPS=( apt-utils whiptail git dhcpcd5)
-	PIHOLE_DEPS=( dnsutils bc dnsmasq lighttpd ${phpVer}-common ${phpVer}-cgi curl unzip wget sudo netcat cron ${IPROUTE_PKG} )
+	PIHOLE_DEPS=( iputils-ping lsof dnsutils bc dnsmasq lighttpd ${phpVer}-common ${phpVer}-cgi curl unzip wget sudo netcat cron ${IPROUTE_PKG} )
 	LIGHTTPD_USER="www-data"
 	LIGHTTPD_GROUP="www-data"
 	LIGHTTPD_CFG="lighttpd.conf.debian"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -87,8 +87,8 @@ if [ -x "$(command -v apt-get)" ]; then
 	# fixes for dependancy differences 
 	# Debian 7 doesn't have iproute2 use iproute
 	${PKG_MANAGER} install --dry-run iproute2 > /dev/null 2>&1 && IPROUTE_PKG="iproute2" || IPROUTE_PKG="iproute"
-	# Ubuntu 16.04 LTS php / php5 fix
-	${PKG_MANAGER} install --dry-run php5 > /dev/null 2>&1 && phpVer="php5" || phpVer="php"
+	# Prefer the php metapackage if it's there, fall back on the php5 pacakges
+	${PKG_MANAGER} install --dry-run php > /dev/null 2>&1 && phpVer="php" || phpVer="php5"
 	# #########################################
 	INSTALLER_DEPS=( apt-utils whiptail git dhcpcd5)
 	PIHOLE_DEPS=( iputils-ping lsof dnsutils bc dnsmasq lighttpd ${phpVer}-common ${phpVer}-cgi curl unzip wget sudo netcat cron ${IPROUTE_PKG} )


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 7

---

Testing has revealed two tiny issues.

- ping and lsof are debugging dependencies that are not default packages in minbase of debian.  Adding to dependency list.
- We have to decide between php and php5.  On debian sid both packages are available.  The logic should prefer the php metapackage over the the php5 package since it's likely to install a more modern php environment.

I will run it though the battery of test to make sure that this doesn't change any of my previous results.