### PR TITLE
Display FTL version & version.sh rewrite

### DIFF
--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -69,8 +69,9 @@ getRemoteVersion(){
 coreOutput() {
   [ "$1" = "-c" -o "$1" = "--current" -o -z "$1" ] && current="$(getLocalVersion ${PHGITDIR})"
   [ "$1" = "-l" -o "$1" = "--latest" -o -z "$1" ] && latest="$(getRemoteVersion pi-hole)"
-  [ "$1" = "--hash" ] && hash="$(getLocalHash ${PHGITDIR})"
-  
+  [ "$1" = "-h" -o "$1" = "--hash" ] && hash="$(getLocalHash ${PHGITDIR})"
+  [ -n "$2" ] && error="true"
+
   if [ -n "$current" -a -n "$latest" ]; then
     str="Pi-hole version is $current (Latest: $latest)"
   elif [ -n "$current" -a -z "$latest" ]; then
@@ -80,17 +81,24 @@ coreOutput() {
   elif [ -n "$hash" ]; then
     str="Current Pi-hole hash is $hash"
   else
-    echo "  Invalid Option! Try 'pihole -v --help' for more information."
-    exit 1
+	error="true"
   fi
+
+  if [ "$error" = "true" ]; then
+	echo "  Invalid Option! Try 'pihole -v --help' for more information."
+	exit 1
+  fi
+
   echo "  $str"
 }
 
 webOutput() {
   [ "$1" = "-c" -o "$1" = "--current" -o -z "$1" ] && current="$(getLocalVersion ${WEBGITDIR})"
   [ "$1" = "-l" -o "$1" = "--latest" -o -z "$1" ] && latest="$(getRemoteVersion AdminLTE)"
-  [ "$1" = "--hash" ] && hash="$(getLocalHash ${WEBGITDIR})"
+  [ "$1" = "-h" -o "$1" = "--hash" ] && hash="$(getLocalHash ${WEBGITDIR})"
   [ ! -d "${WEBGITDIR}" ] && str="Web interface not installed!"
+  [ -n "$2" ] && error="true"
+
   
   if [ -n "$current" -a -n "$latest" ]; then
     str="Admin Console version is $current (Latest: $latest)"
@@ -101,9 +109,14 @@ webOutput() {
   elif [ -n "$hash" ]; then
     str="Current Admin Console hash is $hash"
   else
-    echo "  Invalid Option! Try 'pihole -v --help' for more information."
-    exit 1
+	error="true"
   fi
+
+  if [ "$error" = "true" ]; then
+	echo "  Invalid Option! Try 'pihole -v --help' for more information."
+	exit 1
+  fi
+
   echo "  $str"
 }
 
@@ -111,6 +124,7 @@ ftlOutput() {
   [ "$1" = "-c" -o "$1" = "--current" -o -z "$1" ] && current="$(pihole-FTL version)"
   [ "$1" = "-l" -o "$1" = "--latest" -o -z "$1" ] && latest="$(getRemoteVersion FTL)"
   [ ! -d "${WEBGITDIR}" ] && exit 0
+  [ -n "$2" ] && error="true"
 
   if [ -n "$current" -a -n "$latest" ]; then
     str="FTL version is $current (Latest: $latest)"
@@ -119,16 +133,21 @@ ftlOutput() {
   elif [ -z "$current" -a -n "$latest" ]; then
     str="Latest FTL version is $latest"
   else
-    echo "  Invalid Option! Try 'pihole -v --help' for more information."
-    exit 1
+	error="true"
   fi
+
+  if [ "$error" = "true" ]; then
+	echo "  Invalid Option! Try 'pihole -v --help' for more information."
+	exit 1
+  fi
+
   echo "  $str"
 }
   
 defaultOutput() {
-  coreOutput "$1"
-  webOutput "$1"
-  ftlOutput "$1"
+  coreOutput "$1" "$2"
+  webOutput "$1" "$2"
+  ftlOutput "$1" "$2"
 }
 
 helpFunc() {

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -81,12 +81,12 @@ coreOutput() {
   elif [ -n "$hash" ]; then
     str="Current Pi-hole hash is $hash"
   else
-	error="true"
+    error="true"
   fi
 
   if [ "$error" = "true" ]; then
-	echo "  Invalid Option! Try 'pihole -v --help' for more information."
-	exit 1
+    echo "  Invalid Option! Try 'pihole -v --help' for more information."
+    exit 1
   fi
 
   echo "  $str"
@@ -109,12 +109,12 @@ webOutput() {
   elif [ -n "$hash" ]; then
     str="Current Admin Console hash is $hash"
   else
-	error="true"
+    error="true"
   fi
 
   if [ "$error" = "true" ]; then
-	echo "  Invalid Option! Try 'pihole -v --help' for more information."
-	exit 1
+    echo "  Invalid Option! Try 'pihole -v --help' for more information."
+    exit 1
   fi
 
   echo "  $str"
@@ -133,12 +133,12 @@ ftlOutput() {
   elif [ -z "$current" -a -n "$latest" ]; then
     str="Latest FTL version is $latest"
   else
-	error="true"
+    error="true"
   fi
 
   if [ "$error" = "true" ]; then
-	echo "  Invalid Option! Try 'pihole -v --help' for more information."
-	exit 1
+    echo "  Invalid Option! Try 'pihole -v --help' for more information."
+    exit 1
   fi
 
   echo "  $str"

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -16,7 +16,7 @@ WEBGITDIR="/var/www/html/admin/"
 getLocalVersion() {
   # FTL requires a different method
   if [ "$1" == "FTL" ]; then
-    echo $(pihole-FTL version)
+    pihole-FTL version
     return 0
   fi
 
@@ -25,8 +25,7 @@ getLocalVersion() {
   local version
 
   cd "${directory}" || { echo "${DEFAULT}"; return 1; }
-  version=$(git describe --tags --always || \
-            echo "${DEFAULT}")
+  version=$(git describe --tags --always || echo "$DEFAULT")
   if [[ "${version}" =~ ^v ]]; then
     echo "${version}"
   elif [[ "${version}" == "${DEFAULT}" ]]; then
@@ -50,8 +49,7 @@ getLocalHash() {
   local hash
 
   cd "${directory}" || { echo "${DEFAULT}"; return 1; }
-  hash=$(git rev-parse --short HEAD || \
-         echo "${DEFAULT}")
+  hash=$(git rev-parse --short HEAD || echo "$DEFAULT")
   if [[ "${hash}" == "${DEFAULT}" ]]; then
     echo "ERROR"
     return 1
@@ -66,7 +64,7 @@ getRemoteVersion(){
   local daemon="${1}"
   local version
 
-  version=$(curl --silent --fail https://api.github.com/repos/pi-hole/${daemon}/releases/latest | \
+  version=$(curl --silent --fail "https://api.github.com/repos/pi-hole/${daemon}/releases/latest" | \
             awk -F: '$1 ~/tag_name/ { print $2 }' | \
             tr -cd '[[:alnum:]]._-')
   if [[ "${version}" =~ ^v ]]; then
@@ -79,19 +77,19 @@ getRemoteVersion(){
 }
 
 versionOutput() {
-  [ "$1" == "pi-hole" ] && GITDIR=${COREGITDIR}
-  [ "$1" == "AdminLTE" ] && GITDIR=${WEBGITDIR}
+  [ "$1" == "pi-hole" ] && GITDIR=$COREGITDIR
+  [ "$1" == "AdminLTE" ] && GITDIR=$WEBGITDIR
   [ "$1" == "FTL" ] && GITDIR="FTL"
   
-  [ "$2" == "-c" -o "$2" == "--current" -o -z "$2" ] && current=$(getLocalVersion $GITDIR)
-  [ "$2" == "-l" -o "$2" == "--latest" -o -z "$2" ] && latest=$(getRemoteVersion $1)
-  [ "$2" == "-h" -o "$2" == "--hash" ] && hash=$(getLocalHash $GITDIR)
+  [ "$2" == "-c" ] || [ "$2" == "--current" ] || [ -z "$2" ] && current=$(getLocalVersion $GITDIR)
+  [ "$2" == "-l" ] || [ "$2" == "--latest" ] || [ -z "$2" ] && latest=$(getRemoteVersion "$1")
+  [ "$2" == "-h" ] || [ "$2" == "--hash" ] && hash=$(getLocalHash "$GITDIR")
 
-  if [ -n "$current" -a -n "$latest" ]; then
+  if [ -n "$current" ] && [ -n "$latest" ]; then
     output="${1^} version is $current (Latest: $latest)"
-  elif [ -n "$current" -a -z "$latest" ]; then
+  elif [ -n "$current" ] && [ -z "$latest" ]; then
     output="Current ${1^} version is $current"
-  elif [ -z "$current" -a -n "$latest" ]; then
+  elif [ -z "$current" ] && [ -n "$latest" ]; then
     output="Latest ${1^} version is $latest"
   elif [ "$hash" == "N/A" ]; then
     output=""


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
8

---

While testing to make sure `pihole -v` would output `pihole-FTL version`, I noticed some options didn't work how I expected them to. For example, if I use `pihole -v -p`, I would expect to see the version output of Pi-hole Core. Instead, I'm informed that it's an invalid option.

I've had the following things in mind while rewriting this:
  * I'm operating under the assumption that FTL is only installed if the Admin Console is (Line 113 exit 0)
  * I have modified the help text to only output with `pihole -v --help`
  * I have modified all output to be more similar to the output style of `grep` and `curl` (Ditching ":::")

Testing output:
```
w3k@MCT:~$ pihole -v
  Pi-hole version is v3.0.1-14-ga928cd3 (Latest: v3.0.1)
  Admin Console version is v3.0-9-g3760482 (Latest: v3.0.1)
  FTL version is v2.6.2 (Latest: v2.6.2)
w3k@MCT:~$ pihole -v -c
  Current Pi-hole version is v3.0.1-14-ga928cd3
  Current Admin Console version is v3.0-9-g3760482
  Current FTL version is v2.6.2
w3k@MCT:~$ pihole -v -l
  Latest Pi-hole version is v3.0.1
  Latest Admin Console version is v3.0.1
  Latest FTL version is v2.6.2
w3k@MCT:~$ pihole -v -p --hash
  Current Pi-hole hash is a928cd3
w3k@MCT:~$ pihole -v -a --hash
  Current Admin Console hash is 3760482
w3k@MCT:~$ pihole -v --help
Usage: pihole -v [REPO | OPTION] [OPTION]
Show Pi-hole, Web Admin & FTL versions
  <Shows all Repositories and Options>
w3k@MCT:~$ pihole -v -foo
  Invalid Option!
```