### PR TITLE
Redirect pi.hole to pi.hole/admin/

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -73,7 +73,6 @@ $HTTP["url"] =~ "^(?!/admin)/.*" {
 # Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
 $HTTP["host"] == "pi.hole" {
     $HTTP["url"] == "/" {
-        setenv.add-response-header = ( "X-Pi-hole" => "Redirecting pi.hole to /admin/." )
         url.redirect = ( "" => "/admin/" )
     }
 }

--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -70,5 +70,13 @@ $HTTP["url"] =~ "^(?!/admin)/.*" {
     setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
 }
 
+# Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
+$HTTP["host"] == "pi.hole" {
+    $HTTP["url"] == "/" {
+        setenv.add-response-header = ( "X-Pi-hole" => "Redirecting pi.hole to /admin/." )
+        url.redirect = ( "" => "/admin/" )
+    }
+}
+
 # Add user chosen options held in external file
 include_shell "cat external.conf 2>/dev/null"

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -90,7 +90,6 @@ $HTTP["url"] =~ "^(?!/admin)/.*" {
 # Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
 $HTTP["host"] == "pi.hole" {
     $HTTP["url"] == "/" {
-        setenv.add-response-header = ( "X-Pi-hole" => "Redirecting pi.hole to /admin/." )
         url.redirect = ( "" => "/admin/" )
     }
 }

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -87,5 +87,13 @@ $HTTP["url"] =~ "^(?!/admin)/.*" {
 	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
 }
 
+# Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
+$HTTP["host"] == "pi.hole" {
+    $HTTP["url"] == "/" {
+        setenv.add-response-header = ( "X-Pi-hole" => "Redirecting pi.hole to /admin/." )
+        url.redirect = ( "" => "/admin/" )
+    }
+}
+
 # Add user chosen options held in external file
 include_shell "cat external.conf 2>/dev/null"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 5

---
Navigating to "pi.hole" redirects to the admin interface. (See pull request #1241)

I currently use this configuration in my setup and tested it with Firefox 51.0.1 and Internet Explorer 11. Output of `curl -v pi.hole`:
```
* Rebuilt URL to: pi.hole/
[...]
* Connected to pi.hole (192.168.1.2) port 80 (#0)
> GET / HTTP/1.1
> User-Agent: curl/7.34.0
> Host: pi.hole
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Location: /admin/
< Content-Length: 0
< Date: Tue, 21 Feb 2017 19:49:29 GMT
* Server lighttpd/1.4.35 is not blacklisted
< Server: lighttpd/1.4.35
<
* Connection #0 to host pi.hole left intact
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
