### PR TITLE
Do not include list.PreEventHorizon in pihole -q results

### DIFF
--- a/pihole
+++ b/pihole
@@ -111,18 +111,20 @@ queryFunc() {
   method="${3}"
   lists=( /etc/pihole/list.* /etc/pihole/blacklist.txt)
   for list in ${lists[@]}; do
-    if [ -e "${list}" ]; then
-      result=$(scanList ${domain} ${list} ${method})
-      # Remove empty lines before couting number of results
-      count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
-      echo "::: ${list} (${count} results)"
-      if [[ ${count} > 0 ]]; then
-        echo "${result}"
+    if [ "${list}" != "/etc/pihole/list.preEventHorizon" ]; then
+      if [ -e "${list}" ]; then
+        result=$(scanList ${domain} ${list} ${method})
+        # Remove empty lines before couting number of results
+        count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
+        echo "::: ${list} (${count} results)"
+        if [[ ${count} > 0 ]]; then
+          echo "${result}"
+        fi
+        echo ""
+      else
+        echo "::: ${list} does not exist"
+        echo ""
       fi
-      echo ""
-    else
-      echo "::: ${list} does not exist"
-      echo ""
     fi
   done
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [x] 10 (very familiar)

---

An actual quality PR. Including `list.PreEventHorizon` in the `pihole -q` results can be confusing to users that don't understand what it is. [An example here](https://www.reddit.com/r/pihole/comments/6af948/block_list_identification/?utm_content=comments&utm_medium=hot&utm_source=reddit&utm_name=pihole)

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._