### PR TITLE
Add local-service to dnsmasq's configuration template

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -40,3 +40,5 @@ log-facility=/var/log/pihole.log
 local-ttl=300
 
 log-async
+
+local-service


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Add `local-service` to `dnsmasq`'s configuration template

From `dnsmasq`'s `man` page:

> Accept DNS queries only from hosts whose address is on a local subnet, i.e. a subnet for which an interface exists on the server. This option only has effect if there are no `interface` `except-interface`, `listen-address` or `auth-server` options.

> It is intended to be set as a default on installation, to allow unconfigured installations to be useful but also safe from being used for DNS amplification attacks.

Now that we listen on all devices for easing the setup in combination with local networking and distant networking (via OpenVPN) ( #1273 ), this option should prevent opening security holes on VPS (or similar) setups which lack a proper firewall setup.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
