### PR TITLE
Revert "redirect pi.hole to pi.hole/admin"

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -70,10 +70,5 @@ $HTTP["url"] =~ "^(?!/admin)/.*" {
     setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
 }
 
-$HTTP["host"] =~ "pi.hole$" {
-    setenv.add-response-header = ( "X-Pi-hole" => "Redirecting pi.hole to /admin." )
-    url.rewrite = ( "^(.*)" => "/admin$1" )
-}
-
 # Add user chosen options held in external file
 include_shell "cat external.conf 2>/dev/null"

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -87,10 +87,5 @@ $HTTP["url"] =~ "^(?!/admin)/.*" {
 	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
 }
 
-$HTTP["host"] =~ "pi.hole$" {
-    setenv.add-response-header = ( "X-Pi-hole" => "Redirecting pi.hole to /admin." )
-    url.rewrite = ( "^(.*)" => "/admin$1" )
-}
-
 # Add user chosen options held in external file
 include_shell "cat external.conf 2>/dev/null"


### PR DESCRIPTION
Reverts pi-hole/pi-hole#1241

`http://pi.hole` redirects to `/admin`, however navigating to `/admin` causes the block page to show up.

Have been playing around with the `$HTTP["host"]` rule, but not getting anything solid...