### PR TITLE
Source setupVars in the updater before attempting to use it

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -90,6 +90,7 @@ FTLcheckUpdate() {
 main() {
   local pihole_version_current
   local web_version_current
+  source "${setupVars}"
 
   #This is unlikely
   if ! is_repo "${PI_HOLE_FILES_DIR}" ; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Fixes #1347
The `setupVars` variable exists from when the installer is sourced at the top of the file.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
