### PR TITLE
Fix updater failing on non-English systems

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -91,12 +91,37 @@ GitCheckUpdateAvail() {
 
   # Fetch latest changes in this repo
   git fetch --quiet origin
-  status="$(git status -sb)"
+
+  # @ alone is a shortcut for HEAD. Older versions of git
+  # need @{0}
+  LOCAL="$(git rev-parse @{0})"
+
+  # The suffix @{upstream} to a branchname
+  # (short form <branchname>@{u}) refers
+  # to the branch that the branch specified
+  # by branchname is set to build on top of#
+  # (configured with branch.<name>.remote and
+  # branch.<name>.merge). A missing branchname
+  # defaults to the current one.
+  REMOTE="$(git rev-parse @{upstream})"
 
   # Change back to original directory
   cd "${curdir}"
 
-  if [[ $status == *"behind"* ]]; then
+  if [[ ${#LOCAL} == 0 ]]; then
+    echo "::: Error: Local revision could not be optained, ask Pi-hole support."
+    echo "::: Additional debugging output:"
+    git status
+    exit
+  fi
+  if [[ ${#REMOTE} == 0 ]]; then
+    echo "::: Error: Remote revision could not be optained, ask Pi-hole support."
+    echo "::: Additional debugging output:"
+    git status
+    exit
+  fi
+
+  if [[ "${LOCAL}" != "${REMOTE}" ]]; then
     # Local branch is behind remote branch -> Update
     return 0
   else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---
## NEW LOGIC FOR THE UPDATER
Compare local and remote hashes. Update is available if current remote hash is different than current local hash since we assume that local should never be newer than remote for user

Previous logic: Fetch and then call status to see if `behind` is in the response. However, on German systems it will say `hinterher`. The same issue should be there in other languages. The update can be triggered manually in the meantime:
https://discourse.pi-hole.net/t/updating-pi-hole-on-non-english-systems/1135

Fixes #1095 

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
