### PR TITLE
Update uninstall.sh for check on lighttpd installation

### DIFF
--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -136,7 +136,7 @@ removeNoPurge() {
 	fi
 
 	echo "::: Removing config files and scripts..."
-	package_check ${i} > /dev/null
+	package_check lighttpd > /dev/null
 	if [ $? -eq 1 ]; then
 		${SUDO} rm -rf /etc/lighttpd/ &> /dev/null
 	else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
- [x] 3
---
The uninstall script is failing to properly check for the lighttpd installation. The /etc/lighttpd directory is being removed even when lighttpd is still installed. This results in problems on subsequent install attempts (e.g. php modules are not enabled and the admin page doesn't work) 

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

