### PR TITLE
Don't kill setupVars.conf on update/fresh install

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -873,7 +873,9 @@ configureFirewall() {
 
 finalExports() {
 	# Update variables in setupVars.conf file
-	sed -i.update.bak '/PIHOLE_DOMAIN/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;/QUERY_LOGGING/d;' "${setupVars}"
+	if [ -e "${setupVars}" ]; then
+		sed -i.update.bak '/PIHOLE_DOMAIN/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;/QUERY_LOGGING/d;' "${setupVars}"
+	fi
     {
 	echo "PIHOLE_INTERFACE=${PIHOLE_INTERFACE}"
 	echo "IPV4_ADDRESS=${IPV4_ADDRESS}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -874,7 +874,7 @@ configureFirewall() {
 finalExports() {
 	# Update variables in setupVars.conf file
 	if [ -e "${setupVars}" ]; then
-		sed -i.update.bak '/PIHOLE_DOMAIN/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;/QUERY_LOGGING/d;' "${setupVars}"
+		sed -i.update.bak '/PIHOLE_INTERFACE/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;/QUERY_LOGGING/d;' "${setupVars}"
 	fi
     {
 	echo "PIHOLE_INTERFACE=${PIHOLE_INTERFACE}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -872,10 +872,8 @@ configureFirewall() {
 }
 
 finalExports() {
-	#If it already exists, lets overwrite it with the new values.
-	if [[ -f ${setupVars} ]]; then
-		rm ${setupVars}
-	fi
+	# Update variables in setupVars.conf file
+	sed -i.update.bak '/PIHOLE_DOMAIN/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;/QUERY_LOGGING/d;' "${setupVars}"
     {
 	echo "PIHOLE_INTERFACE=${PIHOLE_INTERFACE}"
 	echo "IPV4_ADDRESS=${IPV4_ADDRESS}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 10 (very familiar)

---
Previous behavior was to remove `setupVars.conf` and write it from scratch. This didn't preserve any settings.

Test: I create the file `/etc/pihole/setupVars.conf` before running the installer:
<pre>
root@ubuntu-512mb-fra1-01: ~# cat /etc/pihole/setupVars.conf
<b>SOME_SETTING=abc</b>
<b>PIHOLE_INTERFACE=something_very_bad</b>
root@ubuntu-512mb-fra1-01: ~#
</pre>

Without this PR after the install:
<pre>
root@ubuntu-512mb-fra1-01: ~# cat /etc/pihole/setupVars.conf
<b>PIHOLE_INTERFACE=eth0</b>
IPV4_ADDRESS=...
IPV6_ADDRESS=...
PIHOLE_DNS_1=8.8.8.8
PIHOLE_DNS_2=8.8.4.4
QUERY_LOGGING=true
root@ubuntu-512mb-fra1-01: ~#
</pre>
------> Interface has been corrected, but other settings are lost

With this PR after the install:
<pre>
root@ubuntu-512mb-fra1-01: ~# cat /etc/pihole/setupVars.conf
<b>SOME_SETTING=abc</b>
<b>PIHOLE_INTERFACE=eth0</b>
IPV4_ADDRESS=...
IPV6_ADDRESS=...
PIHOLE_DNS_1=8.8.8.8
PIHOLE_DNS_2=8.8.4.4
QUERY_LOGGING=true
root@ubuntu-512mb-fra1-01: ~#
</pre>
------> Interface has been corrected and other settings are preserved

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
