### PR TITLE
Fix output for wildcards in gravity.sh

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -243,7 +243,7 @@ gravity_Wildcard() {
 	    if [[ -n "${IPV4_ADDRESS}" && -n "${IPV6_ADDRESS}" ]];then
 	        let numWildcards/=2
 	    fi
-	    plural=; [[ "$num" != "1" ]] && plural=s
+	    plural=; [[ "$numWildcards" != "1" ]] && plural=s
 	    echo "::: Wildcard blocked domain${plural}: $numWildcards"
 	else
 	    echo "::: No wildcards used!"

--- a/gravity.sh
+++ b/gravity.sh
@@ -239,12 +239,12 @@ gravity_Blacklist() {
 gravity_Wildcard() {
 	# Return number of wildcards in output - don't actually handle wildcards
 	if [[ -f "${wildcardlist}" ]]; then
-	    num=$(grep -c ^ "${wildcardlist}")
+	    numWildcards=$(grep -c ^ "${wildcardlist}")
 	    if [[ -n "${IPV4_ADDRESS}" && -n "${IPV6_ADDRESS}" ]];then
-	        let num/=2
+	        let numWildcards/=2
 	    fi
 	    plural=; [[ "$num" != "1" ]] && plural=s
-	    echo "::: Wildcard blocked domain${plural}: $numBlacklisted"
+	    echo "::: Wildcard blocked domain${plural}: $numWildcards"
 	else
 	    echo "::: No wildcards used!"
 	fi


### PR DESCRIPTION
***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

3

---
The implementation of wildcards output for gravity is faulty. It outputs the number of blacklisted items instead of the wildcarded items (numBlacklist instead of "num"). I have renamed the variable, fixed the check and output. Now I see the correct output for number of items in 03-pihole-wildcard.conf.

The mistake is here: https://github.com/pi-hole/pi-hole/pull/1190/commits/a8ac212ee627f0f72aad5e65322541c4b265e5a6#diff-9e53ae7c3c4f9235e5908d902fb93c8aR247

This impacts #1190 and the latest 2.12.1 hotfix release. I would advise another .2 release.
