### PR TITLE
Allow multiple DNS servers

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -92,12 +92,18 @@ SetWebPassword(){
 ProcessDNSSettings() {
 	source "${setupVars}"
 
-	delete_dnsmasq_setting "server="
-	add_dnsmasq_setting "server" "${PIHOLE_DNS_1}"
+	delete_dnsmasq_setting "server"
 
-	if [[ "${PIHOLE_DNS_2}" != "" ]]; then
-		add_dnsmasq_setting "server" "${PIHOLE_DNS_2}"
-	fi
+	COUNTER=1
+	while [[ 1 ]]; do
+		var=PIHOLE_DNS_${COUNTER}
+		echo "${COUNTER} ${var} ${!var}"
+		if [ -z "${!var}" ]; then
+			break;
+		fi
+		add_dnsmasq_setting "server" "${!var}"
+		let COUNTER=COUNTER+1
+	done
 
 	delete_dnsmasq_setting "domain-needed"
 
@@ -125,27 +131,27 @@ trust-anchor=.,19036,8,2,49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE3
 SetDNSServers(){
 
 	# Save setting to file
-	change_setting "PIHOLE_DNS_1" "${args[2]}"
+	delete_setting "PIHOLE_DNS"
+	IFS=',' read -r -a array <<< "${args[2]}"
+	for index in "${!array[@]}"
+	do
+		echo "$index ${array[index]}"
+		add_setting "PIHOLE_DNS_$((index+1))" "${array[index]}"
+	done
 
-	if [[ "${args[3]}" != "none" ]]; then
-		change_setting "PIHOLE_DNS_2" "${args[3]}"
-	else
-		change_setting "PIHOLE_DNS_2" ""
-	fi
-
-	if [[ "${args[4]}" == "domain-needed" ]]; then
+	if [[ "${args[3]}" == "domain-needed" ]]; then
 		change_setting "DNS_FQDN_REQUIRED" "true"
 	else
 		change_setting "DNS_FQDN_REQUIRED" "false"
 	fi
 
-	if [[ "${args[5]}" == "bogus-priv" ]]; then
+	if [[ "${args[4]}" == "bogus-priv" ]]; then
 		change_setting "DNS_BOGUS_PRIV" "true"
 	else
 		change_setting "DNS_BOGUS_PRIV" "false"
 	fi
 
-	if [[ "${args[6]}" == "dnssec" ]]; then
+	if [[ "${args[5]}" == "dnssec" ]]; then
 		change_setting "DNSSEC" "true"
 	else
 		change_setting "DNSSEC" "false"

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -97,7 +97,6 @@ ProcessDNSSettings() {
 	COUNTER=1
 	while [[ 1 ]]; do
 		var=PIHOLE_DNS_${COUNTER}
-		echo "${COUNTER} ${var} ${!var}"
 		if [ -z "${!var}" ]; then
 			break;
 		fi
@@ -135,7 +134,6 @@ SetDNSServers(){
 	IFS=',' read -r -a array <<< "${args[2]}"
 	for index in "${!array[@]}"
 	do
-		echo "$index ${array[index]}"
 		add_setting "PIHOLE_DNS_$((index+1))" "${array[index]}"
 	done
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

After reading the `dnsmasq` code a bit more I figured out that this will not drastically increase the used bandwidth (as I though initially). `dnsmasq` will send queries to any of the upstream servers that are enabled and tries to favor servers that are known to be up (favor = the fastest to respond). Only if this favorite server fails to answer, `dnsmasq` will reach out to the others. It will occasionally send a query to all of them to identify if the favored server is still the best choice.

See https://github.com/pi-hole/AdminLTE/pull/357

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
