### PR TITLE
Also query blacklist with pihole -q

### DIFF
--- a/pihole
+++ b/pihole
@@ -69,7 +69,8 @@ setupLCDFunction() {
 
 queryFunc() {
   domain="${2}"
-  for list in /etc/pihole/list.*; do
+  lists=( /etc/pihole/list.* /etc/pihole/whitelist.txt /etc/pihole/blacklist.txt)
+  for list in ${lists[@]}; do
     count=$(grep -c ${domain} $list)
     echo "::: ${list} (${count} results)"
     if [[ ${count} > 0 ]]; then

--- a/pihole
+++ b/pihole
@@ -69,7 +69,7 @@ setupLCDFunction() {
 
 queryFunc() {
   domain="${2}"
-  lists=( /etc/pihole/list.* /etc/pihole/whitelist.txt /etc/pihole/blacklist.txt)
+  lists=( /etc/pihole/list.* /etc/pihole/blacklist.txt)
   for list in ${lists[@]}; do
     count=$(grep -c ${domain} $list)
     echo "::: ${list} (${count} results)"

--- a/pihole
+++ b/pihole
@@ -70,7 +70,7 @@ setupLCDFunction() {
 queryFunc() {
   domain="${2}"
   for list in /etc/pihole/list.*; do
-    count=$(grep ${domain} $list | wc -l)
+    count=$(grep -c ${domain} $list)
     echo "::: ${list} (${count} results)"
     if [[ ${count} > 0 ]]; then
       grep ${domain} ${list}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 10 (very familiar)

---
Suppose I add `abc.de` to the blacklist.

**Expected behavior**
`pihole -q abc.de` should show that this domain is blocked due to an entry in the blacklist.
![screenshot at 2016-12-05 17-17-19](https://cloud.githubusercontent.com/assets/16748619/20892485/be1ba9f2-bb0e-11e6-992c-0a970ff43800.png)

**Actual behavior**
`pihole -q abc.de` does give no results for why the page is blocked.
![screenshot at 2016-12-05 17-17-44](https://cloud.githubusercontent.com/assets/16748619/20892487/c0a0c810-bb0e-11e6-894d-533286554da8.png)

This will be necessary for the custom block page #961 where we use the `pihole -q domain` function and also want to show that a page is in the blacklist.txt file.

My expected behavior will be implemented by merging this PR.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
