### PR TITLE
Fix: Dynamic instead of static sudoers file

### DIFF
--- a/advanced/pihole.sudo
+++ b/advanced/pihole.sudo
@@ -9,4 +9,3 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
-www-data ALL=NOPASSWD: /usr/local/bin/pihole

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -801,6 +801,8 @@ installPiholeWeb() {
   echo -n "::: Installing sudoer file..."
   mkdir -p /etc/sudoers.d/
   cp /etc/.pihole/advanced/pihole.sudo /etc/sudoers.d/pihole
+  # Add lighttpd user (OS dependent) to sudoers file
+  echo "${LIGHTTPD_USER} ALL=NOPASSWD: /usr/local/bin/pihole" >> /etc/sudoers.d/pihole
   chmod 0440 /etc/sudoers.d/pihole
   echo " done!"
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [X] 10 (very familiar)

---
Fixes (part of) #1004 

Instead of copying a static sudoers file, we only copy a template with some description and add the corresponding web user on-the-fly.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
