### PR TITLE
Redirect to admin panel when accessing 'http://pi.hole/'

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -8,7 +8,7 @@ $serverName = escapeshellcmd($_SERVER['SERVER_NAME']);
 // Let's be nice and redirect them.
 if ($serverName === 'pi.hole')
 {
-    header('HTTP/1.1 302 Found');
+    header('HTTP/1.1 301 Moved Permanently');
     header("Location: /admin/");
 }
 

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -4,6 +4,14 @@
 $uri = escapeshellcmd($_SERVER['REQUEST_URI']);
 $serverName = escapeshellcmd($_SERVER['SERVER_NAME']);
 
+// If the server name is 'pi.hole', it's likely a user trying to get to the admin panel.
+// Let's be nice and redirect them.
+if ($serverName === 'pi.hole')
+{
+    header('HTTP/1.1 302 Found');
+    header("Location: /admin/");
+}
+
 // Retrieve server URI extension (EG: jpg, exe, php)
 $uriExt = pathinfo($uri, PATHINFO_EXTENSION);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

2

---
If someone tries to access 'http://pi.hole/', it will take them to the "Website blocked" page. Very confusing if you don't know to go to 'http://pi.hole/admin/'. This just redirects them to the admin panel.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
