### PR TITLE
Provide remote hashes for version.sh

### DIFF
--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -15,7 +15,7 @@ WEBGITDIR="/var/www/html/admin/"
 
 getLocalVersion() {
   # FTL requires a different method
-  if [ "$1" == "FTL" ]; then
+  if [[ "$1" == "FTL" ]]; then
     pihole-FTL version
     return 0
   fi
@@ -24,7 +24,7 @@ getLocalVersion() {
   local directory="${1}"
   local version
 
-  cd "${directory}" || { echo "${DEFAULT}"; return 1; }
+  cd "${directory}" 2> /dev/null || { echo "${DEFAULT}"; return 1; }
   version=$(git describe --tags --always || echo "$DEFAULT")
   if [[ "${version}" =~ ^v ]]; then
     echo "${version}"
@@ -38,8 +38,8 @@ getLocalVersion() {
 }
 
 getLocalHash() {
-  # FTL hash is not applicable
-  if [ "$1" == "FTL" ]; then
+  # Local FTL hash does not exist on filesystem
+  if [[ "$1" == "FTL" ]]; then
     echo "N/A"
     return 0
   fi
@@ -48,13 +48,34 @@ getLocalHash() {
   local directory="${1}"
   local hash
 
-  cd "${directory}" || { echo "${DEFAULT}"; return 1; }
+  cd "${directory}" 2> /dev/null || { echo "${DEFAULT}"; return 1; }
   hash=$(git rev-parse --short HEAD || echo "$DEFAULT")
   if [[ "${hash}" == "${DEFAULT}" ]]; then
     echo "ERROR"
     return 1
   else
     echo "${hash}"
+  fi
+  return 0
+}
+
+getRemoteHash(){
+  # Remote FTL hash is not applicable
+  if [[ "$1" == "FTL" ]]; then
+    echo "N/A"
+    return 0
+  fi
+
+  local daemon="${1}"
+  local branch="${2}"
+
+  hash=$(git ls-remote --heads "https://github.com/pi-hole/${daemon}" | \
+         awk -v bra="$branch" '$0~bra {print substr($0,0,8);exit}')
+  if [[ -n "$hash" ]]; then
+    echo "$hash"
+  else
+    echo "ERROR"
+    return 1
   fi
   return 0
 }
@@ -77,29 +98,36 @@ getRemoteVersion(){
 }
 
 versionOutput() {
-  [ "$1" == "pi-hole" ] && GITDIR=$COREGITDIR
-  [ "$1" == "AdminLTE" ] && GITDIR=$WEBGITDIR
-  [ "$1" == "FTL" ] && GITDIR="FTL"
+  [[ "$1" == "pi-hole" ]] && GITDIR=$COREGITDIR
+  [[ "$1" == "AdminLTE" ]] && GITDIR=$WEBGITDIR
+  [[ "$1" == "FTL" ]] && GITDIR="FTL"
   
-  [ "$2" == "-c" ] || [ "$2" == "--current" ] || [ -z "$2" ] && current=$(getLocalVersion $GITDIR)
-  [ "$2" == "-l" ] || [ "$2" == "--latest" ] || [ -z "$2" ] && latest=$(getRemoteVersion "$1")
-  [ "$2" == "-h" ] || [ "$2" == "--hash" ] && hash=$(getLocalHash "$GITDIR")
+  [[ "$2" == "-c" ]] || [[ "$2" == "--current" ]] || [[ -z "$2" ]] && current=$(getLocalVersion $GITDIR)
+  [[ "$2" == "-l" ]] || [[ "$2" == "--latest" ]] || [[ -z "$2" ]] && latest=$(getRemoteVersion "$1")
+  if [[ "$2" == "-h" ]] || [[ "$2" == "--hash" ]]; then
+    [[ "$3" == "-c" ]] || [[ "$3" == "--current" ]] || [[ -z "$3" ]] && curHash=$(getLocalHash "$GITDIR")
+    [[ "$3" == "-l" ]] || [[ "$3" == "--latest" ]] || [[ -z "$3" ]] && latHash=$(getRemoteHash "$1" "$(cd "$GITDIR" 2> /dev/null && git rev-parse --abbrev-ref HEAD)")
+  fi
 
-  if [ -n "$current" ] && [ -n "$latest" ]; then
+  if [[ -n "$current" ]] && [[ -n "$latest" ]]; then
     output="${1^} version is $current (Latest: $latest)"
-  elif [ -n "$current" ] && [ -z "$latest" ]; then
+  elif [[ -n "$current" ]] && [[ -z "$latest" ]]; then
     output="Current ${1^} version is $current"
-  elif [ -z "$current" ] && [ -n "$latest" ]; then
+  elif [[ -z "$current" ]] && [[ -n "$latest" ]]; then
     output="Latest ${1^} version is $latest"
-  elif [ "$hash" == "N/A" ]; then
-    output=""
-  elif [ -n "$hash" ]; then
-    output="Current ${1^} hash is $hash"
+  elif [[ "$curHash" == "N/A" ]] || [[ "$latHash" == "N/A" ]]; then
+    output="${1^} hash is not applicable"
+  elif [[ -n "$curHash" ]] && [[ -n "$latHash" ]]; then
+    output="${1^} hash is $curHash (Latest: $latHash)"
+  elif [[ -n "$curHash" ]] && [[ -z "$latHash" ]]; then
+    output="Current ${1^} hash is $curHash"
+  elif [[ -z "$curHash" ]] && [[ -n "$latHash" ]]; then
+    output="Latest ${1^} hash is $latHash"
   else
 	  errorOutput
   fi
 
-  [ -n "$output" ] && echo "  $output"
+  [[ -n "$output" ]] && echo "  $output"
 }
 
 errorOutput() {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

 * Provide remote hashes for comparison
 * Use double braces for all conditions (for consistency)
 * Suppress potential "cd" error output
 * Provide "not applicable" output upon any hash request for FTL, as there is no local hash to retrieve (therefore rendering a remote hash request useless)

```
pihole -v -h
  Pi-hole hash is 68dd2a6 (Latest: 68dd2a6)
  AdminLTE hash is bd654c1 (Latest: bd654c1)
  FTL hash is not applicable
```