### PR TITLE
Stay in repo directory until we error check

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -106,13 +106,13 @@ GitCheckUpdateAvail() {
   REMOTE="$(git rev-parse @{upstream})"
 
   if [[ ${#LOCAL} == 0 ]]; then
-    echo "::: Error: Local revision could not be optained, ask Pi-hole support."
+    echo "::: Error: Local revision could not be obtained, ask Pi-hole support."
     echo "::: Additional debugging output:"
     git status
     exit
   fi
   if [[ ${#REMOTE} == 0 ]]; then
-    echo "::: Error: Remote revision could not be optained, ask Pi-hole support."
+    echo "::: Error: Remote revision could not be obtained, ask Pi-hole support."
     echo "::: Additional debugging output:"
     git status
     exit

--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -105,9 +105,6 @@ GitCheckUpdateAvail() {
   # defaults to the current one.
   REMOTE="$(git rev-parse @{upstream})"
 
-  # Change back to original directory
-  cd "${curdir}"
-
   if [[ ${#LOCAL} == 0 ]]; then
     echo "::: Error: Local revision could not be optained, ask Pi-hole support."
     echo "::: Additional debugging output:"
@@ -120,6 +117,9 @@ GitCheckUpdateAvail() {
     git status
     exit
   fi
+  
+  # Change back to original directory
+  cd "${curdir}"
 
   if [[ "${LOCAL}" != "${REMOTE}" ]]; then
     # Local branch is behind remote branch -> Update


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Moving back to the original directory before error checking caused the debugging information (if there was an error) to be incorrect. It would run `git status` in the executing directory instead of the repo directory.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
