### PR TITLE
Formatting cleanup.

### DIFF
--- a/pihole
+++ b/pihole
@@ -287,10 +287,10 @@ piholeCheckoutFunc() {
 
 helpFunc() {
 	cat << EOM
-::: Control all PiHole specific functions!
+::: Control all Pi-hole specific functions
 :::
 ::: Usage: pihole [options]
-:::		Add -h after -w (whitelist), -b (blacklist), -c (chronometer), or -a (admin)  for more information on usage
+:::		Add -h after -w (whitelist), -b (blacklist), -c (chronometer), or -a (admin) for more information on usage
 :::
 ::: Options:
 :::  -w, whitelist            Whitelist domain(s)
@@ -306,15 +306,15 @@ helpFunc() {
 :::  -g, updateGravity        Update the list of ad-serving domains
 :::  -c, chronometer          Calculates stats and displays to an LCD
 :::  -h, help                 Show this help dialog
-:::  -v, version              Show installed versions of Pi-Hole and Web-Admin
+:::  -v, version              Show installed versions of Pi-hole and Web-Admin
 :::  -q, query                Query the adlists for a specific domain
 :::                             'pihole -q domain -exact' shows exact matches only
 :::  -l, logging              Enable or Disable logging (pass 'on' or 'off')
 :::  -a, admin                Admin webpage options
-:::  uninstall                Uninstall Pi-Hole from your system :(!
-:::  status                   Is Pi-Hole Enabled or Disabled
-:::  enable                   Enable Pi-Hole DNS Blocking
-:::  disable                  Disable Pi-Hole DNS Blocking
+:::  uninstall                Uninstall Pi-hole from your system! :(
+:::  status                   Display if Pi-hole is Enabled or Disabled
+:::  enable                   Enable Pi-hole DNS Blocking
+:::  disable                  Disable Pi-hole DNS Blocking
 :::                             Blocking can also be disabled only temporarily, e.g.,
 :::                             'pihole disable 5m' - will disable blocking for 5 minutes
 :::  restartdns               Restart dnsmasq


### PR DESCRIPTION
Convert backticks to quotes to fix error message.
Make Pi-hole capitalization consistent.

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
2

---
When running "pihole", the following error message is produced:
/usr/local/bin/pihole: line 289: -a: command not found
This is due to the presence of backticks (`) in the help text.

There is also inconsistent spelling and capitalization of "Pi-hole" in the help text.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
