### PR TITLE
whitelist on website blocked doesnt work

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -185,7 +185,7 @@ function add() {
 	}
 
 	$.ajax({
-		url: "admin/scripts/pi-hole/php/add.php",
+		url: "/admin/scripts/pi-hole/php/add.php",
 		method: "post",
 		data: {"domain":domain.val(), "list":"white", "pw":pw.val()},
 		success: function(response) {


### PR DESCRIPTION
Since Pi-hole redirects ad domains to itself, accessing the script via de.ign.com is the same as pi.hole in this case. The fix should be as simple as adding a / before admin on this line.

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_3_

---
_whitelist on website blocked doesnt work_


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
