### PR TITLE
updated log rotate to be able to forward logs

### DIFF
--- a/advanced/logrotate
+++ b/advanced/logrotate
@@ -1,10 +1,40 @@
 /var/log/pihole.log {
-	# su #
-	daily
-	copytruncate
-	rotate 5
-	compress
-	delaycompress
-	notifempty
-	nomail
+    # Rotate the log files daily
+    daily
+
+    # Don't return an error if the log file is missing
+    missingok
+
+    # Do not rotate if the log file is empty
+    notifempty
+
+    # Rotate the log file twice before deleting it
+    rotate 2
+
+    # Compress the log file using gzip
+    compress
+
+    # Delays compression when some program cannot be told to immediately close it's logfile
+    delaycompress
+
+    # Include the date in the rotated log file's name
+    dateext
+
+    # The postrotate script will only be run once (after the old
+    #   logs  have  been  compressed), not once for each log which is rotated.
+    sharedscripts
+
+    # The  lines  between 'postrotate' and 'endscript' are executed after the log is rotated
+    postrotate
+        # If dnsmasq is running, kill it using the user defined signal
+        #[ ! -f /var/run/dnsmasq/dnsmasq.pid ] || kill -USR2 cat /var/run/dnsmasq/dnsmasq.pid
+    	# use pihole restart function
+	/usr/local/bin/pihole restartdns
+    endscript
+
+    # Rotate the original file and create the new file with specified permission, user, and group
+    create 0644 dnsmasq root
+    
+    #send no email
+    nomail
 }


### PR DESCRIPTION

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

5
---
If you use rsyslog - at least on Jessie PI to forward the logfile to some central location rsyslog does not notice the updated logfile. 

After I had added the restart to the post rotate this is working with no issue. As I did not test if this is working on other type of installation that might only be save for a pi based installation.