### PR TITLE
Fedora: write interface config instead of append

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -423,7 +423,7 @@ setStaticIPv4() {
 				echo "DNS1=$PIHOLE_DNS_1"
 				echo "DNS2=$PIHOLE_DNS_2"
 				echo "USERCTL=no"
-			}>> "${IFCFG_FILE}"
+			}> "${IFCFG_FILE}"
 			ip addr replace dev "${PIHOLE_INTERFACE}" "${IPV4_ADDRESS}"
 			if [ -x "$(command -v nmcli)" ];then
 				# Tell NetworkManager to read our new sysconfig file


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
- [x] 8

---
_Fedora interface configuration bugfix_

bug introduced with https://github.com/pi-hole/pi-hole/commit/93a591d487603da88a2e11d962825c63e2238f3a

Originally there was a comment *wrote* to the file with the remaining config *appended*.
This was changed via linting commit resulting in configuration being appended to existing configuration causing duplicate entries.

[reported via reddit](https://www.reddit.com/r/pihole/comments/5bd864/ran_into_some_issues_on_fedora_24_heres_a_quick/?ref=share&ref_source=link)


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

