### PR TITLE
Justify and improve help texts, add missing wildcard description

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -42,11 +42,11 @@ helpFunc() {
 ::: Usage: pihole -${letter} domain1 [domain2 ...]
 :::
 ::: Options:
-:::  -d, --delmode			Remove domains from the ${word}list
-:::  -nr, --noreload		Update ${word}list without refreshing dnsmasq
-:::  -q, --quiet			output is less verbose
-:::  -h, --help				Show this help dialog
-:::  -l, --list				Display your ${word}listed domains
+:::  -d, --delmode            Remove domains from the ${word}list
+:::  -nr, --noreload          Update ${word}list without refreshing dnsmasq
+:::  -q, --quiet              Output is less verbose
+:::  -h, --help               Show this help dialog
+:::  -l, --list               Display your ${word}listed domains
 EOM
 if [[ "${letter}" == "b" ]]; then
 	echo ":::  -wild, --wildcard		Add whitecard entry (only blacklist)"
@@ -229,4 +229,3 @@ PoplistFile
 if ${reload}; then
 	Reload
 fi
-

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -49,7 +49,7 @@ helpFunc() {
 :::  -l, --list               Display your ${word}listed domains
 EOM
 if [[ "${letter}" == "b" ]]; then
-	echo ":::  -wild, --wildcard		Add whitecard entry (only blacklist)"
+	echo ":::  -wild, --wildcard         Add wildcard entry (only blacklist)"
 fi
 	exit 0
 }

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -49,7 +49,7 @@ helpFunc() {
 :::  -l, --list               Display your ${word}listed domains
 EOM
 if [[ "${letter}" == "b" ]]; then
-	echo ":::  -wild, --wildcard         Add wildcard entry (only blacklist)"
+	echo ":::  -wild, --wildcard        Add wildcard entry (only blacklist)"
 fi
 	exit 0
 }

--- a/pihole
+++ b/pihole
@@ -274,19 +274,20 @@ helpFunc() {
 :::		Add -h after -w (whitelist), -b (blacklist), -c (chronometer), or -a (admin)  for more information on usage
 :::
 ::: Options:
-:::  -w, whitelist            Whitelist domains
-:::  -b, blacklist            Blacklist domains
-:::  -d, debug                Start a debugging session if having trouble
-:::  -f, flush                Flush the pihole.log file
-:::  -t, tail                 Output the last lines of the pihole.log file. Lines are appended as the file grows
-:::  -up, updatePihole        Update Pi-hole
+:::  -w, whitelist            Whitelist domain(s)
+:::  -b, blacklist            Blacklist domain(s) (exact match)
+:::  -wild, wildcard          Blacklist whole domain(s) (wildcard)
+:::  -d, debug                Start a debugging session
+:::  -f, flush                Flush the 'pihole.log' file
+:::  -t, tail                 Output the last lines of the 'pihole.log' file. Lines are appended as the file grows
+:::  -up, updatePihole        Update Pi-hole components
 :::  -r, reconfigure          Reconfigure or Repair Pi-hole
 :::  -g, updateGravity        Update the list of ad-serving domains
 :::  -c, chronometer          Calculates stats and displays to an LCD
 :::  -h, help                 Show this help dialog
-:::  -v, version              Show current versions
+:::  -v, version              Show installed versions of Pi-Hole and Web-Admin
 :::  -q, query                Query the adlists for a specific domain
-:::                           Use pihole -q domain -exact if you want to see exact matches only
+:::                           Use 'pihole -q domain -exact' if you want to see exact matches only
 :::  -l, logging              Enable or Disable logging (pass 'on' or 'off')
 :::  -a, admin                Admin webpage options
 :::  uninstall                Uninstall Pi-Hole from your system :(!
@@ -294,7 +295,7 @@ helpFunc() {
 :::  enable                   Enable Pi-Hole DNS Blocking
 :::  disable                  Disable Pi-Hole DNS Blocking
 :::                           Blocking can also be disabled only temporarily, e.g.,
-:::                           pihole disable 5m - will disable blocking for 5 minutes
+:::                           'pihole disable 5m' - will disable blocking for 5 minutes
 :::  restartdns               Restart dnsmasq
 EOM
   exit 0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_4_

---
Justified the help output for the lists script, use of tabs was causing broken indentation in the terminal. Removed tabs, replaced with whitespace to match the 30 character spacing as in the main pihole script.

Added missing description for the -wild flag to pihole script, cleaned up and clarified other help output.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
