### PR TITLE
Fix handling of wildcard help text

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -40,13 +40,8 @@ helpFunc() {
 Example: 'pihole -${param} site.com', or 'pihole -${param} site1.com site2.com'
 ${type^}list one or more domains
 
-Options:"
-
-  if [[ "${listMain}" == "${wildcardlist}" ]]; then
-    echo "  -wild, --wildcard   Block all subdomains of specified domain"
-  fi
-
-echo "  -d, --delmode       Remove domain(s) from the ${type}list
+Options:
+  -d, --delmode       Remove domain(s) from the ${type}list
   -nr, --noreload     Update ${type}list without refreshing dnsmasq
   -q, --quiet         Make output less verbose
   -h, --help          Show this help dialog

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -31,13 +31,16 @@ helpFunc() {
     if [[ ${listMain} == ${whitelist} ]]; then
         letter="w"
         word="white"
+    elif [[ ${listMain} == ${wildcardlist} ]]; then
+        letter="wild"
+        word="wildcard"
     else
         letter="b"
         word="black"
     fi
 
 	cat << EOM
-::: Immediately ${word}lists one or more domains in the hosts file
+::: Immediately add one or more domains to the ${word}list
 :::
 ::: Usage: pihole -${letter} domain1 [domain2 ...]
 :::
@@ -48,7 +51,7 @@ helpFunc() {
 :::  -h, --help               Show this help dialog
 :::  -l, --list               Display your ${word}listed domains
 EOM
-if [[ "${letter}" == "b" ]]; then
+if [[ "${letter}" == "-wild" ]]; then
 	echo ":::  -wild, --wildcard        Add wildcard entry (only blacklist)"
 fi
 	exit 0

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -49,9 +49,9 @@ helpFunc() {
 :::  -nr, --noreload          Update ${word}list without refreshing dnsmasq
 :::  -q, --quiet              Output is less verbose
 :::  -h, --help               Show this help dialog
-:::  -l, --list               Display your ${word}listed domains
+:::  -l, --list               Display domains on the ${word}list
 EOM
-if [[ "${letter}" == "-wild" ]]; then
+if [[ "${letter}" == "wild" ]]; then
 	echo ":::  -wild, --wildcard        Add wildcard entry (only blacklist)"
 fi
 	exit 0

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -29,20 +29,20 @@ listAlt=""
 helpFunc() {
 
     if [[ ${listMain} == ${whitelist} ]]; then
-        letter="w"
+        param="w"
         word="white"
     elif [[ ${listMain} == ${wildcardlist} ]]; then
-        letter="wild"
+        param="wild"
         word="wildcard"
     else
-        letter="b"
+        param="b"
         word="black"
     fi
 
 	cat << EOM
 ::: Immediately add one or more domains to the ${word}list
 :::
-::: Usage: pihole -${letter} domain1 [domain2 ...]
+::: Usage: pihole -${param} domain1 [domain2 ...]
 :::
 ::: Options:
 :::  -d, --delmode            Remove domains from the ${word}list
@@ -51,7 +51,7 @@ helpFunc() {
 :::  -h, --help               Show this help dialog
 :::  -l, --list               Display domains on the ${word}list
 EOM
-if [[ "${letter}" == "wild" ]]; then
+if [[ "${param}" == "wild" ]]; then
 	echo ":::  -wild, --wildcard        Add wildcard entry (only blacklist)"
 fi
 	exit 0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_4_

---
Fixed handling of the "-wild" parameter for the list, rewrote help texts to handle word properly.
Fixes #1304 

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
