### PR TITLE
Disable HTTPS & shift functions to block page

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -51,6 +51,7 @@ compress.filetype           = ( "application/javascript", "text/css", "text/html
 include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
 include_shell "/usr/share/lighttpd/create-mime.assign.pl"
 #include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
+include_shell "find /etc/lighttpd/conf-enabled -name '*.conf' -a ! -name 'letsencrypt.conf' -printf 'include \"%p\"\n' 2>/dev/null"
 
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {

--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -50,7 +50,7 @@ compress.filetype           = ( "application/javascript", "text/css", "text/html
 # default listening port for IPv6 falls back to the IPv4 port
 include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
 include_shell "/usr/share/lighttpd/create-mime.assign.pl"
-include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
+#include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
@@ -59,21 +59,9 @@ $HTTP["url"] =~ "^/admin/" {
         "X-Pi-hole" => "The Pi-hole Web interface is working!",
         "X-Frame-Options" => "DENY"
     )
-}
-
-# Rewite js requests, must be out of $HTTP block due to bug #2526
-url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
-
-# If the URL does not start with /admin, then it is a query for an ad domain
-$HTTP["url"] =~ "^(?!/admin)/.*" {
-    # Create a response header for debugging using curl -I
-    setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-}
-
-# Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
-$HTTP["host"] == "pi.hole" {
-    $HTTP["url"] == "/" {
-        url.redirect = ( "" => "/admin/" )
+    $HTTP["url"] =~ ".ttf$" {
+        # Allow Block Page access to local fonts
+        setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
     }
 }
 

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -75,22 +75,13 @@ fastcgi.server = ( ".php" =>
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
 	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "The Pi-hole Web interface is working!" )
-}
-
-# Rewite js requests, must be out of $HTTP block due to bug #2526
-url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
-
-# If the URL does not start with /admin, then it is a query for an ad domain
-$HTTP["url"] =~ "^(?!/admin)/.*" {
-	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-}
-
-# Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
-$HTTP["host"] == "pi.hole" {
-    $HTTP["url"] == "/" {
-        url.redirect = ( "" => "/admin/" )
+    setenv.add-response-header = (
+        "X-Pi-hole" => "The Pi-hole Web interface is working!",
+        "X-Frame-Options" => "DENY"
+    )
+    $HTTP["url"] =~ ".ttf$" {
+        # Allow Block Page access to local fonts
+        setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
     }
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

5

---

The changes here primarily shift the work of header functions, JS redirects, etc, to the block page as per https://github.com/pi-hole/pi-hole/pull/1416.

Also, by commenting out `include-conf-enabled.pl` and replacing it with `include_shell "find /etc/lighttpd/conf-enabled -name '*.conf' -a ! -name 'letsencrypt.conf' -printf 'include \"%p\"\n' 2>/dev/null"`, the following can be added to `external.conf` to enable HTTPS, without affecting web browsing load speeds:
```
# Only enable SSL for primary FQDN
$HTTP["host"] == "rpi.ddns.com" {
  include_shell "cat conf-enabled/letsencrypt.conf 2>/dev/null"
}
```

A blocked HTTPS query will be instantly dropped, but may provide an error message similar to: `curl: (35) error:14077458:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 unrecognized name`. Autofilling `$HTTP["host"] == ""` within `external.conf` with the proposed `FQDN` key from `setupVars.conf` is not a part of this PR and can be developed separately.