### PR TITLE
Block Page 2.0

### DIFF
--- a/advanced/blockingpage.css
+++ b/advanced/blockingpage.css
@@ -1,136 +1,383 @@
-/* CSS Reset */
-html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video { margin: 0; padding: 0; border: 0; font-size: 100%; font: inherit; vertical-align: baseline; }
-article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section { display: block; }
-body { line-height: 1; }
-ol, ul { list-style: none; }
-blockquote, q { quotes: none; }
-blockquote:before, blockquote:after, q:before, q:after { content: ''; content: none; }
-table { border-collapse: collapse; border-spacing: 0; }
-html { height: 100%; overflow-x: hidden; }
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
 
-/* General Style */
-a	{ color: rgba(0,60,120,0.95); text-decoration: none; } /* 1E3C5A */
-a:hover { color: rgba(210,120,0,0.95); transition-duration: .2s; } /* 255, 128, 0 */
-divs a		{ border-bottom: 1px dashed rgba(30,60,90,0.3); }
-b	{ font-weight: bold; }
-i	{ font-style: italic; }
+/* Text Customisation Options ======> */
+.title:before { content: "Website Blocked"; }
+.altBtn:before { content: "Why am I here?"; }
+.linkPH:before { content: "About Pi-hole"; }
+.linkEmail:before { content: "Contact Admin"; }
 
