### PR TITLE
Don't save `interface=` line to `dnsmasq`s config file

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -32,8 +32,6 @@ no-resolv
 server=@DNS1@
 server=@DNS2@
 
-interface=@INT@
-
 cache-size=10000
 
 log-queries

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -608,7 +608,6 @@ version_check_dnsmasq() {
   echo -n ":::    Copying 01-pihole.conf to /etc/dnsmasq.d/01-pihole.conf..."
   cp ${dnsmasq_pihole_01_snippet} ${dnsmasq_pihole_01_location}
   echo " done."
-  sed -i "s/@INT@/$PIHOLE_INTERFACE/" ${dnsmasq_pihole_01_location}
   if [[ "${PIHOLE_DNS_1}" != "" ]]; then
     sed -i "s/@DNS1@/$PIHOLE_DNS_1/" ${dnsmasq_pihole_01_location}
   else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Remove `interface=...` line from `01-pihole.conf`.
This will resolve a number of headaches when running Pi-hole together with VPN (you will want to have Pi-hole serve both `tun0` and `eth0` then) among others.

New behavior is to listen on all interfaces that are `UP`.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
