### PR TITLE
Add webpage.sh

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2015, 2016 by Jacob Salmela
+# Network-wide ad blocking via your Raspberry Pi
+# http://pi-hole.net
+# Whitelists and blacklists domains
+#
+# Pi-hole is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+
+#globals
+basename=pihole
+piholeDir=/etc/${basename}
+
+helpFunc() {
+	cat << EOM
+::: Set options for the web interface of pihole
+:::
+::: Usage: pihole -web [options]
+:::
+::: Options:
+:::  -p, password		Set web interface password
+:::  -c, celsius		Set Celcius temperature unit
+:::  -f, fahrenheit		Set Fahrenheit temperature unit
+:::  -h, --help			Show this help dialog
+EOM
+	exit 1
+}
+
+args=("$@")
+
+SetTemperatureUnit(){
+
+	# Remove setting from file (create backup setupVars.conf.bak)
+	sed -i.bak '/temperatureunit/d' /etc/pihole/setupVars.conf
+	# Save setting to file
+	if [[ $unit == "F" ]] ; then
+		echo "temperatureunit=F" >> /etc/pihole/setupVars.conf
+	else
+		echo "temperatureunit=C" >> /etc/pihole/setupVars.conf
+	fi
+
+}
+
+SetWebPassword(){
+
+	# Remove password from file (create backup setupVars.conf.bak)
+	sed -i.bak '/webpassword/d' /etc/pihole/setupVars.conf
+	# Compute password hash
+	hash=$(echo -n ${args[2]} | sha256sum | sed 's/\s.*$//')
+	# Save hash to file
+	echo "webpassword=${hash}" >> /etc/pihole/setupVars.conf
+
+}
+
+for var in "$@"; do
+	case "${var}" in
+		"-p" | "password"   ) SetWebPassword;;
+		"-c" | "celsius"    ) unit="C"; SetTemperatureUnit;;
+		"-f" | "fahrenheit" ) unit="F"; SetTemperatureUnit;;
+		"-h" | "--help"     ) helpFunc;;
+	esac
+done
+
+shift
+
+if [[ $# = 0 ]]; then
+	helpFunc
+fi
+

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -18,7 +18,7 @@ helpFunc() {
 ::: Usage: pihole -web [options]
 :::
 ::: Options:
-:::  -p, password		Set web interface password
+:::  -p, password		Set web interface password, an empty input will remove any previously set password
 :::  -c, celsius		Set Celcius temperature unit
 :::  -f, fahrenheit		Set Fahrenheit temperature unit
 :::  -h, --help			Show this help dialog

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -10,9 +10,7 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-#globals
-basename=pihole
-piholeDir=/etc/${basename}
+args=("$@")
 
 helpFunc() {
 	cat << EOM
@@ -28,8 +26,6 @@ helpFunc() {
 EOM
 	exit 1
 }
-
-args=("$@")
 
 SetTemperatureUnit(){
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -43,11 +43,17 @@ SetWebPassword(){
 
 	# Remove password from file (create backup setupVars.conf.bak)
 	sed -i.bak '/WEBPASSWORD/d' /etc/pihole/setupVars.conf
-	# Compute password hash twice to avoid rainbow table vulnerability
-	hash=$(echo -n ${args[2]} | sha256sum | sed 's/\s.*$//')
-	hash=$(echo -n ${hash} | sha256sum | sed 's/\s.*$//')
-	# Save hash to file
-	echo "WEBPASSWORD=${hash}" >> /etc/pihole/setupVars.conf
+	# Set password only if there is one to be set
+	if (( ${#args[2]} > 0 )) ; then
+		# Compute password hash twice to avoid rainbow table vulnerability
+		hash=$(echo -n ${args[2]} | sha256sum | sed 's/\s.*$//')
+		hash=$(echo -n ${hash} | sha256sum | sed 's/\s.*$//')
+		# Save hash to file
+		echo "WEBPASSWORD=${hash}" >> /etc/pihole/setupVars.conf
+		echo "New password set"
+	else
+		echo "Password removed"
+	fi
 
 }
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -29,12 +29,12 @@ EOM
 SetTemperatureUnit(){
 
 	# Remove setting from file (create backup setupVars.conf.bak)
-	sed -i.bak '/temperatureunit/d' /etc/pihole/setupVars.conf
+	sed -i.bak '/TEMPERATUREUNIT/d' /etc/pihole/setupVars.conf
 	# Save setting to file
 	if [[ $unit == "F" ]] ; then
-		echo "temperatureunit=F" >> /etc/pihole/setupVars.conf
+		echo "TEMPERATUREUNIT=F" >> /etc/pihole/setupVars.conf
 	else
-		echo "temperatureunit=C" >> /etc/pihole/setupVars.conf
+		echo "TEMPERATUREUNIT=C" >> /etc/pihole/setupVars.conf
 	fi
 
 }
@@ -42,12 +42,12 @@ SetTemperatureUnit(){
 SetWebPassword(){
 
 	# Remove password from file (create backup setupVars.conf.bak)
-	sed -i.bak '/webpassword/d' /etc/pihole/setupVars.conf
+	sed -i.bak '/WEBPASSWORD/d' /etc/pihole/setupVars.conf
 	# Compute password hash twice to avoid rainbow table vulnerability
 	hash=$(echo -n ${args[2]} | sha256sum | sed 's/\s.*$//')
 	hash=$(echo -n ${hash} | sha256sum | sed 's/\s.*$//')
 	# Save hash to file
-	echo "webpassword=${hash}" >> /etc/pihole/setupVars.conf
+	echo "WEBPASSWORD=${hash}" >> /etc/pihole/setupVars.conf
 
 }
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -13,9 +13,9 @@ args=("$@")
 
 helpFunc() {
 	cat << EOM
-::: Set options for the web interface of pihole
+::: Set admin options for the web interface of pihole
 :::
-::: Usage: pihole -web [options]
+::: Usage: pihole -a [options]
 :::
 ::: Options:
 :::  -p, password		Set web interface password, an empty input will remove any previously set password

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # Pi-hole: A black hole for Internet advertisements
-# (c) 2015, 2016 by Jacob Salmela
 # Network-wide ad blocking via your Raspberry Pi
 # http://pi-hole.net
-# Whitelists and blacklists domains
+# Web interface settings
 #
 # Pi-hole is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -44,8 +43,9 @@ SetWebPassword(){
 
 	# Remove password from file (create backup setupVars.conf.bak)
 	sed -i.bak '/webpassword/d' /etc/pihole/setupVars.conf
-	# Compute password hash
+	# Compute password hash twice to avoid rainbow table vulnerability
 	hash=$(echo -n ${args[2]} | sha256sum | sed 's/\s.*$//')
+	hash=$(echo -n ${hash} | sha256sum | sed 's/\s.*$//')
 	# Save hash to file
 	echo "webpassword=${hash}" >> /etc/pihole/setupVars.conf
 

--- a/pihole
+++ b/pihole
@@ -22,6 +22,11 @@ if [[ ! $EUID -eq 0 ]];then
   fi
 fi
 
+webpageFunc() {
+  /opt/pihole/webpage.sh "$@"
+  exit 0
+}
+
 whitelistFunc() {
  "${PI_HOLE_SCRIPT_DIR}"/list.sh "$@"
   exit 0
@@ -180,7 +185,7 @@ helpFunc() {
 ::: Control all PiHole specific functions!
 :::
 ::: Usage: pihole [options]
-:::		Add -h after -w (whitelist), -b (blacklist), or -c (chronometer)  for more information on usage
+:::		Add -h after -w (whitelist), -b (blacklist), -c (chronometer), or -web (webpage)  for more information on usage
 :::
 ::: Options:
 :::  -w, whitelist            Whitelist domains
@@ -195,6 +200,7 @@ helpFunc() {
 :::  -v, version              Show current versions
 :::  -q, query                Query the adlists for a specific domain
 :::  -l, logging              Enable or Disable logging (pass 'on' or 'off')
+:::  -web, webpage            Webpage options
 :::  uninstall                Uninstall Pi-Hole from your system :(!
 :::  status                   Is Pi-Hole Enabled or Disabled
 :::  enable                   Enable Pi-Hole DNS Blocking
@@ -228,5 +234,6 @@ case "${1}" in
   "disable"                     ) piholeEnable 0;;
   "status"                      ) piholeStatus "$2";;
   "restartdns"                  ) restartDNS;;
+  "-web" | "webpage"            ) webpageFunc "$@";;
   *                             ) helpFunc;;
 esac

--- a/pihole
+++ b/pihole
@@ -185,7 +185,7 @@ helpFunc() {
 ::: Control all PiHole specific functions!
 :::
 ::: Usage: pihole [options]
-:::		Add -h after -w (whitelist), -b (blacklist), -c (chronometer), or -web (webpage)  for more information on usage
+:::		Add -h after -w (whitelist), -b (blacklist), -c (chronometer), or -a (admin)  for more information on usage
 :::
 ::: Options:
 :::  -w, whitelist            Whitelist domains
@@ -200,7 +200,7 @@ helpFunc() {
 :::  -v, version              Show current versions
 :::  -q, query                Query the adlists for a specific domain
 :::  -l, logging              Enable or Disable logging (pass 'on' or 'off')
-:::  -web, webpage            Webpage options
+:::  -a, admin                Admin webpage options
 :::  uninstall                Uninstall Pi-Hole from your system :(!
 :::  status                   Is Pi-Hole Enabled or Disabled
 :::  enable                   Enable Pi-Hole DNS Blocking
@@ -234,6 +234,6 @@ case "${1}" in
   "disable"                     ) piholeEnable 0;;
   "status"                      ) piholeStatus "$2";;
   "restartdns"                  ) restartDNS;;
-  "-web" | "webpage"            ) webpageFunc "$@";;
+  "-a" | "admin"                ) webpageFunc "$@";;
   *                             ) helpFunc;;
 esac


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [ ] 1 (very unfamiliar)
- [ ] 2
- [ ] 3
- [ ] 4
- [ ] 5
- [ ] 6
- [ ] 7
- [X] 8
- [ ] 9
- [ ] 10 (very familiar)

---

This PR is related to two pull requests for the web interface:

- [Add server-side password protection for the web interface](https://github.com/pi-hole/AdminLTE/pull/197)
- [Display CPU temperature in Fahrenheit](https://github.com/pi-hole/AdminLTE/pull/196)

It extends the pihole `command` to be able to set two options for these two new features: setting a password and selecting the unit used to display the CPU temperature. The password will be saved in a secure way (sha256 hash, no plain-text).
```
$ pihole -web
::: Set options for the web interface of pihole
:::
::: Usage: pihole -web [options]
:::
::: Options:
:::  -p, password		Set web interface password
:::  -c, celsius		Set Celcius temperature unit
:::  -f, fahrenheit		Set Fahrenheit temperature unit
:::  -h, --help			Show this help dialog
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
