### PR TITLE
Flush twice to move data out-of-sight of FTL

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -3,18 +3,22 @@
 # (c) 2017 Pi-hole, LLC (https://pi-hole.net)
 # Network-wide ad blocking via your own hardware.
 #
-# Flushes /var/log/pihole.log
+# Flushes Pi-hole's log file
 #
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
-
-
 echo -n "::: Flushing /var/log/pihole.log ..."
 # Test if logrotate is available on this system
 if command -v /usr/sbin/logrotate &> /dev/null; then
+  # Flush twice to move all data out of sight of FTL
+  /usr/sbin/logrotate --force /etc/pihole/logrotate
   /usr/sbin/logrotate --force /etc/pihole/logrotate
 else
+  # Flush both pihole.log and pihole.log.1 (if existing)
   echo " " > /var/log/pihole.log
+  if [ -f /var/log/pihole.log.1 ]; then
+    echo " " > /var/log/pihole.log.1
+  fi
 fi
 echo "... done!"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

Fixes issue reported on [Discourse](https://discourse.pi-hole.net/t/logs-are-not-flushing-correctly/2615/5)

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
