### PR TITLE
Add necessary backend for the new "Settings" page of the web UI

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -99,6 +99,14 @@ RestartDNS(){
 
 }
 
+SetQueryLogOptions(){
+
+	# Remove setting from file (create backup setupVars.conf.bak)
+	sed -i.bak '/API_QUERY_LOG_SHOW/d;' /etc/pihole/setupVars.conf
+	# Save setting to file
+	echo "API_QUERY_LOG_SHOW=${args[2]}" >> /etc/pihole/setupVars.conf
+}
+
 for var in "$@"; do
 	case "${var}" in
 		"-p" | "password"   ) SetWebPassword;;
@@ -109,6 +117,7 @@ for var in "$@"; do
 		"setexcludeclients" ) SetExcludeClients;;
 		"reboot"            ) Reboot;;
 		"restartdns"        ) RestartDNS;;
+		"setquerylog"       ) SetQueryLogOptions;;
 		"-h" | "--help"     ) helpFunc;;
 	esac
 done

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -67,12 +67,30 @@ SetDNSServers(){
 
 }
 
+SetExcludeDomains(){
+
+	# Remove setting from file (create backup setupVars.conf.bak)
+	sed -i.bak '/API_EXCLUDE_DOMAINS/d;' /etc/pihole/setupVars.conf
+	# Save setting to file
+	echo "API_EXCLUDE_DOMAINS=${args[2]}" >> /etc/pihole/setupVars.conf
+}
+
+SetExcludeClients(){
+
+	# Remove setting from file (create backup setupVars.conf.bak)
+	sed -i.bak '/API_EXCLUDE_CLIENTS/d;' /etc/pihole/setupVars.conf
+	# Save setting to file
+	echo "API_EXCLUDE_CLIENTS=${args[2]}" >> /etc/pihole/setupVars.conf
+}
+
 for var in "$@"; do
 	case "${var}" in
 		"-p" | "password"   ) SetWebPassword;;
 		"-c" | "celsius"    ) unit="C"; SetTemperatureUnit;;
 		"-f" | "fahrenheit" ) unit="F"; SetTemperatureUnit;;
 		"setdns"            ) SetDNSServers;;
+		"setexcludedomains" ) SetExcludeDomains;;
+		"setexcludeclients" ) SetExcludeClients;;
 		"-h" | "--help"     ) helpFunc;;
 	esac
 done

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -57,11 +57,22 @@ SetWebPassword(){
 
 }
 
+SetDNSServers(){
+
+	# Remove setting from file (create backup setupVars.conf.bak)
+	sed -i.bak '/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;' /etc/pihole/setupVars.conf
+	# Save setting to file
+	echo "PIHOLE_DNS_1=${args[2]}" >> /etc/pihole/setupVars.conf
+	echo "PIHOLE_DNS_2=${args[3]}" >> /etc/pihole/setupVars.conf
+
+}
+
 for var in "$@"; do
 	case "${var}" in
 		"-p" | "password"   ) SetWebPassword;;
 		"-c" | "celsius"    ) unit="C"; SetTemperatureUnit;;
 		"-f" | "fahrenheit" ) unit="F"; SetTemperatureUnit;;
+		"setdns"            ) SetDNSServers;;
 		"-h" | "--help"     ) helpFunc;;
 	esac
 done

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -89,6 +89,16 @@ Reboot(){
 
 }
 
+RestartDNS(){
+
+	if [ -x "$(command -v systemctl)" ]; then
+		systemctl restart dnsmasq &> /dev/null
+	else
+		service dnsmasq restart &> /dev/null
+	fi
+
+}
+
 for var in "$@"; do
 	case "${var}" in
 		"-p" | "password"   ) SetWebPassword;;
@@ -98,6 +108,7 @@ for var in "$@"; do
 		"setexcludedomains" ) SetExcludeDomains;;
 		"setexcludeclients" ) SetExcludeClients;;
 		"reboot"            ) Reboot;;
+		"restartdns"        ) RestartDNS;;
 		"-h" | "--help"     ) helpFunc;;
 	esac
 done

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -93,7 +93,7 @@ SetExcludeClients(){
 
 Reboot(){
 
-	reboot
+	nohup bash -c "sleep 5; reboot" &> /dev/null </dev/null &
 
 }
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -133,6 +133,9 @@ EnableDHCP(){
 	echo "dhcp-authoritative" >> /etc/dnsmasq.d/01-pihole.conf
 	# Use the specified file to store DHCP lease information
 	echo "dhcp-leasefile=/etc/pihole/dhcp.leases" >> /etc/dnsmasq.d/01-pihole.conf
+	# Suppress logging of the routine operation of these protocols. Errors and problems will still be logged, though.
+	echo "quiet-dhcp" >> /etc/dnsmasq.d/01-pihole.conf
+	echo "quiet-dhcp6" >> /etc/dnsmasq.d/01-pihole.conf
 
 	RestartDNS
 }

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -152,6 +152,14 @@ DisableDHCP(){
 	RestartDNS
 }
 
+SetWebUILayout(){
+
+	# Remove setting from file (create backup setupVars.conf.bak)
+	sed -i.bak '/WEBUIBOXEDLAYOUT/d;' /etc/pihole/setupVars.conf
+	echo "WEBUIBOXEDLAYOUT=${args[2]}" >> /etc/pihole/setupVars.conf
+
+}
+
 for var in "$@"; do
 	case "${var}" in
 		"-p" | "password"   ) SetWebPassword;;
@@ -165,6 +173,7 @@ for var in "$@"; do
 		"setquerylog"       ) SetQueryLogOptions;;
 		"enabledhcp"        ) EnableDHCP;;
 		"disabledhcp"       ) DisableDHCP;;
+		"layout"            ) SetWebUILayout;;
 		"-h" | "--help"     ) helpFunc;;
 	esac
 done

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -83,6 +83,12 @@ SetExcludeClients(){
 	echo "API_EXCLUDE_CLIENTS=${args[2]}" >> /etc/pihole/setupVars.conf
 }
 
+Reboot(){
+
+	reboot
+
+}
+
 for var in "$@"; do
 	case "${var}" in
 		"-p" | "password"   ) SetWebPassword;;
@@ -91,6 +97,7 @@ for var in "$@"; do
 		"setdns"            ) SetDNSServers;;
 		"setexcludedomains" ) SetExcludeDomains;;
 		"setexcludeclients" ) SetExcludeClients;;
+		"reboot"            ) Reboot;;
 		"-h" | "--help"     ) helpFunc;;
 	esac
 done

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -65,6 +65,14 @@ SetDNSServers(){
 	echo "PIHOLE_DNS_1=${args[2]}" >> /etc/pihole/setupVars.conf
 	echo "PIHOLE_DNS_2=${args[3]}" >> /etc/pihole/setupVars.conf
 
+	# Replace within actual dnsmasq config file
+	sed -i '/server=/d;' /etc/dnsmasq.d/01-pihole.conf
+	echo "server=${args[2]}" >> /etc/dnsmasq.d/01-pihole.conf
+	echo "server=${args[3]}" >> /etc/dnsmasq.d/01-pihole.conf
+
+	# Restart dnsmasq to load new configuration
+	RestartDNS
+
 }
 
 SetExcludeDomains(){


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 10 (very familiar)

---
Be able to set the DNS servers by calling `pihole -a setdns xx.xx.xx.xx xx.xx.xx.xx`. This will be used by the web UI settings page which is currently under development.

And much more like enabling the new Pi-Hole DHCP server, etc...

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
