### PR TITLE
Add password to webUI after update if there is none

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1164,15 +1164,16 @@ main() {
     echo "::: View the web interface at http://pi.hole/admin or http://${IPV4_ADDRESS%/*}/admin"
 	else
 		echo "::: Update complete!"
-		if (( ${#pw} > 0 )) ; then
-			echo ":::"
-			echo "::: Note: As security measure a password has been installed for your web interface"
-			echo "::: The currently set password is"
-			echo ":::                                ${pw}"
-			echo ":::"
-			echo "::: You can always change it using"
-			echo ":::                                pihole -a -p new_password"
-		fi
+	fi
+
+	if (( ${#pw} > 0 )) ; then
+		echo ":::"
+		echo "::: Note: As security measure a password has been installed for your web interface"
+		echo "::: The currently set password is"
+		echo ":::                                ${pw}"
+		echo ":::"
+		echo "::: You can always change it using"
+		echo ":::                                pihole -a -p new_password"
 	fi
 
 	echo ":::"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -994,6 +994,11 @@ configureSelinux() {
 }
 
 displayFinalMessage() {
+	if [ ! -z $pw ]; then
+		pwstring="Note: As security measure a password has been installed for your web interface\n The currently set password is\n                                ${pw}\n\n You can always change it using\n                                pihole -a -p new_password"
+	else
+		pswsting=""
+	fi
 	# Final completion message to user
 	whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Configure your devices to use the Pi-hole as their DNS server using:
 
@@ -1003,7 +1008,8 @@ IPv6:	${IPV6_ADDRESS}
 If you set a new IP address, you should restart the Pi.
 
 The install log is in /etc/pihole.
-View the web interface at http://pi.hole/admin or http://${IPV4_ADDRESS%/*}/admin" ${r} ${c}
+View the web interface at http://pi.hole/admin or http://${IPV4_ADDRESS%/*}/admin
+${string}" ${r} ${c}
 }
 
 update_dialogs() {
@@ -1122,6 +1128,12 @@ main() {
 	# Move the log file into /etc/pihole for storage
 	mv ${tmpLog} ${instalLogLoc}
 
+	# Add password to web UI if there is none
+	if [[ $(grep 'WEBPASSWORD' -c /etc/pihole/setupVars.conf) == 0 ]] ; then
+	    pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
+	    pihole -a -p ${pw}
+	fi
+
 	if [[ "${useUpdateVars}" == false ]]; then
 	    displayFinalMessage
 	fi
@@ -1144,6 +1156,15 @@ main() {
     echo "::: View the web interface at http://pi.hole/admin or http://${IPV4_ADDRESS%/*}/admin"
 	else
 		echo "::: Update complete!"
+		if [ ! -z $pw ]; then
+			echo ":::"
+			echo "::: Note: As security measure a password has been installed for your web interface"
+			echo "::: The currently set password is"
+			echo ":::                                ${pw}"
+			echo ":::"
+			echo "::: You can always change it using"
+			echo ":::                                pihole -a -p new_password"
+		fi
 	fi
 
 	echo ":::"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1005,12 +1005,7 @@ If you set a new IP address, you should restart the Pi.
 
 The install log is in /etc/pihole.
 View the web interface at http://pi.hole/admin or http://${IPV4_ADDRESS%/*}/admin
-
-Note: As security measure a password has been installed for your web interface
-The currently set password is
-                                ${1}
-You can always change it using
-                                pihole -a -p new_password" ${r} ${c}
+The currently set password is ${1}" ${r} ${c}
 	else
 	whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Configure your devices to use the Pi-hole as their DNS server using:
 
@@ -1169,7 +1164,7 @@ main() {
     echo "::: View the web interface at http://pi.hole/admin or http://${IPV4_ADDRESS%/*}/admin"
 	else
 		echo "::: Update complete!"
-		if [ ! -z $pw ]; then
+		if (( ${#pw} > 0 )) ; then
 			echo ":::"
 			echo "::: Note: As security measure a password has been installed for your web interface"
 			echo "::: The currently set password is"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -994,11 +994,7 @@ configureSelinux() {
 }
 
 displayFinalMessage() {
-	if [ ! -z $pw ]; then
-		pwstring="Note: As security measure a password has been installed for your web interface\n The currently set password is\n                                ${pw}\n\n You can always change it using\n                                pihole -a -p new_password"
-	else
-		pswsting=""
-	fi
+	if (( ${#1} > 0 )) ; then
 	# Final completion message to user
 	whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Configure your devices to use the Pi-hole as their DNS server using:
 
@@ -1009,7 +1005,23 @@ If you set a new IP address, you should restart the Pi.
 
 The install log is in /etc/pihole.
 View the web interface at http://pi.hole/admin or http://${IPV4_ADDRESS%/*}/admin
-${string}" ${r} ${c}
+
+Note: As security measure a password has been installed for your web interface
+The currently set password is
+                                ${1}
+You can always change it using
+                                pihole -a -p new_password" ${r} ${c}
+	else
+	whiptail --msgbox --backtitle "Make it so." --title "Installation Complete!" "Configure your devices to use the Pi-hole as their DNS server using:
+
+IPv4:	${IPV4_ADDRESS%/*}
+IPv6:	${IPV6_ADDRESS}
+
+If you set a new IP address, you should restart the Pi.
+
+The install log is in /etc/pihole.
+View the web interface at http://pi.hole/admin or http://${IPV4_ADDRESS%/*}/admin" ${r} ${c}
+	fi
 }
 
 update_dialogs() {
@@ -1129,13 +1141,14 @@ main() {
 	mv ${tmpLog} ${instalLogLoc}
 
 	# Add password to web UI if there is none
+	pw=""
 	if [[ $(grep 'WEBPASSWORD' -c /etc/pihole/setupVars.conf) == 0 ]] ; then
 	    pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
 	    pihole -a -p ${pw}
 	fi
 
 	if [[ "${useUpdateVars}" == false ]]; then
-	    displayFinalMessage
+	    displayFinalMessage ${pw}
 	fi
 
 	echo "::: Restarting services..."


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 10 (very familiar)

---
Add password to webUI after update if there is none. Just in case the web UI is accessible from the outside or if there are bad guys in your network it might be a good idea to have the password always enabled. The user can still chose to disable the password explicitly be setting an empty one. This explicit choice will not be overwritten by this PR.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._

