### PR TITLE
Add possiblity for delayed reactivation of blocking

### DIFF
--- a/pihole
+++ b/pihole
@@ -132,7 +132,7 @@ piholeEnable() {
         echo "::: Example:"
         echo ":::    pihole disable 5s    -    will disable blocking for 5 seconds"
         echo ":::    pihole disable 7m    -    will disable blocking for 7 minutes"
-        echo "::: Blocking will not automatically be reenabled!"
+        echo "::: Blocking will not automatically be re-enabled!"
       fi
     fi
   else

--- a/pihole
+++ b/pihole
@@ -118,25 +118,20 @@ piholeEnable() {
     sed -i 's/^addn-hosts/#addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
     echo "::: Blocking has been disabled!"
     if [[ $# > 1 ]] ; then
-      if [ -x "$(command -v nohup)" ]; then
-        if [[ ${2} == *"s"* ]] ; then
-          tt=${2%"s"}
-          echo "::: Blocking will be reenabled in ${tt} seconds"
-          nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
-        elif [[ ${2} == *"m"* ]] ; then
-          tt=${2%"m"}
-          echo "::: Blocking will be reenabled in ${tt} minutes"
-          tt=$((${tt}*60))
-          nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
-        else
-          echo "::: Unknown format for delayed reactivation of the blocking!"
-          echo "::: Example:"
-          echo ":::    pihole disable 5s    -    will disable blocking for 5 seconds"
-          echo ":::    pihole disable 7m    -    will disable blocking for 7 minutes"
-          echo "::: Blocking will not automatically be reenabled!"
-        fi
+      if [[ ${2} == *"s"* ]] ; then
+        tt=${2%"s"}
+        echo "::: Blocking will be reenabled in ${tt} seconds"
+        nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
+      elif [[ ${2} == *"m"* ]] ; then
+        tt=${2%"m"}
+        echo "::: Blocking will be reenabled in ${tt} minutes"
+        tt=$((${tt}*60))
+        nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
       else
-        echo "::: Command 'nohup' has to be available for this feature."
+        echo "::: Unknown format for delayed reactivation of the blocking!"
+        echo "::: Example:"
+        echo ":::    pihole disable 5s    -    will disable blocking for 5 seconds"
+        echo ":::    pihole disable 7m    -    will disable blocking for 7 minutes"
         echo "::: Blocking will not automatically be reenabled!"
       fi
     fi
@@ -247,7 +242,7 @@ case "${1}" in
   "-q" | "query"                ) queryFunc "$@";;
   "-l" | "logging"              ) piholeLogging "$@";;
   "uninstall"                   ) uninstallFunc;;
-  "enable"                      ) piholeEnable 1 $2;;
+  "enable"                      ) piholeEnable 1;;
   "disable"                     ) piholeEnable 0 $2;;
   "status"                      ) piholeStatus "$2";;
   "restartdns"                  ) restartDNS;;

--- a/pihole
+++ b/pihole
@@ -120,16 +120,13 @@ piholeEnable() {
     if [[ $# > 1 ]] ; then
       if [ -x "$(command -v nohup)" ]; then
         if [[ ${2} == *"s"* ]] ; then
-          echo "Seconds"
           tt=${2%"s"}
           echo "::: Blocking will be reenabled in ${tt} seconds"
-          echo "sleep ${tt}; pihole enable"
           nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
         elif [[ ${2} == *"m"* ]] ; then
           tt=${2%"m"}
           echo "::: Blocking will be reenabled in ${tt} minutes"
           tt=$((${tt}*60))
-          echo "sleep ${tt}; pihole enable"
           nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
         else
           echo "::: Unknown format for delayed reactivation of the blocking!"

--- a/pihole
+++ b/pihole
@@ -117,6 +117,32 @@ piholeEnable() {
     #Disable Pihole
     sed -i 's/^addn-hosts/#addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
     echo "::: Blocking has been disabled!"
+    if [[ $# > 1 ]] ; then
+      if [ -x "$(command -v nohup)" ]; then
+        if [[ ${2} == *"s"* ]] ; then
+          echo "Seconds"
+          tt=${2%"s"}
+          echo "::: Blocking will be reenabled in ${tt} seconds"
+          echo "sleep ${tt}; pihole enable"
+          nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
+        elif [[ ${2} == *"m"* ]] ; then
+          tt=${2%"m"}
+          echo "::: Blocking will be reenabled in ${tt} minutes"
+          tt=$((${tt}*60))
+          echo "sleep ${tt}; pihole enable"
+          nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
+        else
+          echo "::: Unknown format for delayed reactivation of the blocking!"
+          echo "::: Example:"
+          echo ":::    pihole disable 5s    -    will disable blocking for 5 seconds"
+          echo ":::    pihole disable 7m    -    will disable blocking for 7 minutes"
+          echo "::: Blocking will not automatically be reenabled!"
+        fi
+      else
+        echo "::: Command 'nohup' has to be available for this feature."
+        echo "::: Blocking will not automatically be reenabled!"
+      fi
+    fi
   else
     #Enable pihole
     echo "::: Blocking has been enabled!"
@@ -224,8 +250,8 @@ case "${1}" in
   "-q" | "query"                ) queryFunc "$@";;
   "-l" | "logging"              ) piholeLogging "$@";;
   "uninstall"                   ) uninstallFunc;;
-  "enable"                      ) piholeEnable 1;;
-  "disable"                     ) piholeEnable 0;;
+  "enable"                      ) piholeEnable 1 $2;;
+  "disable"                     ) piholeEnable 0 $2;;
   "status"                      ) piholeStatus "$2";;
   "restartdns"                  ) restartDNS;;
   *                             ) helpFunc;;

--- a/pihole
+++ b/pihole
@@ -120,11 +120,11 @@ piholeEnable() {
     if [[ $# > 1 ]] ; then
       if [[ ${2} == *"s"* ]] ; then
         tt=${2%"s"}
-        echo "::: Blocking will be reenabled in ${tt} seconds"
+        echo "::: Blocking will be re-enabled in ${tt} seconds"
         nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
       elif [[ ${2} == *"m"* ]] ; then
         tt=${2%"m"}
-        echo "::: Blocking will be reenabled in ${tt} minutes"
+        echo "::: Blocking will be re-enabled in ${tt} minutes"
         tt=$((${tt}*60))
         nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
       else

--- a/pihole
+++ b/pihole
@@ -217,6 +217,8 @@ helpFunc() {
 :::  status                   Is Pi-Hole Enabled or Disabled
 :::  enable                   Enable Pi-Hole DNS Blocking
 :::  disable                  Disable Pi-Hole DNS Blocking
+:::                           Blocking can also be disabled only temporarily, e.g.,
+:::                           pihole disable 5m - will disable blocking for 5 minutes
 :::  restartdns               Restart dnsmasq
 EOM
   exit 1


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])
Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [ ] 1 (very unfamiliar)
- [ ] 2
- [ ] 3
- [ ] 4
- [ ] 5
- [ ] 6
- [ ] 7
- [X] 8
- [ ] 9
- [ ] 10 (very familiar)

---

Fixes #880 

Adds possibility to disable blocking only temporarily.
Currently, it is possible to specify the delay in seconds and minutes:

- `pihole disable 5s` will disable blocking for 5 seconds
- `pihole disable 7m` will disable blocking for 7 minutes
- etc.

Note that this will even work if the user logs out from the remote connection in the meantime.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

