### PR TITLE
pihole -q: Add option to show all partial or only exact matches

### DIFF
--- a/pihole
+++ b/pihole
@@ -71,10 +71,10 @@ queryFunc() {
   domain="${2}"
   lists=( /etc/pihole/list.* /etc/pihole/blacklist.txt)
   for list in ${lists[@]}; do
-    count=$(grep -c ${domain} $list)
+    count=$(grep -c -E "(^|\s)${domain}($|\s)" $list)
     echo "::: ${list} (${count} results)"
     if [[ ${count} > 0 ]]; then
-      grep ${domain} ${list}
+      grep -E "(^|\s)${domain}($|\s)" ${list}
     fi
     echo ""
   done

--- a/pihole
+++ b/pihole
@@ -68,19 +68,27 @@ setupLCDFunction() {
 }
 
 scanList(){
-    grep -E "(^|\s)${domain}($|\s)" "$1"
+  domain="${1}"
+  list="${2}"
+  method="${3}"
+  if [[ ${method} == "-exact" ]] ; then
+    grep -E "(^|\s)${domain}($|\s)" "${list}"
+  else
+    grep "${domain}" "${list}"
+  fi
 }
 
 queryFunc() {
   domain="${2}"
+  method="${3}"
   lists=( /etc/pihole/list.* /etc/pihole/blacklist.txt)
   for list in ${lists[@]}; do
-    result=$(scanList $list)
+    result=$(scanList ${domain} ${list} ${method})
     # Remove empty lines before couting number of results
     count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
     echo "::: ${list} (${count} results)"
     if [[ ${count} > 0 ]]; then
-        echo $result
+      echo "${result}"
     fi
     echo ""
   done
@@ -224,6 +232,7 @@ helpFunc() {
 :::  -h, help                 Show this help dialog
 :::  -v, version              Show current versions
 :::  -q, query                Query the adlists for a specific domain
+:::                           Use pihole -q domain -exact if you want to see exact matches only
 :::  -l, logging              Enable or Disable logging (pass 'on' or 'off')
 :::  -a, admin                Admin webpage options
 :::  uninstall                Uninstall Pi-Hole from your system :(!

--- a/pihole
+++ b/pihole
@@ -67,14 +67,20 @@ setupLCDFunction() {
   exit 0
 }
 
+scanList(){
+    grep -E "(^|\s)${domain}($|\s)" "$1"
+}
+
 queryFunc() {
   domain="${2}"
   lists=( /etc/pihole/list.* /etc/pihole/blacklist.txt)
   for list in ${lists[@]}; do
-    count=$(grep -c -E "(^|\s)${domain}($|\s)" $list)
+    result=$(scanList $list)
+    # Remove empty lines before couting number of results
+    count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
     echo "::: ${list} (${count} results)"
     if [[ ${count} > 0 ]]; then
-      grep -E "(^|\s)${domain}($|\s)" ${list}
+        echo $result
     fi
     echo ""
   done


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 10 (very familiar)

---
Show only exact matches for `pihole -q <domain>`

Also increases speed of the query by a factor of two (only noticeable on slow machines).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

