### PR TITLE
Improve CLI domain filter

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -66,7 +66,7 @@ HandleOther(){
 	domain=$(sed -e "y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/" <<< "$1")
 
 	#check validity of domain
-	validDomain=$(perl -ne "print if /\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b/" <<< "$domain")
+	validDomain=$(perl -ne 'print if /^(?!.*[^a-z0-9-\.].*)\b((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}\b/' <<< "$domain")
 	if [ -z "${validDomain}" ]; then
 		echo "::: $1 is not a valid argument or domain name"
 	else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Improve CLI domain name filter for validating domains that shall be added to the white-/blacklists

Previous (current `development`):
- `http://example.com` - OK :no_entry_sign: 
- `http://example.com/` - OK :no_entry_sign: 
- `http://example.com/something.php` - OK :no_entry_sign: 
- `example.com/something.php` - OK :no_entry_sign: 
- `https://example.com` - OK :no_entry_sign: 
- `example.com?some=stuff` - OK :no_entry_sign: 
- `example.com` - OK :white_check_mark: 

This PR:
- `http://example.com` - not valid :white_check_mark: 
- `http://example.com/` - not valid :white_check_mark: 
- `http://example.com/something.php` - not valid :white_check_mark: 
- `example.com/something.php` - not valid :white_check_mark: 
- `https://example.com` - not valid :white_check_mark: 
- `example.com?some=stuff` - not valid :white_check_mark: 
- `example.com` - OK :white_check_mark: 

International characters (like ä. ö. ü) were not permitted before. This behavior is not changed by this PR.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
