### PR TITLE
Add check for lighty.conf before trying to move it

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -708,6 +708,7 @@ installConfigs() {
 	if [ ! -d "/etc/lighttpd" ]; then
 		mkdir /etc/lighttpd
 		chown "${USER}":root /etc/lighttpd
+	elif [ -f "/etc/lighttpd/lighttpd.conf" ]; then
 		mv /etc/lighttpd/lighttpd.conf /etc/lighttpd/lighttpd.conf.orig
 	fi
 	cp /etc/.pihole/advanced/${LIGHTTPD_CFG} /etc/lighttpd/lighttpd.conf


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [x] 3
---
This should fix two problems:
1. Backup of original lighttpd.conf is not happening.
2. Install fails when /etc/lighttpd/ does not exist.
    * mv command throws error
    * installConfigs does not complete (because set -e)
    * installPihole does not complete (because set -e)
    * main completes and reports successful install

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

