### PR TITLE
Add localise-queries flag to dnsmasq's config

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -25,6 +25,8 @@ addn-hosts=/etc/pihole/local.list
 
 domain-needed
 
+localise-queries
+
 bogus-priv
 
 no-resolv


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:** 10

---

This PR is building on top of the discussion in #1407 

We add the flag `localise-queries` to `01-pihole.conf`

From the `man` page:
> --localise-queries
> Return answers to DNS queries from /etc/hosts which depend on the interface over which the query was received. If a name in /etc/hosts has more than one address associated with it, and at least one of those addresses is on the same subnet as the interface to which the query was sent, then return only the address(es) on that subnet. This allows for a server to have multiple addresses in /etc/hosts corresponding to each of its interfaces, and hosts will get the correct address based on which network they are attached to. Currently this facility is limited to IPv4.


This option is available since (at least) `dnsmasq v2.60`.


The result **without** this flag on two different machines (the first one is running `dnsmasq` locally):
```
pi@raspberrypi ~ $ dig +noall +answer raspberrypi
raspberrypi.            300     IN      A       192.168.2.10
raspberrypi.            300     IN      A       127.0.1.1

me@desktop ~ $ dig +noall +answer raspberrypi
raspberrypi.		300	IN	A	127.0.1.1
raspberrypi.		300	IN	A	192.168.2.10
```

And **with** this flag:
```
pi@raspberrypi ~ $ dig +noall +answer raspberrypi
raspberrypi.            300     IN      A       127.0.1.1

me@desktop ~ $ dig +noall +answer raspberrypi
raspberrypi.		300	IN	A	192.168.2.10
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
