### PR TITLE
Use Firewalld --add-service instead of port

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -965,7 +965,7 @@ configureFirewall() {
     whiptail --title "Firewall in use" --yesno "We have detected a running firewall\n\nPi-hole currently requires HTTP and DNS port access.\n\n\n\nInstall Pi-hole default firewall rules?" ${r} ${c} || \
     { echo -e ":::\n::: Not installing firewall rulesets."; return 0; }
     echo -e ":::\n:::\n Configuring FirewallD for httpd and dnsmasq."
-    firewall-cmd --permanent --add-port=80/tcp --add-port=53/tcp --add-port=53/udp
+    firewall-cmd --permanent --add-service={http,dns}
     firewall-cmd --reload
     return 0
   # Check for proper kernel modules to prevent failure

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -965,7 +965,7 @@ configureFirewall() {
     whiptail --title "Firewall in use" --yesno "We have detected a running firewall\n\nPi-hole currently requires HTTP and DNS port access.\n\n\n\nInstall Pi-hole default firewall rules?" ${r} ${c} || \
     { echo -e ":::\n::: Not installing firewall rulesets."; return 0; }
     echo -e ":::\n:::\n Configuring FirewallD for httpd and dnsmasq."
-    firewall-cmd --permanent --add-service={http,dns}
+    firewall-cmd --permanent --add-service=http --add-service=dns
     firewall-cmd --reload
     return 0
   # Check for proper kernel modules to prevent failure

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -78,7 +78,7 @@ def test_configureFirewall_firewalld_running_no_errors(Pihole):
     assert expected_stdout in configureFirewall.stdout
     firewall_calls = Pihole.run('cat /var/log/firewall-cmd').stdout
     assert 'firewall-cmd --state' in firewall_calls
-    assert 'firewall-cmd --permanent --add-port=80/tcp --add-port=53/tcp --add-port=53/udp' in firewall_calls
+    assert 'firewall-cmd --permanent --add-service=http --add-service=dns' in firewall_calls
     assert 'firewall-cmd --reload' in firewall_calls
 
 def test_configureFirewall_firewalld_disabled_no_errors(Pihole):


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

6

---
Hi, Firewalld offers the use of services instead of adding straight ports. It's much more cleaner and more verbose to see "http" and "dns" as allowed rather than port numbers. Port numbers, especially 53 require the user to know it's dns - which is ambiguous for novices.

In any case, if it's an aesthetic choice to use numbers, that's fine. At the very least, I can do a new PR using brace expansion for numbers, as I have here. Rather than duplicating add-port twice.

Cheers

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
