### PR TITLE
Errors should not escape black holes

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -105,9 +105,13 @@ gravity_collapse() {
 gravity_patternCheck() {
 	patternBuffer=$1
 	success=$2
-	# check if the patternbuffer is a non-zero length file
+	error=$3
 	if [ $success = true ]; then
-		if [[ -s "${patternBuffer}" ]]; then
+		# check if download was successful but list has not been modified
+		if [ "${error}" == "304" ]; then
+			echo ":::   No changes detected, transport skipped!"
+		# check if the patternbuffer is a non-zero length file
+		elif [[ -s "${patternBuffer}" ]]; then
 			# Some of the blocklists are copyright, they need to be downloaded
 			# and stored as is. They can be processed for content after they
 			# have been saved.
@@ -148,20 +152,20 @@ gravity_transport() {
 	# Analyze http response
 	echo -n ":::   Status: "
 	case "$err" in
-		"200"          ) echo "Success (OK)"; success=true;;
-		"304"          ) echo "Not modified"; success=false;;
-		"403"          ) echo "Forbidden"; success=false;;
-		"404"          ) echo "Not found"; success=false;;
-		"408"          ) echo "Time-out"; success=false;;
-		"451"          ) echo "Unavailable For Legal Reasons"; success=false;;
-		"521"          ) echo "Web Server Is Down (Cloudflare)"; success=false;;
-		"522"          ) echo "Connection Timed Out (Cloudflare)"; success=false;;
-		"500"          ) echo "Internal Server Error"; success=false;;
-		*              ) echo "Status $err"; success=false;;
+		"200"  ) echo "Success (OK)"; success=true;;
+		"304"  ) echo "Not modified"; success=true;;
+		"403"  ) echo "Forbidden"; success=false;;
+		"404"  ) echo "Not found"; success=false;;
+		"408"  ) echo "Time-out"; success=false;;
+		"451"  ) echo "Unavailable For Legal Reasons"; success=false;;
+		"521"  ) echo "Web Server Is Down (Cloudflare)"; success=false;;
+		"522"  ) echo "Connection Timed Out (Cloudflare)"; success=false;;
+		"500"  ) echo "Internal Server Error"; success=false;;
+		*      ) echo "Status $err"; success=false;;
 	esac
 
 	# Process result
-	gravity_patternCheck "${patternBuffer}" ${success}
+	gravity_patternCheck "${patternBuffer}" ${success} "${err}"
 
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
- [X] 10 (very familiar)

---
Currently we try to download the lists and if the resulting file is an empty file we interpret it as being not downloaded because there is no update for this list available.

However, that might be wrong, since there could also be another error causing this: Forbidden (Error 403), Not Found (Error 404), Time-Out (Error 408), Internal Server Error (Error 500), among others.

This PR implements a proper error handling to avoid accreting particles with zero mass (i.e. empty files) and thinking that that causes no harm to the accretion disk (in the end we assume that we will always have a list, even if it is a cached one).

Also, this PR adds a check for the existence of a file that we want to aggregate to the list of domains. This is error-prone since the list might have never gotten downloaded correctly.

Exemplary output:
<pre>
::: Getting raw.githubusercontent.com list... done
:::   Status: <b>Success (OK)</b>
:::   List updated, transport successful!
::: Getting mirror1.malwaredomains.com list... done
:::   Status: <b>Not modified</b>
:::   No changes detected, transport skipped!
::: Getting sysctl.org list... done
:::   Status: <b>Not modified</b>
:::   No changes detected, transport skipped!
::: Getting zeustracker.abuse.ch list... done
:::   Status: <b>Not modified</b>
:::   No changes detected, transport skipped!
::: Getting s3.amazonaws.com list... done
:::   Status: <b>Not modified</b>
:::   No changes detected, transport skipped!
::: Getting s3.amazonaws.com list... done
:::   Status: <b>Not modified</b>
:::   No changes detected, transport skipped!
::: Getting hosts-file.net list... done
:::   Status: <b>Not modified</b>
:::   No changes detected, transport skipped!
::: Getting raw.githubusercontent.com list... done
:::   Status: <b>Success (OK)</b>
:::   List updated, transport successful!
</pre>

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
