### PR TITLE
Add manual edit warnings to lighttpd.conf.* files

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -9,6 +9,14 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
+###############################################################################
+#     FILE AUTOMATICALLY OVERWRITTEN BY PI-HOLE INSTALL/UPDATE PROCEDURE.     #
+# ANY CHANGES MADE TO THIS FILE AFTER INSTALL WILL BE LOST ON THE NEXT UPDATE #
+#                                                                             #
+#              CHANGES SHOULD BE MADE IN A SEPERATE CONFIG FILE:              #
+#                         /etc/lighttpd/external.conf                         #
+###############################################################################
+
 server.modules = (
 	"mod_access",
 	"mod_accesslog",
@@ -21,15 +29,15 @@ server.modules = (
 )
 
 server.document-root        = "/var/www/html"
-server.error-handler-404	= "pihole/index.php"
+server.error-handler-404    = "pihole/index.php"
 server.upload-dirs          = ( "/var/cache/lighttpd/uploads" )
 server.errorlog             = "/var/log/lighttpd/error.log"
 server.pid-file             = "/var/run/lighttpd.pid"
 server.username             = "www-data"
 server.groupname            = "www-data"
 server.port                 = 80
-accesslog.filename			= "/var/log/lighttpd/access.log"
-accesslog.format			= "%{%s}t|%V|%r|%s|%b"
+accesslog.filename          = "/var/log/lighttpd/access.log"
+accesslog.format            = "%{%s}t|%V|%r|%s|%b"
 
 
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -9,6 +9,14 @@
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
 
+###############################################################################
+#     FILE AUTOMATICALLY OVERWRITTEN BY PI-HOLE INSTALL/UPDATE PROCEDURE.     #
+# ANY CHANGES MADE TO THIS FILE AFTER INSTALL WILL BE LOST ON THE NEXT UPDATE #
+#                                                                             #
+#              CHANGES SHOULD BE MADE IN A SEPERATE CONFIG FILE:              #
+#                         /etc/lighttpd/external.conf                         #
+###############################################################################
+
 server.modules = (
 	"mod_access",
 	"mod_auth",
@@ -22,15 +30,15 @@ server.modules = (
 )
 
 server.document-root        = "/var/www/html"
-server.error-handler-404	= "pihole/index.php"
+server.error-handler-404    = "pihole/index.php"
 server.upload-dirs          = ( "/var/cache/lighttpd/uploads" )
 server.errorlog             = "/var/log/lighttpd/error.log"
 server.pid-file             = "/var/run/lighttpd.pid"
 server.username             = "lighttpd"
 server.groupname            = "lighttpd"
 server.port                 = 80
-accesslog.filename			= "/var/log/lighttpd/access.log"
-accesslog.format			= "%{%s}t|%V|%r|%s|%b"
+accesslog.filename          = "/var/log/lighttpd/access.log"
+accesslog.format            = "%{%s}t|%V|%r|%s|%b"
 
 
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
5

---

I copied the text block from `01-pihole.conf` to the `lighttpd.conf.*` files to warn users that manual changes to these files will be overwritten.

Also made some slight cosmetic adjustments (tabs -> spaces) to these files.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
