### PR TITLE
Test if DNS service is listening on local port 53 when reporting status

### DIFF
--- a/pihole
+++ b/pihole
@@ -185,7 +185,7 @@ piholeLogging() {
 }
 
 piholeStatus() {
-  if [[ $(netstat -plnt | grep -c ':53') > 0 ]]; then
+  if [[ $(netstat -plnt | grep -c ':53 ') > 0 ]]; then
     if [[ "${1}" != "web" ]] ; then
       echo "::: DNS service is running"
     fi

--- a/pihole
+++ b/pihole
@@ -185,6 +185,19 @@ piholeLogging() {
 }
 
 piholeStatus() {
+  if [[ $(netstat -plnt | grep -c ':53') > 0 ]]; then
+    if [[ "${1}" != "web" ]] ; then
+      echo "::: DNS service is running"
+    fi
+  else
+    if [[ "${1}" == "web" ]] ; then
+      echo "-1";
+    else
+      echo "::: DNS service is NOT running"
+    fi
+    return
+  fi
+
   if [[ $(grep -i "^#addn-hosts=/" /etc/dnsmasq.d/01-pihole.conf) ]] ; then
     #list is commented out
     if [[ "${1}" == "web" ]] ; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---
Fixes #1050 

Test if DNS service is listening on local port 53 when reporting status. 

Current behavior:
```
root@ubuntu-512mb-fra1-01:/etc/.pihole# service dnsmasq stop
root@ubuntu-512mb-fra1-01:/etc/.pihole# pihole status
::: Pi-hole blocking is Enabled
root@ubuntu-512mb-fra1-01:/etc/.pihole# service dnsmasq start
root@ubuntu-512mb-fra1-01:/etc/.pihole# pihole status
::: Pi-hole blocking is Enabled
```

Proposed behavior:
```
root@ubuntu-512mb-fra1-01:/etc/.pihole# service dnsmasq stop
root@ubuntu-512mb-fra1-01:/etc/.pihole# pihole status
::: DNS service is NOT running
root@ubuntu-512mb-fra1-01:/etc/.pihole# service dnsmasq start
root@ubuntu-512mb-fra1-01:/etc/.pihole# pihole status
::: DNS service is running
::: Pi-hole blocking is Enabled
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
