### PR TITLE
Use logrotate for pihole.log

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -11,5 +11,10 @@
 # (at your option) any later version.
 
 echo -n "::: Flushing /var/log/pihole.log ..."
-echo " " > /var/log/pihole.log
+# Test if logrotate is available on this system
+if command -v /usr/sbin/logrotate &> /dev/null; then
+  /usr/sbin/logrotate --force /etc/.pihole/logrotate
+else
+  echo " " > /var/log/pihole.log
+fi
 echo "... done!"

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -13,7 +13,7 @@
 echo -n "::: Flushing /var/log/pihole.log ..."
 # Test if logrotate is available on this system
 if command -v /usr/sbin/logrotate &> /dev/null; then
-  /usr/sbin/logrotate --force /etc/.pihole/logrotate
+  /usr/sbin/logrotate --force /etc/.pihole/advanced/logrotate
 else
   echo " " > /var/log/pihole.log
 fi

--- a/advanced/logrotate
+++ b/advanced/logrotate
@@ -1,0 +1,9 @@
+/var/log/pihole.log {
+	daily
+	copytruncate
+	rotate 5
+	compress
+	delaycompress
+	notifempty
+	nomail
+}

--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -26,4 +26,4 @@
 #          The flush script will use logrotate if available
 00 00   * * *   root    PATH="$PATH:/usr/local/bin/" pihole flush
 
-@reboot /usr/sbin/logrotate /etc/.pihole/advanced/logrotate
+@reboot root /usr/sbin/logrotate /etc/.pihole/advanced/logrotate

--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -26,4 +26,4 @@
 #          The flush script will use logrotate if available
 00 00   * * *   root    PATH="$PATH:/usr/local/bin/" pihole flush
 
-@reboot /usr/sbin/logrotate --force /etc/.pihole/logrotate
+@reboot /usr/sbin/logrotate /etc/.pihole/logrotate

--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -26,4 +26,4 @@
 #          The flush script will use logrotate if available
 00 00   * * *   root    PATH="$PATH:/usr/local/bin/" pihole flush
 
-@reboot /usr/sbin/logrotate /etc/.pihole/logrotate
+@reboot /usr/sbin/logrotate /etc/.pihole/advanced/logrotate

--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -23,4 +23,7 @@
 
 # Pi-hole: Flush the log daily at 00:00 so it doesn't get out of control
 #          Stats will be viewable in the Web interface thanks to the cron job above
+#          The flush script will use logrotate if available
 00 00   * * *   root    PATH="$PATH:/usr/local/bin/" pihole flush
+
+@reboot /usr/sbin/logrotate --force /etc/.pihole/logrotate


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Add logrotate for pihole.log (see also [this thread](https://discourse.pi-hole.net/t/implement-logrotation-for-var-log-pihole-log/1266/2) on Discourse)

Selected options:

- `daily` (rotate the log once per day)
- `copytruncate` (copy the existing file to the new place and truncate the original file afterwards)
- `rotate 5` (keep 5 days/manual flush cycles)
- `compress` + `delaycompress` (compress files older than 1 day)
- `notifyempty` (do not rotate the log if it is empty)
- `nomail` (don't mail old log files to any address)

As fallback the old flushing routine will still be used if `logrotate` is not found.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
