### PR TITLE
Silence rm warning if no DHCP server is used

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -249,7 +249,7 @@ ra-param=*,0,0
 	fi
 
 	else
-		rm "${dhcpconfig}"
+		rm "${dhcpconfig}" &> /dev/null
 	fi
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Silence possible warning if DHCP server is not active:
```
rm: cannot remove '/etc/dnsmasq.d/02-pihole-dhcp.conf': No such file or directory
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
