### PR TITLE
Implement DHCPv6 for Pi-hole DHCP server

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -188,7 +188,7 @@ dhcp-leasefile=/etc/pihole/dhcp.leases
 quiet-dhcp
 quiet-dhcp6
 
-enable-ra
+#enable-ra
 dhcp-option=option6:dns-server,[::]
 dhcp-range=::100,::1ff,constructor:${interface}
 " > /etc/dnsmasq.d/02-pihole-dhcp.conf

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -165,7 +165,15 @@ EnableDHCP(){
 
 	# Remove possible old setting from file
 	sed -i '/dhcp-/d;/quiet-dhcp/d;' /etc/dnsmasq.d/01-pihole.conf
+
+	# Get Pi-hole interface from setupVars.conf
 	interface=$(grep 'PIHOLE_INTERFACE=' /etc/pihole/setupVars.conf | sed "s/.*=//")
+	# Use eth0 as fallback interface
+	if [ -z ${interface} ]; then
+		interface="eth0"
+	fi
+
+	# Write settings to file
 	echo "###############################################################################
 #  DHCP SERVER CONFIG FILE AUTOMATICALLY POPULATED BY PI-HOLE WEB INTERFACE.  #
 #            ANY CHANGES MADE TO THIS FILE WILL BE LOST ON CHANGE             #

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -178,6 +178,10 @@ dhcp-option=option:router,${args[4]}
 dhcp-leasefile=/etc/pihole/dhcp.leases
 quiet-dhcp
 quiet-dhcp6
+
+enable-ra
+dhcp-option=option6:dns-server,[::]
+dhcp-range=::100,::1ff,constructor:eth0
 " > /etc/dnsmasq.d/02-pihole-dhcp.conf
 
 	RestartDNS

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -165,6 +165,7 @@ EnableDHCP(){
 
 	# Remove possible old setting from file
 	sed -i '/dhcp-/d;/quiet-dhcp/d;' /etc/dnsmasq.d/01-pihole.conf
+	interface=$(grep 'PIHOLE_INTERFACE=' /etc/pihole/setupVars.conf | sed "s/.*=//")
 	echo "###############################################################################
 #  DHCP SERVER CONFIG FILE AUTOMATICALLY POPULATED BY PI-HOLE WEB INTERFACE.  #
 #            ANY CHANGES MADE TO THIS FILE WILL BE LOST ON CHANGE             #
@@ -181,7 +182,7 @@ quiet-dhcp6
 
 enable-ra
 dhcp-option=option6:dns-server,[::]
-dhcp-range=::100,::1ff,constructor:eth0
+dhcp-range=::100,::1ff,constructor:${interface}
 " > /etc/dnsmasq.d/02-pihole-dhcp.conf
 
 	RestartDNS

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -163,18 +163,22 @@ EnableDHCP(){
 	echo "DHCP_END=${args[3]}" >> /etc/pihole/setupVars.conf
 	echo "DHCP_ROUTER=${args[4]}" >> /etc/pihole/setupVars.conf
 
-	# Remove setting from file
+	# Remove possible old setting from file
 	sed -i '/dhcp-/d;/quiet-dhcp/d;' /etc/dnsmasq.d/01-pihole.conf
-	# Save setting to file
-	echo "dhcp-range=${args[2]},${args[3]},infinite" >> /etc/dnsmasq.d/01-pihole.conf
-	echo "dhcp-option=option:router,${args[4]}" >> /etc/dnsmasq.d/01-pihole.conf
-	# Changes the behaviour from strict RFC compliance so that DHCP requests on unknown leases from unknown hosts are not ignored. This allows new hosts to get a lease without a tedious timeout under all circumstances. It also allows dnsmasq to rebuild its lease database without each client needing to reacquire a lease, if the database is lost.
-	echo "dhcp-authoritative" >> /etc/dnsmasq.d/01-pihole.conf
-	# Use the specified file to store DHCP lease information
-	echo "dhcp-leasefile=/etc/pihole/dhcp.leases" >> /etc/dnsmasq.d/01-pihole.conf
-	# Suppress logging of the routine operation of these protocols. Errors and problems will still be logged, though.
-	echo "quiet-dhcp" >> /etc/dnsmasq.d/01-pihole.conf
-	echo "quiet-dhcp6" >> /etc/dnsmasq.d/01-pihole.conf
+	echo "###############################################################################
+#  DHCP SERVER CONFIG FILE AUTOMATICALLY POPULATED BY PI-HOLE WEB INTERFACE.  #
+#            ANY CHANGES MADE TO THIS FILE WILL BE LOST ON CHANGE             #
+###############################################################################
+
+dhcp-authoritative
+
+dhcp-range=${args[2]},${args[3]},infinite
+dhcp-option=option:router,${args[4]}
+
+dhcp-leasefile=/etc/pihole/dhcp.leases
+quiet-dhcp
+quiet-dhcp6
+" > /etc/dnsmasq.d/02-pihole-dhcp.conf
 
 	RestartDNS
 }
@@ -185,8 +189,11 @@ DisableDHCP(){
 	sed -i.bak '/DHCP_ACTIVE/d;' /etc/pihole/setupVars.conf
 	echo "DHCP_ACTIVE=false" >> /etc/pihole/setupVars.conf
 
-	# Remove setting from file
+	# Remove possibly set setting from file
 	sed -i '/dhcp-/d;/quiet-dhcp/d;' /etc/dnsmasq.d/01-pihole.conf
+
+	# Remove settings file
+	rm /etc/dnsmasq.d/02-pihole-dhcp.conf
 
 	RestartDNS
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
- [X] 10 (very familiar)

---
Implements DHCPv6. No changes to the web UI requires, as DHCPv6 will always be enabled when IPv4 comes up and needs no special settings.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
