### PR TITLE
remove pihole -s flag

### DIFF
--- a/pihole
+++ b/pihole
@@ -69,11 +69,6 @@ updateGravityFunc() {
   exit 0
 }
 
-setupLCDFunction() {
-  "${PI_HOLE_SCRIPT_DIR}"/setupLCD.sh
-  exit 0
-}
-
 scanList(){
   domain="${1}"
   list="${2}"
@@ -287,7 +282,6 @@ helpFunc() {
 :::  -up, updatePihole        Update Pi-hole
 :::  -r, reconfigure          Reconfigure or Repair Pi-hole
 :::  -g, updateGravity        Update the list of ad-serving domains
-:::  -s, setupLCD             Automatically configures the Pi to use the 2.8 LCD screen to display stats on it
 :::  -c, chronometer          Calculates stats and displays to an LCD
 :::  -h, help                 Show this help dialog
 :::  -v, version              Show current versions
@@ -320,7 +314,6 @@ case "${1}" in
   "-up" | "updatePihole"        ) updatePiholeFunc;;
   "-r"  | "reconfigure"         ) reconfigurePiholeFunc;;
   "-g" | "updateGravity"        ) updateGravityFunc "$@";;
-  "-s" | "setupLCD"             ) setupLCDFunction;;
   "-c" | "chronometer"          ) chronometerFunc "$@";;
   "-h" | "help"                 ) helpFunc;;
   "-v" | "version"              ) versionFunc "$@";;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

8
---
`pihole -s` hasn't worked well for some time.  There is no built in protection from running it on non-Pi systems, and has been known to brick some people's installs.  For this reason, it is being removed.  Users can still manually execute the commands found [here](https://learn.adafruit.com/adafruit-pitft-28-inch-resistive-touchscreen-display-raspberry-pi/touchscreen-install-and-calibrate) if they need to add in LCD support.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
