### PR TITLE
Change how user and group are stored in the logrotate config file

### DIFF
--- a/advanced/logrotate
+++ b/advanced/logrotate
@@ -1,4 +1,5 @@
 /var/log/pihole.log {
+	# su #
 	daily
 	copytruncate
 	rotate 5

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -949,7 +949,7 @@ installLogrotate() {
   # the local properties of the /var/log directory
   logusergroup="$(stat -c '%U %G' /var/log)"
   if [[ ! -z $logusergroup ]]; then
-    echo "su ${logusergroup}" >> /etc/pihole/logrotate
+    sed -i "s/# su #/su ${logusergroup}/" /etc/pihole/logrotate
   fi
   echo " done!"
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10
---

Change how user and group are stored in the logrotate config file (necessary on Ubuntu 16.04.1)
Fixes #1193 

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
