### PR TITLE
Solve piholeLogFlush.sh having to be issued 2 x to clear logs

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -10,9 +10,9 @@
 
 echo -n "::: Flushing /var/log/pihole.log ..."
 # Test if logrotate is available on this system
-if command -v /usr/sbin/logrotate &> /dev/null; then
+if command -v /usr/sbin/logrotate >/dev/null; then
   # Flush twice to move all data out of sight of FTL
-  /usr/sbin/logrotate --force /etc/pihole/logrotate
+  /usr/sbin/logrotate --force /etc/pihole/logrotate; sleep 3
   /usr/sbin/logrotate --force /etc/pihole/logrotate
 else
   # Flush both pihole.log and pihole.log.1 (if existing)


### PR DESCRIPTION
Simplified the command -v syntax, and added a sleep 3 timer to the first execution of the log rotation. The second execution was being issued while the first was still running, thus it would fail and you would have to issue the "Flush Logs" command a second time.

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
6