### PR TITLE
redirect pi.hole to pi.hole/admin

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -70,5 +70,10 @@ $HTTP["url"] =~ "^(?!/admin)/.*" {
     setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
 }
 
+$HTTP["host"] =~ "pi.hole$" {
+    setenv.add-response-header = ( "X-Pi-hole" => "Redirecting pi.hole to /admin." )
+    url.rewrite = ( "^(.*)" => "/admin$1" )
+}
+
 # Add user chosen options held in external file
 include_shell "cat external.conf 2>/dev/null"

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -87,5 +87,10 @@ $HTTP["url"] =~ "^(?!/admin)/.*" {
 	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
 }
 
+$HTTP["host"] =~ "pi.hole$" {
+    setenv.add-response-header = ( "X-Pi-hole" => "Redirecting pi.hole to /admin." )
+    url.rewrite = ( "^(.*)" => "/admin$1" )
+}
+
 # Add user chosen options held in external file
 include_shell "cat external.conf 2>/dev/null"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

8
---
Implementing [a feature request from Discourse](https://discourse.pi-hole.net/t/redirect-pi-hole-to-pi-hole-admin/1419): Redirect `pi.hole` to `pi.hole/admin` instead of sending the user to the block page. 


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
