### PR TITLE
Document `sed` substitution for user readability

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -158,6 +158,10 @@ RemoveDomain() {
             # Remove it from the other one
             echo "::: Removing $1 from $list..."
             # Busybox sed compatible case-insensitive domain removal
+              # grep case insensitive domain from list, print line numbers
+              # split on ':' with awk and print the line number
+              # For conditions with more than one match, substitute newline with ','
+              # sed substitute final trailing ',' with newline
             sed -i "$(grep -in "^${domain}$" ${list} | awk -F':' '{print $1}' | tr '\n' ',' | sed 's/,$/\n/')d" ${list}
             reload=true
         else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Comment the oneliner with explanations of what each step does.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._