### PR TITLE
Improve logrotate support

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -13,7 +13,7 @@
 echo -n "::: Flushing /var/log/pihole.log ..."
 # Test if logrotate is available on this system
 if command -v /usr/sbin/logrotate &> /dev/null; then
-  /usr/sbin/logrotate --force /etc/.pihole/advanced/logrotate
+  /usr/sbin/logrotate --force /etc/pihole/logrotate
 else
   echo " " > /var/log/pihole.log
 fi

--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -26,4 +26,4 @@
 #          The flush script will use logrotate if available
 00 00   * * *   root    PATH="$PATH:/usr/local/bin/" pihole flush
 
-@reboot root /usr/sbin/logrotate /etc/.pihole/advanced/logrotate
+@reboot root /usr/sbin/logrotate /etc/pihole/logrotate

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -934,6 +934,18 @@ finalExports() {
   fi
 }
 
+installLogrotate() {
+  # Install the logrotate script
+  echo ":::"
+  echo -n "::: Installing latest logrotate script..."
+  cp /etc/.pihole/advanced/logrotate /etc/pihole/logrotate
+  # Raspbian will use the default "su root root"
+  # Ubuntu will use a custom user/group "su root syslog"
+  # We read the global config file and copy what we find into our file
+  echo $(sed '/^su/!d' /etc/logrotate.conf) >> /etc/pihole/logrotate
+  echo " done!"
+}
+
 installPihole() {
   # Install base files and web interface
   create_pihole_user
@@ -953,6 +965,7 @@ installPihole() {
   CreateLogFile
   installPiholeWeb
   installCron
+  installLogrotate
   configureFirewall
   finalExports
   runGravity
@@ -983,6 +996,7 @@ updatePihole() {
   CreateLogFile
   installPiholeWeb
   installCron
+  installLogrotate
   finalExports #re-export setupVars.conf to account for any new vars added in new versions
   runGravity
 }

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -939,10 +939,16 @@ installLogrotate() {
   echo ":::"
   echo -n "::: Installing latest logrotate script..."
   cp /etc/.pihole/advanced/logrotate /etc/pihole/logrotate
-  # Raspbian will use the default "su root root"
-  # Ubuntu will use a custom user/group "su root syslog"
-  # We read the global config file and copy what we find into our file
-  echo $(sed '/^su/!d' /etc/logrotate.conf) >> /etc/pihole/logrotate
+  # Different operating systems have different user / group
+  # settings for logrotate that makes it impossible to create
+  # a static logrotate file that will work with e.g.
+  # Rasbian and Ubuntu at the same time. Hence, we have to
+  # customize the logrotate script here in order to reflect
+  # the local properties of the /var/log directory
+  logusergroup="$(stat -c '%U %G' /var/log)"
+  if [[ ! -z $logusergroup ]]; then
+    echo "su ${logusergroup}" >> /etc/pihole/logrotate
+  fi
   echo " done!"
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

When Pi-hole tries to rotate its logs on Ubuntu, the following message appears:

```
error: skipping "/var/log/pihole.log" because parent directory has insecure permissions
(It's world writable or writable by group which is not "root") Set "su" directive in
config file to tell logrotate which user/group should be used for rotation.
```
Different operating systems have different user / group settings for `logrotate` that makes it impossible to create a static `logrotate` file that will work with e.g. Raspbian and Ubuntu at the same time. Hence, we have to customize the `logrotate` script dynamically in order to reflect the local properties of the /var/log directory.

The reason why this only affects our `logrotate` config and not others is that we explicitly call our config file. In this case, `logrotate` skips reading the global config file and misses this critical information.

On Raspbian this adds
```
su root root
```
to our `logrotate` file (`pihole flush` is working fine)

On Ubuntu this adds
```
su root syslog
```
to our `logrotate` file (`pihole flush` is working fine)

See also [this](https://bugs.launchpad.net/ubuntu/+source/logrotate/+bug/1278193) bug report ob Launchpad.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
