### PR TITLE
Correct path for automated installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ _If you wish to read over the script before running it, run `nano basic-install.
 
 ```
 git clone --depth 1 https://github.com/pi-hole/pi-hole.git Pi-hole
-cd Pi-hole/automated_installer/
+cd Pi-hole/automated\ install/
 bash basic-install.sh
 ```
 


### PR DESCRIPTION
Small change to README.md, correcting path for `basic-install.sh`. 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

2

---

Updated README.md with correct path for `basic-install.sh`