### PR TITLE
Bugfix: Delete INSTALL_WEB line before adding new one

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -964,7 +964,7 @@ finalExports() {
 
   # Update variables in setupVars.conf file
   if [ -e "${setupVars}" ]; then
-    sed -i.update.bak '/PIHOLE_INTERFACE/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;/QUERY_LOGGING/d;' "${setupVars}"
+    sed -i.update.bak '/PIHOLE_INTERFACE/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;/QUERY_LOGGING/d;/INSTALL_WEB/d;' "${setupVars}"
   fi
     {
   echo "PIHOLE_INTERFACE=${PIHOLE_INTERFACE}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

As reported in https://github.com/pi-hole/FTL/issues/1#issuecomment-282445723, the installer adds another `INSTALL_WEB=...` line during each and every `pihole -r` run, instead of deleting and re-adding the line (i.e. updating it). This misbehavior is fixed by this small PR.

Before:
```
INSTALL_WEB=true
INSTALL_WEB=true
INSTALL_WEB=true
INSTALL_WEB=true
PIHOLE_INTERFACE=eth0
```

Now:
```
PIHOLE_INTERFACE=eth0
INSTALL_WEB=true
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