-footer, pre, td { font-family: monospace; padding-left: 15px; }
-/*body, header { background: #E1E1E1; }*/
+#bpOutput:before { content: "Info"; }
+.error:before, .exception:before { content: "Error" !important; }
+.success:before { content: "Success" !important; }
+
+.add:after { content: "The domain is being whitelisted..."; }
+.exception:after { content: "An unhandled exception occured. This may happen when your browser is unable to load jQuery, or when the webserver is denying access to the Pi-hole API."; }
+.success:after { content: "Website has been whitelisted! You may need to flush your DNS cache"; }
+
+.recentwl:after { content: "This site appears to have been recently whitelisted. Please flush your DNS cache and/or restart your browser."; }
+.cname:before { content: "This site is an alias for "; } /* <a href="http://cname.com">cname.com</a> */
+.cname:after { content: ", which may be blocked by Pi-hole."; }
+
+.blacklist:before { content: "Manually Blacklisted"; }
+.wildcard:before { content: "Manually Blacklisted by Wildcard"; }
+.noblock:before { content: "Not found on any Blacklist"; }
+
+#bpBlock:before { content: "Access to the following website has been denied:"; }
+#bpFlag:before { content: "This is primarily due to being flagged as:"; }
+
+#bpHelpTxt:before { content: "If you have an ongoing use for this website, please "; }
+#bpHelpTxt a:before, #bpHelpTxt span:before { content: "ask the administrator"; }
+#bpHelpTxt:after{ content: " of the Pi-hole on this network to have it whitelisted"; }
+
+#bpBack:before { content: "Back to safety"; }
+#bpInfo:before { content: "Technical Info"; }
+#bpFoundIn:before { content: "This site is found in "; }
+#bpFoundIn span:after { content: " of "; }
+#bpFoundIn:after { content: " lists:"; }
+#bpWhitelist:before { content: "Whitelist"; }
+
+footer span:before { content: "Page generated on "; }
+/* Text Customisation Options <=============================== */
+
+/* Hide whitelisting form entirely */
+/* #bpWLButtons { display: none; } */
+
+/* http://necolas.github.io/normalize.css ======> */
+html { font-family: sans-serif; line-height: 1.15; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; }
+body { margin: 0; }
+article, aside, footer, header, nav, section { display: block; }
+h1 { font-size: 2em; margin: 0.67em 0; }
+figcaption, figure, main { display: block; }
+figure { margin: 1em 40px; }
+hr { box-sizing: content-box; height: 0; overflow: visible; }
+pre { font-family: monospace, monospace; font-size: 1em; }
+a { background-color: transparent; -webkit-text-decoration-skip: objects; }
+a:active, a:hover { outline-width: 0; }
+abbr[title] { border-bottom: none; text-decoration: underline; text-decoration: underline dotted; }
+b, strong { font-weight: inherit; }
+b, strong { font-weight: bolder; }
+code, kbd, samp { font-family: monospace, monospace; font-size: 1em; }
+dfn { font-style: italic; }
+mark { background-color: #ff0; color: #000; }
+small { font-size: 80%; }
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
+sub { bottom: -0.25em; }
+sup { top: -0.5em; }
+audio, video { display: inline-block; }
+audio:not([controls]) { display: none; height: 0; }
+img { border-style: none; }
+svg:not(:root) { overflow: hidden; }
+button, input, optgroup, select, textarea { font-family: sans-serif; font-size: 100%; line-height: 1.15; margin: 0; }
+button, input { overflow: visible; }
+button, select { text-transform: none; }
+button, html [type="button"], [type="reset"], [type="submit"] { -webkit-appearance: button; }
+button::-moz-focus-inner, [type="button"]::-moz-focus-inner, [type="reset"]::-moz-focus-inner, [type="submit"]::-moz-focus-inner { border-style: none; padding: 0; }
+button:-moz-focusring, [type="button"]:-moz-focusring, [type="reset"]:-moz-focusring, [type="submit"]:-moz-focusring { outline: 1px dotted ButtonText; }
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
+legend { box-sizing: border-box; color: inherit; display: table; max-width: 100%; padding: 0; white-space: normal; }
+progress { display: inline-block; vertical-align: baseline; }
+textarea { overflow: auto; }
+[type="checkbox"], [type="radio"] { box-sizing: border-box; padding: 0; }
+[type="number"]::-webkit-inner-spin-button, [type="number"]::-webkit-outer-spin-button { height: auto; }
+[type="search"] { -webkit-appearance: textfield; outline-offset: -2px; }
+[type="search"]::-webkit-search-cancel-button, [type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
+::-webkit-file-upload-button { -webkit-appearance: button; font: inherit; }
+details, menu { display: block; }
+summary { display: list-item; }
+canvas { display: inline-block; }
+template { display: none; }
+[hidden] { display: none; }
+/* Normalize.css <=============================== */
+
+html { font-size: 62.5%; }
+
+a { color: #3c8dbc; text-decoration: none; }
+a:hover { color: #72afda; text-decoration: underline; }
+b { color: rgb(68,68,68); }
+p { margin: 0; }
+
+label, .buttons a {
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/* Touch device dark tap highlight */
+header h1 a, label, .buttons * { -webkit-tap-highlight-color: transparent; } 
+
+/* Webkit Focus Glow */
+textarea, input, button { outline: none; }
+
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: local("Source Sans Pro"), local("SourceSansPro-Regular"), url("/admin/style/vendor/SourceSansPro/SourceSansPro-Regular.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "Source Sans Pro";
+  font-style: normal;
+  font-weight: 700;
+  src: local("Source Sans Pro Bold"), local("SourceSansPro-Bold"), url("/admin/style/vendor/SourceSansPro/SourceSansPro-Bold.ttf") format("truetype");
+}
 
 body {
-	background-image: -webkit-linear-gradient(top, rgba(240,240,240,0.95), rgba(190,190,190,0.95));
-	background-image: linear-gradient(to bottom, rgba(240,240,240,0.95), rgba(190,190,190,0.95));
-	background-attachment: fixed;
-	color: rgba(64,64,64,0.95);
-	font: 14px, sans-serif;
-	line-height: 1em;
+  background: #dbdbdb url("/admin/img/boxed-bg.jpg") repeat fixed;
+  color: #333;
+  font: 1.4rem "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 2.2rem;
+}
+
+/* User is greeted with a splash page when browsing to Pi-hole IP address */
+#splashpage { background: #222; color: rgba(255,255,255,0.7); text-align: center; }
+#splashpage img { margin: 5px; width: 256px; }
+#splashpage b { color: inherit; }
+
+#bpWrapper {
+  margin: 0 auto;
+  max-width: 1250px;
+  box-shadow: 0 0 8px rgba(0,0,0,0.5);
+}
+
+@media only screen and (min-width: 1251px) {
+  #bpWrapper, footer { border-radius: 0 0 5px 5px; }
+  #bpAbout { border-right-width: 1px !important; }
 }
 
 header {
-	min-width: 320px;
-	width: 100%;
-	text-shadow: 0 1px rgba(255,255,255,0.6);
-	display: table;
-	table-layout: fixed;
-	border: 1px solid rgba(0,0,0,0.25);
-	border-top-color: rgba(255,255,255,0.85);
-	border-style: solid none;
-	background-image: -webkit-linear-gradient(top, rgba(240,240,240,0.95), rgba(220,220,220,0.95));
-	background-image: linear-gradient(to bottom, rgba(240,240,240,0.95), rgba(220,220,220,0.95));
-	box-shadow:  0 0 1px 1px rgba(0,0,0,0.04);
+  background: #3c8dbc;
+  display: table;
+  position: relative;
+  width: 100%;
 }
 
-header h1, header div {
-	display: table-cell;
-	color: inherit;
-	font-weight: bold;
-	vertical-align: middle;
-	white-space: nowrap;
-	overflow: hidden;
-	box-sizing: border-box;
+header h1, header h1 a, header .spc, header #bpAlt label {
+  display: table-cell;
+  color: #fff;
+  white-space: nowrap;
+  vertical-align: middle;
+  height: 50px;
 }
 
-header h1 {
-	font-size: 22px;
-	font-weight: bold;
-	width: 100%;
-	padding: 8px 0;
-	text-indent: 32px;
-	background: url("http://pi.hole/admin/img/logo.svg") left no-repeat;
-	background-size: 30px 22px;
+h1 a {
+  background-color: rgba(0,0,0,0.1);
+  font-family: "Helvetica Neue", Helvetica, Arial ,sans-serif;
+  font-size: 2rem;
+  font-weight: normal;
+  min-width: 230px;
+  text-align: center;  
 }
 
-header h1 a, h1 a:hover { color: inherit; }
-header .alt { width: 85px; font-size: 0.8em; padding-right: 4px; text-align: right; line-height: 1.25em; }
-.active { color: green; }
-.inactive { color: red; }
+h1 a:hover, header #bpAlt:hover { background-color: rgba(0,0,0,0.12); color: inherit; text-decoration: none; }
+
+header .spc { width: 100%; }
+
+header #bpAlt label {
+  background: url("/admin/img/logo.svg") no-repeat center left 15px;
+  background-size: 15px 23px;
+  padding: 0 15px;
+  text-indent: 30px; 
+}
+
+[type=checkbox][id$="Toggle"] { display: none; }
+[type=checkbox][id$="Toggle"]:checked ~ #bpAbout,
+[type=checkbox][id$="Toggle"]:checked ~ #bpMoreInfo {
+  display: block; }
+
+/* Click anywhere else on screen to hide #bpAbout */
+#bpAboutToggle:checked {
+  display: block;
+  height: 300px; /* VH Fallback */
+  height: 100vh;
+  left: 0;
+  top: 0;
+  opacity: 0;
+  position: absolute;
+  width: 100%;  
+}
+
+#bpAbout {
+  background: #3c8dbc;
+  border-bottom-left-radius: 5px;
+  border: 1px solid #FFF;
+  border-right-width: 0;
+  box-shadow: -1px 1px 1px rgba(0,0,0,0.12);
+  box-sizing: border-box;
+  display: none;
+  font-size: 1.7rem;
+  top: 50px;
+  position: absolute;
+  right: 0;
+  width: 280px;  
+  z-index: 1;
+}
+
+.aboutPH {
+  box-sizing: border-box;
+  color: rgba(255,255,255,0.8);
+  display: block;
+  padding: 10px;
+  width: 100%;
+  text-align: center;
+}
+
+.aboutImg {
+  background: url("/admin/img/logo.svg") no-repeat center;
+  background-size: 90px 90px;
+  border: 3px solid rgba(255,255,255,0.2);
+  height: 90px;
+  margin: 0 auto;
+  padding: 2px;
+  width: 90px;
+}
+
+.aboutPH p { margin: 10px 0; }
+.aboutPH small { display: block; font-size: 1.2rem; }
+
+.aboutLink { 
+  background: #fff;
+  border-top: 1px solid #ddd;
+  display: table;
+  font-size: 1.4rem;
+  text-align: center;
+  width: 100%;
+}
+
+.aboutLink a {
+  display: table-cell;
+  padding: 14px;
+  min-width: 50%;
+}
 
 main {
-	display: block;
-	width: 80%;
-	padding: 10px;
-	font-size: 1em;
-	background-color: rgba(255,255,255,0.85);
-	margin: 8px auto;
-	box-sizing: border-box;
-	border: 1px solid rgba(0,0,0,0.25);
-	box-shadow:  4px 4px rgba(0,0,0,0.1);
-	line-height: 1.2em;
-	border-radius: 8px;
+  background: #ecf0f5;
+  font-size: 1.65rem;
+  padding: 10px;
 }
 
-h2 { /* Rgba is shared with .transparent th */
-	font: 1.15em sans-serif;
-	background-color: rgba(255,0,0,0.4);
-	text-shadow: none;
-	line-height: 1.1em;
-	padding-bottom: 1px;
-	margin-top: 8px;
-	margin-bottom: 4px;
-	background: -webkit-linear-gradient(left, rgba(0,0,0,0.25), transparent 80%) no-repeat;
-	background: linear-gradient(to right, rgba(0,0,0,0.25), transparent 80%) no-repeat;
-	background-size: 100% 1px;
-	background-position: 0 17px;
+#bpOutput {
+  background: #00c0ef;
+  border-radius: 3px;
+  border: 1px solid rgba(0,0,0,0.1);  
+  color: #fff;
+  font-size: 1.4rem;
+  margin-bottom: 10px;
+  margin-top: 5px;
+  padding: 15px;  
 }
 
-h2:first-child { margin-top: 0; }
-h2 ~ *:not(h2) { margin-left: 4px; }
-li { padding: 2px 0; }
-li::before { content: "\00BB\00a0"; }
-li a { position: relative; top: 1px; } /* Center bullet-point arrows */
-
-/* Button Style */
-.buttons a, button, input, .transparent th a { /* Swapped rgba is shared with input[type='url'] */
-	display: inline-block;
-	color: rgba(32,32,32,0.9);
-	font-weight: bold;
-	text-align: center;
-	cursor: pointer;
-	text-shadow: 0 1px rgba(255,255,255,0.2);
-	line-height: 0.86em;
-	font-size: 1em;
-	padding: 4px 8px;
-	background: #FAFAFA;
-	background-image: -webkit-linear-gradient(top, rgba(255,255,255,0.05), rgba(0,0,0,0.05));
-	background-image: linear-gradient(to bottom, rgba(255,255,255,0.05), rgba(0,0,0,0.05));
-	border: 1px solid rgba(0,0,0,0.25);
-	border-radius: 4px;
-	box-shadow: 0 1px 0 rgba(0,0,0,0.04);
+#bpOutput:before {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='7' height='14' viewBox='0 0 7 14'%3E%3Cpath fill='%23fff' d='M6,11a1.371,1.371,0,0,1,1,1v1a1.371,1.371,0,0,1-1,1H1a1.371,1.371,0,0,1-1-1V12a1.371,1.371,0,0,1,1-1H2V8H1A1.371,1.371,0,0,1,0,7V6A1.371,1.371,0,0,1,1,5H4A1.371,1.371,0,0,1,5,6v5H6ZM3.5,0A1.5,1.5,0,1,1,2,1.5,1.5,1.5,0,0,1,3.5,0Z'/%3E%3C/svg%3E") no-repeat center left;
+  display: block;
+  font-size: 1.8rem;
+  text-indent: 15px;
 }
 
-.buttons { white-space: nowrap; width: 100%; display: table; }
-.buttons33 { white-space: nowrap; width: 33.333%; display: table; text-align: center; margin-left: 33.333% }
-.mini a { width: 50%; }
-a.safe { background-color: rgba(0,220,0,0.5); }
-button.safe { background-color: rgba(0,220,0,0.5); }
-a.warn { background-color: rgba(220,0,0,0.5); }
+#bpOutput.hidden { display: none; }
+#bpOutput.success { background: #00a65a; }
+#bpOutput.error { background: #dd4b39; }
 
-.blocked a, .mini a { display: table-cell; }
-.blocked a.safe50 { width: 50%; background-color: rgba(0,220,0,0.5); }
-.blocked a.safe33 { width: 33.333%; background-color: rgba(0,220,0,0.5); }
+.blockMsg, .flagMsg {
+  font: bold 1.8rem Consolas, Courier, monospace;
+  padding: 5px 10px 10px 10px;
+  text-indent: 15px;
+}
 
-/* Types of text */
-.msg { white-space: pre; overflow: auto; -webkit-overflow-scrolling: touch; display: block; line-height: 1.2em; font-weight: bold; font-size: 1.15em; margin: 4px 8px 8px 8px; white-space: pre-line; }
+#bpHelpTxt { padding-bottom: 10px; }
 
-footer { font-size: 0.8em; text-align: center; width: 87%; margin: 4px auto; }
+.buttons {
+  border-spacing: 5px 0;
+  display: table;
+  width: 100%;
+}
+
+.buttons * {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  border-radius: 3px;
+  border: 1px solid rgba(0,0,0,0.1);
+  box-sizing: content-box;
+  display: table-cell;
+  font-size: 1.65rem;
+  margin-right: 5px;
+  min-height: 20px;
+  padding: 6px 12px;
+  position: relative;
+  text-align: center;
+  vertical-align: top;
+  white-space: nowrap;
+  width: auto;  
+}
+
+#bpButtons * { width: 50%; color: #FFF; }
+#bpBack           { background-color: #00a65a; }
+#bpInfo           { background-color: #3c8dbc;  }
+#bpWhitelist  { background-color: #dd4b39; }
+
+.buttons a { text-decoration: none; }
+
+/* Button hover dark overlay */
+.buttons *:not(input):not([disabled]):hover {
+  background-image: linear-gradient(to bottom, rgba(0,0,0,0.1), rgba(0,0,0,0.1));
+  color: #FFF;
+}
+
+/* Button active shadow inset */
+.buttons *:not([disabled]):not(input):active {
+  box-shadow: inset 0 3px 5px rgba(0,0,0,0.125);
+}
+
+/* Input border colour */
+.buttons *:not([disabled]):hover, .buttons input:focus {
+  border-color: rgba(0,0,0,0.25);
+}
+
+:-ms-input-placeholder { color: rgba(51,51,51,0.8) !important; }
+input[type=password] { font-size: 1.4rem; }
+
+.buttons [type=password][disabled] { color: rgba(0,0,0,1) !important; }
+.buttons [disabled] { color: rgba(0,0,0,0.55) !important; background-color: #e3e3e3 !important; }
+
+@keyframes slidein { from { max-height: 0; opacity: 0; } to { max-height: 300px; opacity: 1; } }
+#bpMoreToggle:checked ~ #bpMoreInfo { display: block; margin-top: 8px; animation: slidein 0.05s linear; }
+#bpMoreInfo { display: none; margin-top: 10px; }
+
+#bpQueryOutput {
+  font-size: 1.2rem;
+  line-height: 1.65rem;
+  margin: 5px 0 0 0;
+  overflow: auto;
+  padding: 0 5px;
+  -webkit-overflow-scrolling: touch;
+}
+
+#bpQueryOutput span { margin-right: 4px; }
+
+#bpWLButtons { width: auto; margin-top: 10px; }
+#bpWLButtons * { display: inline-block; }
+#bpWLDomain { display: none; }
+#bpWLPassword { width: 160px; }
+#bpWhitelist { color: #fff; cursor: pointer; }
+
+footer {
+  background: #fff;
+  border-top: 1px solid #d2d6de;
+  color: #444;
+  font: 1.2rem Consolas, Courier, monospace;
+  padding: 8px;  
+}
+
+/* Responsive small-screen content */
+@media only screen and (max-width: 500px) {
+  h1 a { font-size: 1.8rem; min-width: 170px; }
+  footer span:before { content: "Generated "; }
+  footer span { display: block; }
+}

--- a/advanced/index.js
+++ b/advanced/index.js
@@ -1,1 +1,0 @@
-var x = "Pi-hole: A black hole for Internet advertisements."

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -1,224 +1,331 @@
 <?php
-/* Detailed Pi-hole Block Page: Show "Website Blocked" if user browses to site, but not to image/file requests based on the work of WaLLy3K for DietPi & Pi-Hole */
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
 
-function validIP($address){
-	if (preg_match('/[.:0]/', $address) && !preg_match('/[1-9a-f]/', $address)) {
-		// Test if address contains either `:` or `0` but not 1-9 or a-f
-		return false;
-	}
-	return !filter_var($address, FILTER_VALIDATE_IP) === false;
+// Function to validate server name (Including underscores & IPv6)
+ini_set("pcre.recursion_limit", 1500); 
+function validate_server_name($domain) { // Cr: http://stackoverflow.com/a/4694816
+    if (filter_var($domain, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) return TRUE;
+    return (preg_match("/^([a-z\d]((-|_)*[a-z\d])*)(\.([a-z\d]((-|_)*[a-z\d])*))*$/i", $domain) // Valid chars check
+        && preg_match("/^.{1,253}$/", $domain) // Overall length check
+        && preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domain)); // Length of each label
 }
 
-$uri = escapeshellcmd($_SERVER['REQUEST_URI']);
-$serverName = escapeshellcmd($_SERVER['SERVER_NAME']);
-
-// If the server name is 'pi.hole', it's likely a user trying to get to the admin panel.
-// Let's be nice and redirect them.
-if ($serverName === 'pi.hole')
-{
-    header('HTTP/1.1 301 Moved Permanently');
-    header("Location: /admin/");
+// Validate SERVER_NAME output
+if (validate_server_name($_SERVER["SERVER_NAME"]) === TRUE) {
+    $serverName = $_SERVER["SERVER_NAME"];
+} else {
+    die("[ERROR]: <code>SERVER_NAME</code> header output does not appear to be valid: <code>".$_SERVER["SERVER_NAME"]."</code>");
 }
 
-// Retrieve server URI extension (EG: jpg, exe, php)
-ini_set('pcre.recursion_limit',100);
-$uriExt = pathinfo($uri, PATHINFO_EXTENSION);
-
-// Define which URL extensions get rendered as "Website Blocked"
-$webExt = array('asp', 'htm', 'html', 'php', 'rss', 'xml');
-
-// Get IPv4 and IPv6 addresses from setupVars.conf (if available)
+// Get values from setupVars.conf
 $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
-$ipv4 = isset($setupVars["IPV4_ADDRESS"]) ? explode("/", $setupVars["IPV4_ADDRESS"])[0] : $_SERVER['SERVER_ADDR'];
-$ipv6 = isset($setupVars["IPV6_ADDRESS"]) ? explode("/", $setupVars["IPV6_ADDRESS"])[0] : $_SERVER['SERVER_ADDR'];
+$svFQDN = (!empty($setupVars["FQDN"]) && validate_server_name($setupVars["FQDN"]) === TRUE) ? $setupVars["FQDN"] : "";
+$svPasswd = !empty($setupVars["WEBPASSWORD"]);
+$svEmail = (!empty($setupVars["ADMIN_EMAIL"]) && filter_var($setupVars["ADMIN_EMAIL"], FILTER_VALIDATE_EMAIL)) ? $setupVars["ADMIN_EMAIL"] : "";
+unset($setupVars);
 
-$AUTHORIZED_HOSTNAMES = array(
-	$ipv4,
-	$ipv6,
-	str_replace(array("[","]"), array("",""), $_SERVER["SERVER_ADDR"]),
-	"pi.hole",
-	"localhost");
-// Allow user set virtual hostnames
-$virtual_host = getenv('VIRTUAL_HOST');
-if (!empty($virtual_host))
-	array_push($AUTHORIZED_HOSTNAMES, $virtual_host);
+// Set landing page name, found within /var/www/html/
+$landPage = "landing.php";
 
-// Immediately quit since we didn't block this page (the IP address or pi.hole is explicitly requested)
-if(validIP($serverName) || in_array($serverName,$AUTHORIZED_HOSTNAMES))
-{
-	http_response_code(404);
-	die();
+// Set empty array for hostnames to be accepted as self address for splash page
+$authorizedHosts = [];
+
+// Append FQDN to $authorizedHosts
+if (!empty($svFQDN)) array_push($authorizedHosts, $svFQDN);
+  
+// Append virtual hostname to $authorizedHosts
+if (!empty($_SERVER["VIRTUAL_HOST"])) {
+    if (validate_server_name($_SERVER["VIRTUAL_HOST"]) === TRUE) {
+        array_push($authorizedHosts, $_SERVER["VIRTUAL_HOST"]);
+    } else {
+        die("[ERROR]: <code>VIRTUAL_HOST</code> header output does not appear to be valid: <code>".$_SERVER["VIRTUAL_HOST"]."</code>");
+    }
 }
 
-if(in_array($uriExt, $webExt) || empty($uriExt))
-{
-	// Requested resource has an extension listed in $webExt
-	// or no extension (index access to some folder incl. the root dir)
-	$showPage = true;
-}
-else
-{
-	// Something else
-	$showPage = false;
-}
+// Set which extension types get rendered as "Website Blocked" (Including "" for index file extensions)
+$validExtTypes = array("asp", "htm", "html", "php", "rss", "xml", "");
 
-// Handle incoming URI types
-if (!$showPage)
-{
-?>
-<html>
-<head>
-<script>window.close();</script></head>
-<body>
-<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
-</body>
-</html>
-<?php
-	die();
+// Get extension of current URL
+$currentUrlExt = pathinfo($_SERVER["REQUEST_URI"], PATHINFO_EXTENSION);
+
+// Set mobile friendly viewport
+$viewPort = '<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>';
+
+// Set response header
+function setHeader($t = "x") {
+    header("X-Pi-hole: A black hole for Internet advertisements.");
+    if (isset($t) && $t === "js") header("Content-Type: application/javascript");
 }
 
-// Get Pi-hole version
-$piHoleVersion = exec('cd /etc/.pihole/ && git describe --tags --abbrev=0');
-
-// Don't show the URI if it is the root directory
-if($uri == "/")
-{
-	$uri = "";
+// Determine block page redirect
+if ($serverName === "pi.hole") {
+    exit(header("Location: /admin"));
+} elseif (filter_var($serverName, FILTER_VALIDATE_IP) || in_array($serverName, $authorizedHosts)) {
+    // Show splash page or landing page when directly browsing via IP or auth'd hostname
+    $splashPage = "
+    <html><head>
+        $viewPort
+        <link rel='stylesheet' href='/blockpage.css' type='text/css'/>
+    </head><body id='splashpage'><img src='/admin/img/logo.svg'/><br/>Pi-<b>hole</b>: Your black hole for Internet advertisements</body></html>
+    ";
+    $pageType = is_file(getcwd()."/$landPage") ? include $landPage : "$splashPage";
+    unset($serverName, $svFQDN, $svPasswd, $svEmail, $authorizedHosts, $validExtTypes, $currentUrlExt, $viewPort);
+    exit($pageType);
+} elseif ($currentUrlExt === "js") {
+    // Set Javascript redirect for blocked sources
+    exit(setHeader("js").'var x = "Pi-hole: A black hole for Internet advertisements."');
+} elseif (strpos($_SERVER["REQUEST_URI"], "?") !== FALSE && isset($_SERVER["HTTP_REFERER"])) {
+    // Set blank image upon receiving REQUEST_URI w/ query string & HTTP_REFERRER (Presumably from iframe)
+    exit(setHeader().'<html>
+        <head><script>window.close();</script></head>
+        <body><img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs="></body>
+    </html>');
+} elseif (!in_array($currentUrlExt, $validExtTypes) || substr_count($_SERVER["REQUEST_URI"], "?")) {
+    // Set svg image upon receiving non $validExtTypes URL extension or query string (Presumably not from an iframe)
+    $blockImg = '<a href="/"><svg xmlns="http://www.w3.org/2000/svg" width="110" height="16"><defs><style>a {text-decoration: none;} circle {stroke: rgba(152,2,2,0.5); fill: none; stroke-width: 2;} rect {fill: rgba(152,2,2,0.5);} text {opacity: 0.3; font: 11px Arial;}</style></defs><circle cx="8" cy="8" r="7"/><rect x="10.3" y="-6" width="2" height="12" transform="rotate(45)"/><text x="19.3" y="12">Blocked by Pi-hole</text></svg></a>';
+    exit(setHeader()."<html>
+        <head>$viewPort</head>
+        <body>$blockImg</body>
+    </html>");
 }
 
+/* Start processing block page from here */
+
+// Get Pi-hole core branch name
+$phBranch = exec("cd /etc/.pihole/ && git rev-parse --abbrev-ref HEAD");
+if ($phBranch !== "master") {
+    error_reporting(E_ALL);
+    ini_set("display_errors", 1);
+    ini_set("display_startup_errors", 1);
+}
+
+// Validate SERVER_IP output
+if (filter_var($_SERVER['SERVER_ADDR'], FILTER_VALIDATE_IP)) {
+    $serverAddr = $_SERVER["SERVER_ADDR"];
+} else {
+    die("[ERROR]: <code>SERVER_IP</code> header output does not appear to be valid: <code>".$_SERVER["SERVER_ADDR"]."</code>");
+}
+
+// Determine placeholder text based off $svPasswd presence
+$wlPlaceHolder = empty($svPasswd) ? "No admin password set" : "Javascript disabled";
+
+// Get admin email address
+$bpAskAdmin = !empty($svEmail) ? '<a href="mailto:'.$svEmail.'?subject=Site Blocked: '.$serverName.'"></a>' : "<span/>";
+
+// Determine if at least one block list has been generated
+if (empty(glob("/etc/pihole/list.0.*.domains"))) die("[ERROR]: There are no domain lists generated lists within <code>/etc/pihole/</code>! Please update gravity by running <code>pihole -g</code>, or repair Pi-hole using <code>pihole -r</code>.");
+
+// Get contents of adlist.list
+$adLists = is_file("/etc/pihole/adlists.list") ? "/etc/pihole/adlists.list" : "/etc/pihole/adlists.default";
+if (!is_file($adLists)) die("[ERROR]: Unable to find file: <code>$adLists</code>");
+
+// Get all URLs starting with "http" or "www" from $adLists and re-index array numerically
+$adlistsUrls = array_values(preg_grep("/(^http)|(^www)/i", file($adLists, FILE_IGNORE_NEW_LINES)));
+if (empty($adlistsUrls)) die("[ERROR]: There are no adlist URL's found within <code>$adLists</code>");
+$adlistsCount = count($adlistsUrls) + 3; // +1 because array starts at 0, +2 for Blacklist & Wildcard lists
+
+// Get results of queryads.php exact search
+ini_set("default_socket_timeout", 3);
+function queryAds($serverName) {
+    $preQueryTime = microtime(true)-$_SERVER["REQUEST_TIME_FLOAT"];
+    $queryAds = file("http://127.0.0.1/admin/scripts/pi-hole/php/queryads.php?domain=$serverName&exact", FILE_IGNORE_NEW_LINES);
+    $queryTime = sprintf("%.0f", (microtime(true)-$_SERVER["REQUEST_TIME_FLOAT"]) - $preQueryTime);
+    try {
+        if ($queryTime >= ini_get("default_socket_timeout")) {
+            throw new Exception ("Connection timeout (".ini_get("default_socket_timeout")."s)");
+        } elseif ($queryAds[0][0] === ":") {
+            if (strpos($queryAds[0], "Invalid") !== FALSE) throw new Exception ("Invalid Domain ($serverName)");
+            if (strpos($queryAds[0], "No exact") !== FALSE) return array("0" => "none");
+            throw new Exception ("Unhandled error message (<code>$queryAds[0]</code>)");
+        } elseif ($queryAds[0][0] !== "/") {
+            throw new Exception ("Unexpected output (<code>$queryAds[0]</code>)");
+        }
+        return $queryAds;
+    } catch (Exception $e) {
+        die("[ERROR]: Unable to parse results from <i>queryads.php</i>: <code>".$e->getMessage()."</code>");
+    }
+}
+$queryAds = queryAds($serverName);
+
+// Filter, sort, and count $queryAds array
+if ($queryAds[0] !== "none") {
+    $queryAds = preg_replace("/(\/etc\/pihole\/)|(\/etc\/dnsmasq\.d\/)/", "", $queryAds);
+    $queryAds = preg_replace("/(^list\.)|(\..*domains)/", "", $queryAds);
+    $featuredTotal = count($queryAds);
+}
+
+// Determine if domain has been blacklisted or wildcarded
+if ($queryAds[0] === "blacklist.txt") {
+    $intBlacklist = array("&#960;" => $queryAds[0]);
+    $queryAds[0] = "&#960;"; // Manually blacklisted sites do not have a number
+    $notableFlagClass = "blacklist";
+} elseif ($queryAds[0] === "03-pihole-wildcard.conf") {
+    $intBlacklist = array("&#960;" => $queryAds[0]);
+    $queryAds[0] = "&#960;";
+    $notableFlagClass = "wildcard";
+} elseif ($queryAds[0] === "none") {
+    $featuredTotal = "0";
+    $notableFlagClass = "noblock";
+
+    // Determine appropriate info message if CNAME exists
+    $dnsRecord = dns_get_record("$serverName")[0];
+    if (array_key_exists("target", $dnsRecord)) {
+        $wlInfo = $dnsRecord['target'];
+    } else {
+        $wlInfo = "recentwl";
+    }
+}
+
+// Merge $intBlacklist with $adlistsUrls if domain has been blacklisted or wildcarded
+if (isset($intBlacklist)) $adlistsUrls = array_merge($intBlacklist, $adlistsUrls);
+
+// Set #bpOutput notification
+$wlOutputClass = (isset($wlInfo) && $wlInfo === "recentwl") ? $wlInfo : "hidden";
+$wlOutput = (isset($wlInfo) && $wlInfo !== "recentwl") ? "<a href='http://$wlInfo'>$wlInfo</a>" : "";
+
+// Get Pi-hole core version
+if ($phBranch !== "master") {
+    $phVersion = exec("cd /etc/.pihole/ && git describe --long --dirty --tags");
+    $execTime = microtime(true)-$_SERVER["REQUEST_TIME_FLOAT"];
+} else {
+    $phVersion = exec("cd /etc/.pihole/ && git describe --tags --abbrev=0");
+}
 ?>
 <!DOCTYPE html>
 <html>
+<!-- Pi-hole: A black hole for Internet advertisements
+*  (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  This file is copyright under the latest version of the EUPL. -->
 <head>
-	<meta charset='UTF-8'/>
-	<title>Website Blocked</title>
-	<link rel='stylesheet' href='http://pi.hole/pihole/blockingpage.css'/>
-	<link rel='shortcut icon' href='http://pi.hole/admin/img/favicon.png' type='image/png'/>
-	<meta name='viewport' content='width=device-width,initial-scale=1.0,maximum-scale=1.0, user-scalable=no'/>
-	<meta name='robots' content='noindex,nofollow'/>
+  <meta charset="UTF-8">
+  <?=$viewPort ?>
+  <?=setHeader() ?>
+  <meta name="robots" content="noindex,nofollow"/>
+  <meta http-equiv="x-dns-prefetch-control" content="off">
+  <link rel="shortcut icon" href="http://<?=$serverAddr ?>/admin/img/favicon.png" type="image/x-icon"/>
+  <link rel="stylesheet" href="http://<?=$serverAddr ?>/blockpage.css" type="text/css"/>
+  <title>? <?=$serverName ?></title>
+  <script src="http://<?=$serverAddr ?>/admin/scripts/vendor/jquery.min.js"></script>
+  <script>
+    window.onload = function () {
+      <?php
+      // Remove href fallback from "Back to safety" button
+      if ($featuredTotal > 0) echo '$("#bpBack").removeAttr("href");';
+      // Enable whitelisting if $svPasswd is present & JS is available
+      if (!empty($svPasswd) && $featuredTotal > 0) {
+          echo '$("#bpWLPassword, #bpWhitelist").prop("disabled", false);';
+          echo '$("#bpWLPassword").attr("placeholder", "Password");';
+      }
+      ?>
+    }
+  </script>
 </head>
-<body id="body">
+<body id="blockpage"><div id="bpWrapper">
 <header>
-	<h1><a href='/'>Website Blocked</a></h1>
+  <h1 id="bpTitle">
+    <a class="title" href="/"><?php //Website Blocked ?></a>
+  </h1>
+  <div class="spc"></div>
+
+  <input id="bpAboutToggle" type="checkbox"/>
+  <div id="bpAbout">
+    <div class="aboutPH">
+      <div class="aboutImg"/></div>
+      <p>Open Source Ad Blocker
+        <small>Designed for Raspberry Pi</small>
+      </p>
+    </div>
+    <div class="aboutLink">
+      <a class="linkPH" href="https://github.com/pi-hole/pi-hole/wiki/What-is-Pi-hole%3F-A-simple-explanation"><?php //About PH ?></a>
+      <?php if (!empty($svEmail)) echo '<a class="linkEmail" href="mailto:'.$svEmail.'"></a>'; ?>
+    </div>
+  </div>
+
+  <div id="bpAlt">
+    <label class="altBtn" for="bpAboutToggle"><?php //Why am I here? ?></label>
+  </div>
 </header>
+
 <main>
-	<div>Access to the following site has been blocked:<br/>
-	<span class='pre msg'><?php echo $serverName.$uri; ?></span></div>
-	<div>If you have an ongoing use for this website, please ask the owner of the Pi-hole in your network to have it whitelisted.</div>
-	<input id="domain" type="hidden" value="<?php echo $serverName; ?>">
-	<input id="quiet" type="hidden" value="yes">
-	<button id="btnSearch" class="buttons blocked" type="button" style="visibility: hidden;"></button>
-	This page is blocked because it is explicitly contained within the following block list(s):
-	<pre id="output" style="width: 100%; height: 100%;" hidden="true"></pre><br/>
-	<div class='buttons blocked'>
-		<a class='safe33' href='javascript:history.back()'>Go back</a>
-		<a class='safe33' id="whitelisting">Whitelist this page</a>
-		<a class='safe33' href='javascript:window.close()'>Close window</a>
-	</div>
-		<div style="width: 98%; text-align: center; padding: 10px;" hidden="true" id="whitelistingform">
-			<p>Note that whitelisting domains which are blocked using the wildcard method won't work.</p>
-			<p>Password required!</p><br/>
-		<form>
-			<input name="list" type="hidden" value="white"><br/>
-			Domain:<br/>
-			<input name="domain" value="<?php echo $serverName ?>" disabled><br/><br/>
-			Password:<br/>
-			<input type="password" id="pw" name="pw"><br/><br/>
-			<button class="buttons33 safe" id="btnAdd" type="button">Whitelist</button>
-		</form><br/>
-		<pre id="whitelistingoutput" style="width: 100%; height: 100%; padding: 5px;" hidden="true"></pre><br/>
-		</div>
+  <div id="bpOutput" class="<?=$wlOutputClass ?>"><?=$wlOutput ?></div>
+  <div id="bpBlock">
+    <p class="blockMsg"><?=$serverName ?></p>
+  </div>
+  <?php if(isset($notableFlagClass)) { ?>
+    <div id="bpFlag">
+        <p class="flagMsg <?=$notableFlagClass ?>"></p>
+    </div>
+  <?php } ?>
+  <div id="bpHelpTxt"><?=$bpAskAdmin ?></div>
+  <div id="bpButtons" class="buttons">
+    <a id="bpBack" onclick="javascript:history.back()" href="about:home"></a>
+    <?php if ($featuredTotal > 0) echo '<label id="bpInfo" for="bpMoreToggle"></label>'; ?>
+  </div>
+  <input id="bpMoreToggle" type="checkbox">
+  <div id="bpMoreInfo">
+    <span id="bpFoundIn"><span><?=$featuredTotal ?></span><?=$adlistsCount ?></span>
+    <pre id='bpQueryOutput'><?php if ($featuredTotal > 0) foreach ($queryAds as $num) { echo "<span>[$num]:</span>$adlistsUrls[$num]\n"; } ?></pre>
+    <form id="bpWLButtons" class="buttons">
+      <input id="bpWLDomain" type="text" value="<?=$serverName ?>" disabled/>
+      <input id="bpWLPassword" type="password" placeholder="<?=$wlPlaceHolder ?>" disabled/><button id="bpWhitelist" type="button" disabled></button>
+    </form>
+  </div>
 </main>
-<footer>Generated <?php echo date('D g:i A, M d'); ?> by Pi-hole <?php echo $piHoleVersion; ?></footer>
-<script src="http://pi.hole/admin/scripts/vendor/jquery.min.js"></script>
-<script>
-// Create event for when the output is appended to
-(function($) {
-    var origAppend = $.fn.append;
 
-    $.fn.append = function () {
-        return origAppend.apply(this, arguments).trigger("append");
-    };
-})(jQuery);
-</script>
-<script src="http://pi.hole/admin/scripts/pi-hole/js/queryads.js"></script>
+<footer><span><?=date("l g:i A, F dS"); ?>.</span> Pi-hole <?=$phVersion ?> (<?=gethostname()."/".$serverAddr; if (isset($execTime)) printf("/%.2fs", $execTime); ?>)</footer>
+</div>
+
 <script>
-function inIframe () {
-    try {
-        return window.self !== window.top;
-    } catch (e) {
-        return true;
+  function add() {
+    $("#bpOutput").removeClass("hidden error exception");
+    $("#bpOutput").addClass("add");
+    var domain = "<?=$serverName ?>";
+    var pw = $("#bpWLPassword");
+    if(domain.length === 0) {
+      return;
     }
-}
 
-// Try to detect if page is loaded within iframe
-if(inIframe())
-{
-    // Within iframe
-    // hide content of page
-    $('#body').hide();
-    // remove background
-    document.body.style.backgroundImage = "none";
-}
-else
-{
-    // Query adlists
-    $( "#btnSearch" ).click();
-}
+    $.ajax({
+      url: "/admin/scripts/pi-hole/php/add.php",
+      method: "post",
+      data: {"domain":domain, "list":"white", "pw":pw.val()},
+      success: function(response) {
+        if(response.indexOf("Pi-hole blocking") !== -1) {
+          setTimeout(function(){window.location.reload(1);}, 10000);
+          $("#bpOutput").removeClass("add");
+          $("#bpOutput").addClass("success");
+        } else {
+          $("#bpOutput").removeClass("add");
+          $("#bpOutput").addClass("error");
+          $("#bpOutput").html(""+response+"");
+        }
 
-$( "#whitelisting" ).on( "click", function(){ $( "#whitelistingform" ).removeAttr( "hidden" ); });
+      },
+      error: function(jqXHR, exception) {
+        $("#bpOutput").removeClass("add");
+        $("#bpOutput").addClass("exception");
+      }
+    });
+  }
 
-// Remove whitelist functionality if the domain was blocked because of a wildcard
-$( "#output" ).bind("append", function(){
-	if($( "#output" ).contents()[0].data.indexOf("Wildcard blocking") !== -1)
-	{
-		$( "#whitelisting" ).hide();
-		$( "#whitelistingform" ).hide();
-	}
-});
+  <?php if ($featuredTotal > 0) { ?>
+    $(document).keypress(function(e) {
+        if(e.which === 13 && $("#bpWLPassword").is(":focus")) {
+            add();
+        }
+    });
 
-function add() {
-	var domain = $("#domain");
-	var pw = $("#pw");
-	if(domain.val().length === 0){
-		return;
-	}
-
-	$.ajax({
-		url: "admin/scripts/pi-hole/php/add.php",
-		method: "post",
-		data: {"domain":domain.val(), "list":"white", "pw":pw.val()},
-		success: function(response) {
-			$( "#whitelistingoutput" ).removeAttr( "hidden" );
-			if(response.indexOf("Pi-hole blocking") !== -1)
-			{
-				// Reload page after 5 seconds
-				setTimeout(function(){window.location.reload(1);}, 5000);
-				$( "#whitelistingoutput" ).html("---> Success <---<br/>You may have to flush your DNS cache");
-			}
-			else
-			{
-				$( "#whitelistingoutput" ).html("---> "+response+" <---");
-			}
-
-		},
-		error: function(jqXHR, exception) {
-			$( "#whitelistingoutput" ).removeAttr( "hidden" );
-			$( "#whitelistingoutput" ).html("---> Unknown Error <---");
-		}
-	});
-}
-// Handle enter button for adding domains
-$(document).keypress(function(e) {
-    if(e.which === 13 && $("#pw").is(":focus")) {
+    $("#bpWhitelist").on("click", function() {
         add();
-    }
-});
-
-// Handle buttons
-$("#btnAdd").on("click", function() {
-    add();
-});
+    });
+  <?php } ?>
 </script>
-</body>
-</html>
+
+</body></html>

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -210,7 +210,7 @@ if ($phBranch !== "master") {
   <meta name="robots" content="noindex,nofollow"/>
   <meta http-equiv="x-dns-prefetch-control" content="off">
   <link rel="shortcut icon" href="http://<?=$serverAddr ?>/admin/img/favicon.png" type="image/x-icon"/>
-  <link rel="stylesheet" href="http://<?=$serverAddr ?>/blockpage.css" type="text/css"/>
+  <link rel="stylesheet" href="http://<?=$serverAddr ?>/pihole/blockingpage.css" type="text/css"/>
   <title>? <?=$serverName ?></title>
   <script src="http://<?=$serverAddr ?>/admin/scripts/vendor/jquery.min.js"></script>
   <script>

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -57,9 +57,9 @@ $currentUrlExt = pathinfo($_SERVER["REQUEST_URI"], PATHINFO_EXTENSION);
 $viewPort = '<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>';
 
 // Set response header
-function setHeader($t = "x") {
+function setHeader($type = "x") {
     header("X-Pi-hole: A black hole for Internet advertisements.");
-    if (isset($t) && $t === "js") header("Content-Type: application/javascript");
+    if (isset($type) && $type === "js") header("Content-Type: application/javascript");
 }
 
 // Determine block page redirect
@@ -147,10 +147,14 @@ function queryAds($serverName) {
         }
         return $queryAds;
     } catch (Exception $e) {
-        die("[ERROR]: Unable to parse results from <i>queryads.php</i>: <code>".$e->getMessage()."</code>");
+        return array("0" => "error", "1" => $e->getMessage());
     }
 }
 $queryAds = queryAds($serverName);
+
+if ($queryAds[0] === "error") {
+    die("[ERROR]: Unable to parse results from <i>queryads.php</i>: <code>".$queryAds[1]."</code>");
+}
 
 // Filter, sort, and count $queryAds array
 if ($queryAds[0] !== "none") {
@@ -211,7 +215,7 @@ if ($phBranch !== "master") {
   <meta http-equiv="x-dns-prefetch-control" content="off">
   <link rel="shortcut icon" href="http://<?=$serverAddr ?>/admin/img/favicon.png" type="image/x-icon"/>
   <link rel="stylesheet" href="http://<?=$serverAddr ?>/pihole/blockingpage.css" type="text/css"/>
-  <title>? <?=$serverName ?></title>
+  <title>● <?=$serverName ?></title>
   <script src="http://<?=$serverAddr ?>/admin/scripts/vendor/jquery.min.js"></script>
   <script>
     window.onload = function () {

--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -51,6 +51,7 @@ compress.filetype           = ( "application/javascript", "text/css", "text/html
 include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
 include_shell "/usr/share/lighttpd/create-mime.assign.pl"
 #include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
+include_shell "find /etc/lighttpd/conf-enabled -name '*.conf' -a ! -name 'letsencrypt.conf' -printf 'include \"%p\"\n' 2>/dev/null"
 
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {

--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -50,7 +50,7 @@ compress.filetype           = ( "application/javascript", "text/css", "text/html
 # default listening port for IPv6 falls back to the IPv4 port
 include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
 include_shell "/usr/share/lighttpd/create-mime.assign.pl"
-include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
+#include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
@@ -59,21 +59,9 @@ $HTTP["url"] =~ "^/admin/" {
         "X-Pi-hole" => "The Pi-hole Web interface is working!",
         "X-Frame-Options" => "DENY"
     )
-}
-
-# Rewite js requests, must be out of $HTTP block due to bug #2526
-url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
-
-# If the URL does not start with /admin, then it is a query for an ad domain
-$HTTP["url"] =~ "^(?!/admin)/.*" {
-    # Create a response header for debugging using curl -I
-    setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-}
-
-# Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
-$HTTP["host"] == "pi.hole" {
-    $HTTP["url"] == "/" {
-        url.redirect = ( "" => "/admin/" )
+    $HTTP["url"] =~ ".ttf$" {
+        # Allow Block Page access to local fonts
+        setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
     }
 }
 

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -75,22 +75,13 @@ fastcgi.server = ( ".php" =>
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
 	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "The Pi-hole Web interface is working!" )
-}
-
-# Rewite js requests, must be out of $HTTP block due to bug #2526
-url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
-
-# If the URL does not start with /admin, then it is a query for an ad domain
-$HTTP["url"] =~ "^(?!/admin)/.*" {
-	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-}
-
-# Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
-$HTTP["host"] == "pi.hole" {
-    $HTTP["url"] == "/" {
-        url.redirect = ( "" => "/admin/" )
+    setenv.add-response-header = (
+        "X-Pi-hole" => "The Pi-hole Web interface is working!",
+        "X-Frame-Options" => "DENY"
+    )
+    $HTTP["url"] =~ ".ttf$" {
+        # Allow Block Page access to local fonts
+        setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
     }
 }
 

--- a/pihole
+++ b/pihole
@@ -84,62 +84,45 @@ scanList(){
   domain="${1}"
   list="${2}"
   method="${3}"
-  if [[ ${method} == "-exact" ]] ; then
-    grep -i -E "(^|\s)${domain}($|\s)" "${list}"
-  else
-    grep -i "${domain}" "${list}"
-  fi
-}
 
-processWildcards() {
-  IFS="." read -r -a array <<< "${1}"
-  for (( i=${#array[@]}-1; i>=0; i-- )); do
-    ar=""
-    for (( j=${#array[@]}-1; j>${#array[@]}-i-2; j-- )); do
-      if [[ $j == $((${#array[@]}-1)) ]]; then
-        ar="${array[$j]}"
-      else
-        ar="${array[$j]}.${ar}"
-      fi
-    done
-    echo "${ar}"
-  done
+  if [[ ${method} == "-exact" ]]; then
+    grep -i -E -l "(^|\/)${domain}($|\/)" ${list}
+  else
+    grep -i "${domain}" ${list}
+  fi
 }
 
 queryFunc() {
-  domain="${2}"
   method="${3}"
-  lists=( /etc/pihole/list.* /etc/pihole/blacklist.txt)
-  for list in ${lists[@]}; do
-    if [ -e "${list}" ]; then
-      result=$(scanList ${domain} ${list} ${method})
-      # Remove empty lines before couting number of results
-      count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
-      echo "::: ${list} (${count} results)"
-      if [[ ${count} > 0 ]]; then
-        echo "${result}"
-      fi
-      echo ""
-    else
-      echo "::: ${list} does not exist"
-      echo ""
-    fi
-  done
-
-  # Scan for possible wildcard matches
-  if [ -e "${wildcardlist}" ]; then
-    local wildcards=($(processWildcards "${domain}"))
-    for domain in ${wildcards[@]}; do
-      result=$(scanList "\/${domain}\/" ${wildcardlist})
-      # Remove empty lines before couting number of results
-      count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
-      if [[ ${count} > 0 ]]; then
-        echo "::: Wildcard blocking ${domain} (${count} results)"
-        echo "${result}"
-        echo ""
-      fi
-    done
+  
+  # If domain contains non ASCII characters, convert domain to punycode if python exists
+  # Cr: https://serverfault.com/a/335079
+  if [ -z "${2}" ]; then
+    echo "::: No domain specified"
+    exit 1
+  elif [[ ${2} = *[![:ascii:]]* ]]; then
+    [ `which python` ] && domain=$(python -c 'import sys;print sys.argv[1].decode("utf-8").encode("idna")' "${2}")
+  else
+    domain="${2}"
   fi
+  
+  # Scan Blacklist and Wildcards
+  lists="/etc/pihole/blacklist.txt $wildcardlist"
+  result=$(scanList ${domain} "${lists}" ${method})
+  if [ -n "$result" ]; then
+    echo "$result"
+    exit 0
+  fi
+
+  # Scan Domains lists
+  result=$(scanList ${domain} "/etc/pihole/*.domains" ${method})
+  if [ -n "$result" ]; then
+    sort -t . -k 2 -g <<< "$result"
+  else
+    [ -n "$method" ] && exact="exact "
+    echo "::: No ${exact}results found for ${domain}"
+  fi
+  
   exit 0
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

6

---
Modifications for `/usr/local/bin/pihole`:
* Allow scanList() to search files using a wildcard by removing quotes wrapped around `${list}`
* scanList() will not provide a domain ouput on each string if exact is specified (`grep -l`)
* Remove processWildcards() function
* Return a message if no domain is specified
* IDN domains are converted to punycode when running a `pihole -q` search if the `python` package is available, otherwise will revert to current behaviour
* Scan Blacklist & Wildcards first, exiting from search if a match is found (Fixes #1330)
* Use one `grep` subshell to search for all "*.domains" lists at once (opposed to looping to get every matching file name, and then spawning a `grep` instance for every matching file)
* queryFunc() will not return "(0 results)" output from files where no match is found
* Sort results based off list number
* Return a message if no results are found

Modifications for `/var/www/html/pihole/index.php` (Block Page):
* Set pcre.recursion_limit, 3x the limit necessary to process a valid 253 character domain name
* An "About Pi-hole" link on the block page provides an ELI5 explanation to those not familiar with Pi-hole
* An email contact link on the block page provides users of your Pi-hole with a means to easily get in touch with you
* Browsing to your Pi-hole's address will show a simple "landing page", which can be replaced by adding "landing.php" within "/var/www/html"
* Users manually browsing to file/image based content (i.e: non HTML based content) on blocked sites will be greeted with a small "Blocked by Pi-hole" image
* Sites that are manually blacklisted will display a notice of this on the block page
* Sites that aren't directly blocked, but have a CNAME record, will show a notification on the block page (e.g: If raw.githubusercontent.com is not blocked, but github.map.fastly.net is)
* On the block page, "Back to Safety" now directs the user to "about:home" if Javascript is disabled
* Whitelisting is disabled for installs without a password, or if a client does not have Javascript

* Known issues:
  * Admin Console needs a text field under "Web User Interface" where the admin can enter a preferred contact email when a site needs to be whitelisted, to be saved to setupVars.conf with the key "ADMIN_EMAIL"
  * Admin Console needs a text field under "Networking" where the admin can enter their Pi-hole's externally contactable FQDN, allowing access to their landing page when browsing to mypi.duckdns.org, to be saved to setupVars.conf with the key "FQDN"
  * I am not aware of expected output of `$_SERVER["VIRTUAL_HOST"]`, so I have assumed it should be filtered as if it's a domain

Modifications for `/var/www/html/pihole/blockingpage.css`:
* Block page UI overhaul to replicate the style of the Admin Console
* Block page UI is now mobile friendly
* Users can safely customise text in order to make the block page more friendly for their household

Modifications for `/etc/lighttpd/lighttpd.conf`:
* Disable `include-conf-enabled.pl`, as blindly enabling HTTPS (as Let's Encrypt does by having a file in that folder) makes loading web pages slower (and in the case of macOS/iOS, provides certificate error popups)
* Make Block page handle JS request rewrite, allowing users to better utilise their `lighttpd` service
* Make Block page handle debugging Pi-hole header
* Make Block page redirect users from `pi.hole` to `http://pi.hole/admin`

Supporting changes needed to allow users to enable HTTPS without affecting page load speeds:
```
# Only enable SSL for primary FQDN
$HTTP["host"] == "rpi.ddns.com" {
  include_shell "cat conf-enabled/letsencrypt.conf 2>/dev/null"
}
```

* Using the key `FQDN` (as found within `setupVars.conf`) to replace "rpi.ddns.com", will enable Let's Encrypt configuration if the file exists
* Expected behaviour: Querying a blocked page via HTTPS returns an error similar to: `curl: (35) error:14077458:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 unrecognized name`, but the request will still be dropped immediately