### PR TITLE
Test for dpkg lock before using apt-get

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -59,8 +59,8 @@ distro_check() {
 if command -v apt-get &> /dev/null; then
   #Debian Family
   #############################################
-  PKG_MANAGER="test_dpkg_lock; apt-get"
-  UPDATE_PKG_CACHE="${PKG_MANAGER} update"
+  PKG_MANAGER="apt-get"
+  UPDATE_PKG_CACHE="test_dpkg_lock; ${PKG_MANAGER} update"
   PKG_INSTALL=(${PKG_MANAGER} --yes --no-install-recommends install)
   # grep -c will return 1 retVal on 0 matches, block this throwing the set -e with an OR TRUE
   PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
@@ -799,6 +799,7 @@ install_dependent_packages() {
       fi
     done
     if [[ ${#installArray[@]} -gt 0 ]]; then
+      test_dpkg_lock
       debconf-apt-progress -- "${PKG_INSTALL[@]}" "${installArray[@]}"
       return
     fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -90,27 +90,12 @@ if command -v apt-get &> /dev/null; then
   test_dpkg_lock() {
     i=0
     while fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
-      echo -en "\r::: Waiting for package manager to finish"
-      j=0
-      while [ $j -lt 6 ]; do
-        if [ $j -lt $i ]; then
-          echo -n "."
-        else
-          echo -n " "
-        fi
-        ((j=j+1))
-      done
       sleep 0.5
-      if [ $i -lt 6 ]; then
-        ((i=i+1))
-      else
-        i=0
-      fi
+      ((i=i+1))
     done
-    # Add final newline only if we entered the loop at least once
-    if [ $j -gt 0 ]; then
-      echo ""
-    fi
+    # Always return success, since we only return if there is no
+    # lock (anymore)
+    return 0
   }
 
 elif command -v rpm &> /dev/null; then
@@ -764,7 +749,7 @@ update_package_cache() {
 
   echo ":::"
   echo -n "::: Updating local cache of available packages..."
-  if eval ${UPDATE_PKG_CACHE} &> /dev/null; then
+  if eval "${UPDATE_PKG_CACHE}" &> /dev/null; then
     echo " done!"
   else
     echo -n "\n!!! ERROR - Unable to update package cache. Please try \"${UPDATE_PKG_CACHE}\""


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

This will solve a number of issues for people seeing the package installer crashing. Basically, this change will ensure to check that the package manager can actually be run before trying to update e.g. the package lists and/or install packages.

This kind of problems can e.g. be seen on fresh installed virtual machines. They commonly run `unattended-upgrade` at the first boot to get all security updates. Depending on the resources, this can take several minutes within which the Pi-hole installer crashes with no obvious reason. This PR solves this problem as the installer will always wait until it is safe to use the package manager
```
root@vultr:~# cd /etc/.pihole
root@vultr:/etc/.pihole# git checkout tweak/dpkg_lock 
Branch tweak/dpkg_lock set up to track remote branch tweak/dpkg_lock from origin.
Switched to a new branch 'tweak/dpkg_lock'
root@vultr:/etc/.pihole# ./automated\ install/basic-install.sh
:::
::: You are root.
::: Verifying free disk space...
:::
::: Updating local cache of available packages...
```
and continues only afterwards.

Note that this implementation is Debian specific, an there is no implementation for Fedora based systems so far (I don't even know if `dnf` uses a lock as well).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
