### PR TITLE
Include CIDR notation for IPv4 non-natural blocks.

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -173,7 +173,8 @@ find_IPv4_information() {
   # Find IP used to route to outside world
   route=$(ip route get 8.8.8.8)
   IPv4dev=$(awk '{for (i=1; i<=NF; i++) if ($i~/dev/) print $(i+1)}' <<< "${route}")
-  IPV4_ADDRESS=$(awk '{print $7}' <<< "${route}")
+  IPv4bare=$(awk '{print $7}' <<< "${route}")
+  IPV4_ADDRESS=$(ip -o -f inet addr show | grep "${IPv4bare}" |  awk '{print $4}' | awk 'END {print}')
   IPv4gw=$(awk '{print $3}' <<< "${route}")
 
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Include the CIDR notation for `dhcpcd5` configuration for non-natural blocks. Still includes the multi-address per interface detection. 

Does not account for interfaces with multiple default routes. 

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._