### PR TITLE
Fix default listening behavior of dnsmasq

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -32,6 +32,8 @@ no-resolv
 server=@DNS1@
 server=@DNS2@
 
+interface=@INT@
+
 cache-size=10000
 
 log-queries

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -144,15 +144,13 @@ trust-anchor=.,19036,8,2,49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE3
 
 	if [[ "${DNSMASQ_LISTENING}" == "all" ]]; then
 		# Listen on all interfaces, permit all origins
-		# Leave a comment in 01-pihole.conf
-		add_dnsmasq_setting "# Listening on all interfaces"
 		add_dnsmasq_setting "except-interface" "nonexisting"
-	elif [[ "${DNSMASQ_LISTENING}" == "single" ]]; then
-		# Listen only on one interface
-		add_dnsmasq_setting "interface" "${PIHOLE_INTERFACE}"
-	else
+	elif [[ "${DNSMASQ_LISTENING}" == "local" ]]; then
 		# Listen only on all interfaces, but only local subnets
 		add_dnsmasq_setting "local-service"
+	else
+		# Listen only on one interface
+		add_dnsmasq_setting "interface" "${PIHOLE_INTERFACE}"
 	fi
 
 }
@@ -394,12 +392,12 @@ SetListeningMode(){
 	if [[ "${args[2]}" == "all" ]] ; then
 		echo "Listening on all interfaces, permiting all origins, hope you have a firewall!"
 		change_setting "DNSMASQ_LISTENING" "all"
-	elif [[ "${args[2]}" == "single" ]] ; then
-		echo "Listening only on interface ${PIHOLE_INTERFACE}"
-		change_setting "DNSMASQ_LISTENING" "single"
-	else
+	elif [[ "${args[2]}" == "local" ]] ; then
 		echo "Listening on all interfaces, permitting only origins that are at most one hop away (local devices)"
 		change_setting "DNSMASQ_LISTENING" "local"
+	else
+		echo "Listening only on interface ${PIHOLE_INTERFACE}"
+		change_setting "DNSMASQ_LISTENING" "single"
 	fi
 
 	# Don't restart DNS server yet because other settings

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -608,6 +608,7 @@ version_check_dnsmasq() {
   echo -n ":::    Copying 01-pihole.conf to /etc/dnsmasq.d/01-pihole.conf..."
   cp ${dnsmasq_pihole_01_snippet} ${dnsmasq_pihole_01_location}
   echo " done."
+  sed -i "s/@INT@/$PIHOLE_INTERFACE/" ${dnsmasq_pihole_01_location}
   if [[ "${PIHOLE_DNS_1}" != "" ]]; then
     sed -i "s/@DNS1@/$PIHOLE_DNS_1/" ${dnsmasq_pihole_01_location}
   else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

**Pulling against master**

Default behavior is old behavior (listen on gravity interface (e.g. `eth0`), permit all origins)

Raspbian ships `dnsmasq` `v2.72` which is problematic. Tested with `v2.76` and didn't see any problems.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
