### PR TITLE
Double hash the password directly in the install script

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -67,6 +67,13 @@ SetTemperatureUnit(){
 
 }
 
+HashPassword(){
+    # Compute password hash twice to avoid rainbow table vulnerability
+    return=$(echo -n ${1} | sha256sum | sed 's/\s.*$//')
+		return=$(echo -n ${return} | sha256sum | sed 's/\s.*$//')
+		echo ${return}
+}
+
 SetWebPassword(){
 
 	if [ "${SUDO_USER}" == "www-data" ]; then
@@ -93,9 +100,7 @@ SetWebPassword(){
 	read -s -p "Confirm Password: " CONFIRM
 	echo ""
 	if [ "${PASSWORD}" == "${CONFIRM}" ] ; then
-		# Compute password hash twice to avoid rainbow table vulnerability
-		hash=$(echo -n ${PASSWORD} | sha256sum | sed 's/\s.*$//')
-		hash=$(echo -n ${hash} | sha256sum | sed 's/\s.*$//')
+		hash=$(HashPassword ${PASSWORD})
 		# Save hash to file
 		change_setting "WEBPASSWORD" "${hash}"
 		echo "New password set"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1413,9 +1413,9 @@ main() {
     pw=""
     if [[ $(grep 'WEBPASSWORD' -c /etc/pihole/setupVars.conf) == 0 ]] ; then
         pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
-        hash=$(echo -n ${pw} | sha256sum | sed 's/\s.*$//')
+        hash=$(echo -n ${pw} | sha256sum | sed 's/\s.*$//' | sha256sum | sed 's/\s.*$//')
         hash=$(echo -n ${hash} | sha256sum | sed 's/\s.*$//')
-        echo "WEBPASSWORD=${hash}" >> ${setupVars}
+        echo "WEBPASSWORD=$(echo -n ${pw} | sha256sum | sed 's/\s.*$//' | sha256sum | sed 's/\s.*$//')" >> ${setupVars}
     fi
   fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1414,7 +1414,7 @@ main() {
     if [[ $(grep 'WEBPASSWORD' -c /etc/pihole/setupVars.conf) == 0 ]] ; then
         pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
         . /opt/pihole/webpage.sh
-        echo "WEBPASSWORD=$(HashPassword ${1})" >> ${setupVars}
+        echo "WEBPASSWORD=$(HashPassword ${pw})" >> ${setupVars}
     fi
   fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1413,7 +1413,9 @@ main() {
     pw=""
     if [[ $(grep 'WEBPASSWORD' -c /etc/pihole/setupVars.conf) == 0 ]] ; then
         pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
-        /usr/local/bin/pihole -a -p "${pw}"
+        hash=$(echo -n ${pw} | sha256sum | sed 's/\s.*$//')
+        hash=$(echo -n ${hash} | sha256sum | sed 's/\s.*$//')
+        echo "WEBPASSWORD=${hash}" >> ${setupVars}
     fi
   fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1414,7 +1414,7 @@ main() {
     if [[ $(grep 'WEBPASSWORD' -c /etc/pihole/setupVars.conf) == 0 ]] ; then
         pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
         . /opt/pihole/webpage.sh
-        echo "WEBPASSWORD=$(HashPassword ${1})
+        echo "WEBPASSWORD=$(HashPassword ${1})"
     fi
   fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1414,7 +1414,7 @@ main() {
     if [[ $(grep 'WEBPASSWORD' -c /etc/pihole/setupVars.conf) == 0 ]] ; then
         pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
         . /opt/pihole/webpage.sh
-        echo "WEBPASSWORD=$(HashPassword ${1})"
+        echo "WEBPASSWORD=$(HashPassword ${1})" >> ${setupVars}
     fi
   fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1413,9 +1413,8 @@ main() {
     pw=""
     if [[ $(grep 'WEBPASSWORD' -c /etc/pihole/setupVars.conf) == 0 ]] ; then
         pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
-        hash=$(echo -n ${pw} | sha256sum | sed 's/\s.*$//' | sha256sum | sed 's/\s.*$//')
-        hash=$(echo -n ${hash} | sha256sum | sed 's/\s.*$//')
-        echo "WEBPASSWORD=$(echo -n ${pw} | sha256sum | sed 's/\s.*$//' | sha256sum | sed 's/\s.*$//')" >> ${setupVars}
+        . /opt/pihole/webpage.sh
+        echo "WEBPASSWORD=$(HashPassword ${1})
     fi
   fi
 


### PR DESCRIPTION
Alternative fix for https://github.com/pi-hole/pi-hole/issues/1414

Hash the password in the install script, rather than adding an undocumented method to change the password into the password script