### PR TITLE
User-friendly queryFunc() output

### DIFF
--- a/pihole
+++ b/pihole
@@ -199,7 +199,7 @@ Options:
           if [[ -n "$bp" ]]; then
            printf "  [i] %s\n" "$match"
           elif [[ -n "$exact" ]]; then
-            printf "Wildcard result in ${wildcardlist/\/etc\/dnsmasq.d\//} *.%s\n" "$match"
+            printf "Wildcard result in ${wildcardlist/\/etc\/dnsmasq.d\//}\n"
           else
             printf "Result from ${wildcardlist/\/etc\/dnsmasq.d\//}\n  *.%s\n" "$match"
           fi

--- a/pihole
+++ b/pihole
@@ -87,10 +87,14 @@ scanList(){
   domain="${1}"
   list="${2}"
   method="${3}"
-  if [[ ${method} == "-exact" ]] ; then
-    grep -i -E "(^|\s)${domain}($|\s)" "${list}"
+
+  # Switch folder, preventing grep from printing file path
+  cd "/etc/pihole" || return 1
+
+  if [[ -n "${method}" ]]; then
+    grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} /dev/null 2> /dev/null
   else
-    grep -i "${domain}" "${list}"
+    grep -i "${domain}" ${list} /dev/null 2> /dev/null
   fi
 }
 
@@ -110,46 +114,210 @@ processWildcards() {
 }
 
 queryFunc() {
-  domain="${2}"
-  
-  if [[ -z "${domain}" ]]; then
-    echo -e "  ${COL_LIGHT_RED}Invalid option${COL_NC}
-  Try 'pihole query --help' for more information."
+  options="$*"
+  options="${options/-q /}"
+
+  if [[ "${options}" == "-h" ]] || [[ "${options}" == "--help" ]]; then
+    echo "Usage: pihole -q [option] <domain>
+Example: 'pihole -q -exact domain.com'
+Query the adlists for a specified domain
+
+Options:
+  -adlist             Print the name of the block list URL
+  -exact              Search the block lists for exact domain matches
+  -all                Return all query matches within a block list
+  -h, --help          Show this help dialog"
+    exit 0
+  fi
+
+  if [[ "${options}" == *"-exact"* ]]; then
+    method="exact"
+    exact=true
+  fi
+
+  if [[ "${options}" == *"-adlist"* ]]; then
+    adlist=true
+  fi
+
+  if [[ "${options}" == *"-bp"* ]]; then
+    method="exact"
+    blockpage=true
+  fi
+
+  if [[ "${options}" == *"-all"* ]]; then
+    all=true
+  fi
+
+  # Strip valid options, leaving only the domain and invalid options
+  options=$(sed 's/ \?-\(exact\|adlist\|bp\|all\) \?//g' <<< "$options")
+
+  # Handle errors
+  if [[ "${options}" == *" "* ]]; then
+    error=true
+    str="Unknown option specified"
+  elif [[ "${options}" == "-q" ]]; then
+    error=true
+    str="No domain specified"
+  fi
+
+  if [[ -n "${error}" ]]; then
+    echo -e "  ${COL_LIGHT_RED}${str}${COL_NC}
+  Try 'pihole -q --help' for more information."
     exit 1
   fi
-  
-  method="${3}"
-  lists=( /etc/pihole/list.* /etc/pihole/blacklist.txt)
-  for list in ${lists[@]}; do
-    if [ -e "${list}" ]; then
-      result=$(scanList ${domain} ${list} ${method})
-      # Remove empty lines before couting number of results
-      count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
-      echo "${list} (${count} results)"
-      if [[ ${count} > 0 ]]; then
-        echo "${result}"
-      fi
-      echo ""
-    else
-      echo -e "  ${CROSS} List does not exist"
-      echo ""
-    fi
-  done
 
-  # Scan for possible wildcard matches
-  if [ -e "${wildcardlist}" ]; then
-    local wildcards=($(processWildcards "${domain}"))
-    for domain in ${wildcards[@]}; do
-      result=$(scanList "\/${domain}\/" ${wildcardlist})
-      # Remove empty lines before couting number of results
-      count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
-      if [[ ${count} > 0 ]]; then
-        echo -e "  ${TICK} Wildcard blocking ${domain} (${count} results)"
-        echo "${result}"
-        echo ""
+  # If domain contains non ASCII characters, convert domain to punycode if python is available
+  # Cr: https://serverfault.com/a/335079
+  if [[ "$options" = *[![:ascii:]]* ]]; then
+    if command -v python &> /dev/null; then
+      query=$(python -c 'import sys;print sys.argv[1].decode("utf-8").encode("idna")' "${options}")
+    fi
+  else
+    query="${options}"
+  fi
+
+  # Scan Whitelist and Blacklist
+  lists="whitelist.txt blacklist.txt"
+  results=($(scanList "${query}" "${lists}" "${method}"))
+
+  if [[ -n "${results[*]}" ]]; then
+    # Loop through each scanList line to print appropriate title
+    for result in "${results[@]}"; do
+      filename="${result/:*/}"
+      if [[ -n "$exact" ]]; then
+        printf "  Exact result in %s\n" "${filename}"
+      elif [[ -n "$blockpage" ]]; then
+        printf "  [i] %s\n" "${filename}"
+      else
+        domain="${result/*:/}"
+        if [[ ! "${filename}" == "${filename_prev:-}" ]]; then
+          printf "  Result from %s\n" "${filename}"
+        fi
+        printf "    %s\n" "${domain}"
+        filename_prev="${filename}"
       fi
     done
   fi
+
+  # Scan Wildcards
+  if [[ -e "${wildcardlist}" ]]; then
+    wildcards=($(processWildcards "${query}"))
+
+    for match in "${wildcards[@]}"; do
+      results=($(scanList "\/${match}\/" ${wildcardlist}))
+
+      if [[ -n "${results[*]}" ]]; then
+        # Remove empty lines before couting number of results
+        count=$(sed '/^\s*$/d' <<< "${results[@]}" | wc -l)
+        if [[ "${count}" -ge 0 ]]; then
+          blResult=true
+          if [[ -z "${blockpage}" ]]; then
+            printf "  Wildcard result in %s\n" "${wildcardlist/*dnsmasq.d\/}"
+          fi
+
+          if [[ -n "${blockpage}" ]]; then
+            echo "  ${INFO} ${match}"
+          else
+            echo "    *.${match}"
+          fi
+        fi
+      fi
+    done
+
+    [[ -n "${blResult}" ]] && [[ -n "${blockpage}" ]] && exit 0
+  fi
+
+  # Glob *.domains file names, remove file paths and sort by list number
+  lists_raw=(/etc/pihole/*.domains)
+  IFS_OLD=$IFS
+  IFS=$'\n'
+  lists=$(sort -t . -k 2 -g <<< "${lists_raw[*]//\/etc\/pihole\//}")
+
+  # Scan Domains files
+  results=($(scanList "${query}" "${lists}" "${method}"))
+
+  # Handle notices
+  if [[ -z "${blResult}" ]] && [[ -z "${results[*]}" ]]; then
+    notice=true
+    str="No ${method/t/t }results found for ${query} found within block lists"
+  elif [[ -z "${all}" ]] && [[ "${#results[*]}" -ge 16000 ]]; then
+    # 16000 chars is 15 chars X 1000 lines worth of results
+    notice=true
+    str="Hundreds of ${method/t/t }results found for ${query}
+    This can be overriden using the -all option"
+  fi
+
+  if [[ -n "${notice}" ]]; then
+    echo -e "  ${INFO} ${str}"
+    exit
+  fi
+
+  # Remove unwanted content from results
+  if [[ -z "${method}" ]]; then
+    results=($(sed "/:#/d" <<< "${results[*]}")) # Lines starting with comments
+    results=($(sed "s/[ \t]#.*//g" <<< "${results[*]}")) # Comments after domain
+    results=($(sed "s/:.*[ \t]/:/g" <<< "${results[*]}")) # IP address
+  fi
+  IFS=$IFS_OLD
+
+  # Get adlist content as array
+  if [[ -n "${adlist}" ]] || [[ -n "${blockpage}" ]]; then
+    if [[ -f "/etc/pihole/adlists.list" ]]; then
+      for url in $(< /etc/pihole/adlists.list); do
+        if [[ "${url:0:4}" == "http" ]] || [[ "${url:0:3}" == "www" ]]; then
+          adlists+=("$url")
+        fi
+      done
+    else
+      echo -e "  ${COL_LIGHT_RED}The file '/etc/pihole/adlists.list' was not found${COL_NC}"
+      exit 1
+    fi
+  fi
+
+  if [[ -n "${results[*]}" ]]; then
+    if [[ -n "${exact}" ]]; then
+      echo "  Exact result(s) for ${query} found in:"
+    fi
+
+    for result in "${results[@]}"; do
+      filename="${result/:*/}"
+
+      # Convert file name to URL name for -adlist or -bp options
+      if [[ -n "${adlist}" ]] || [[ -n "${blockpage}" ]]; then
+        filenum=("${filename/list./}")
+        filenum=("${filenum/.*/}")
+        filename="${adlists[$filenum]}"
+      fi
+
+      if [[ -n "${exact}" ]]; then
+        printf "    %s\n" "${filename}"
+      elif [[ -n "${blockpage}" ]]; then
+        printf "  [%s] %s\n" "${filenum}" "${filename}"
+      else # Standard query output
+
+        # Print filename heading once per file, not for every match
+        if [[ ! "${filename}" == "${filename_prev:-}" ]]; then
+          unset count
+          printf "  Result from %s\n" "${filename}"
+        else
+          let count++
+        fi
+
+        # Print matching domain if $max_count has not been reached
+        [[ -z "${all}" ]] && max_count="20"
+        if [[ -z "${all}" ]] && [[ "${count}" -eq "${max_count}" ]]; then
+          echo "    Over $count results found, skipping rest of file"
+        elif [[ -z "${all}" ]] && [[ "${count}" -gt "${max_count}" ]]; then
+          continue
+        else
+          domain="${result/*:/}"
+          printf "    %s\n" "${domain}"
+        fi
+        filename_prev="${filename}"
+      fi
+    done
+  fi
+
   exit 0
 }
 
@@ -425,7 +593,7 @@ Options:
   -l, logging         Specify whether the Pi-hole log should be used
                         Add '-h' for more info on logging usage
   -q, query           Query the adlists for a specified domain
-                        Add '-exact' AFTER a specified domain for exact match
+                        Add '-h' for more info on query usage
   -up, updatePihole   Update Pi-hole subsystems
   -v, version         Show installed versions of Pi-hole, Admin Console & FTL
                         Add '-h' for more info on version usage

--- a/pihole
+++ b/pihole
@@ -214,7 +214,7 @@ Options:
   lists_raw=(/etc/pihole/*.domains)
   IFS_OLD=$IFS
   IFS=$'\n'
-  lists=$(sort -t . -k 2 -g <<< "${lists_raw[*]//\/etc\/pihole\//}")
+  lists=$(sort -t . -k 2 -g <<< "${lists_raw[*]}")
   IFS=$IFS_OLD
   
   # Scan Domains files
@@ -244,7 +244,7 @@ Options:
     
     # Convert file name to URL name for -adlist or -bp options
     if [[ -n "$adlist" ]] || [[ -n "$bp" ]]; then
-      file_num=("${file/*list./}")
+      file_num=("${file/list./}")
       file_num=("${file_num/.*/}")
       file="${adlists[$file_num]}"
     fi

--- a/pihole
+++ b/pihole
@@ -83,45 +83,130 @@ updateGravityFunc() {
 scanList() {
   domain="${1}"
   list="${2}"
-  method="${3}"
-
-  if [[ "${method}" == "-exact" ]]; then
-    grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list}
+  [[ "$@" == *"-exact"* ]] && exact=true
+  
+  if [[ "$exact" == true ]]; then
+    grep="$(grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} 2> /dev/null)"
+    sort -t . -k 2 -g <<< "$grep"
   else
-    grep -i "${domain}" ${list}
+    grep="$(grep -i "${domain}" ${list} 2> /dev/null)"
+    # Do not perform list number sort on gigantic matches
+    [[ "$(wc -l <<< "$grep")" -le "100" ]] && sort -t . -k 2 -g <<< "$grep" || echo "$grep"
   fi
 }
 
 queryFunc() {
-  method="${3}"
+  options="$@"
+  
+  if [[ "$options" == "-q -h"* ]] || [[ "$options" == "-q --help"* ]]; then
+    echo "Usage: pihole -q [option] <domain>
+Example: 'pihole -q -exact domain.com'
+Query the adlists for a specified domain
 
+Options:
+  -adlist             Print the name of the block list URL
+  -exact              Search the block lists for exact domain matches
+  -all                Return all query matches within a block list
+  -h, --help          Show this help dialog"
+    exit 0
+  fi
+  
+  if [[ "$options" == *"-exact"* ]]; then
+    exact=true
+    options="${options/-exact/}"
+  fi
+  
+  if [[ "$options" == *"-adlist"* ]]; then
+    adlist=true
+    options="${options/-adlist/}"
+  fi
+  
+  if [[ "$options" == *"-all"* ]]; then
+    count_all=true
+    options="${options/-all/}"
+  fi
+  options="$(tr -d "[:space:]" <<< "${options/-q/}")"
+  
   # If domain contains non ASCII characters, convert domain to punycode if python exists
   # Cr: https://serverfault.com/a/335079
-  if [[ -z "${2}" ]]; then
+  if [[ -z "$options" ]]; then
     echo "::: No domain specified"
     exit 1
-  elif [[ "${2}" = *[![:ascii:]]* ]]; then
-    [[ "$(which python)" ]] && domain=$(python -c 'import sys;print sys.argv[1].decode("utf-8").encode("idna")' "${2}")
+  elif [[ "$options" = *[![:ascii:]]* ]]; then
+    [[ "$(which python)" ]] && domain=$(python -c 'import sys;print sys.argv[1].decode("utf-8").encode("idna")' "$options")
   else
-    domain="${2}"
+    domain="$options"
   fi
-
+  
   # Scan Whitelist, Blacklist and Wildcards
   lists="/etc/pihole/whitelist.txt /etc/pihole/blacklist.txt $wildcardlist"
-  result=$(scanList ${domain} "${lists}" ${method})
-  if [[ -n "$result" ]]; then
-    echo "$result"
+  results=($(scanList ${domain} "${lists}" ${method}))
+  
+  if [[ -n "$results" ]]; then
+    for result in "${results[@]}"; do
+      if [[ "$exact" == true ]]; then
+        printf "Exact result found in %s\n" "${result/*\//}"
+      else
+        file="${result/:*/}"
+        match="${result/*:/}"
+        printf "%s:\n  %s\n" "$file" "$match"
+      fi
+    done
     [[ ! -t 1 ]] && exit 0
   fi
-
-  # Scan Domains lists
-  result=$(scanList ${domain} "/etc/pihole/*.domains" ${method})
-  if [[ -n "$result" ]]; then
-    sort -t . -k 2 -g <<< "$result"
-  else
-    [ -n "$method" ] && exact="exact "
-    echo "::: No ${exact}results found for ${domain}"
+  
+  # Scan Domains files
+  results=("$(scanList ${domain} "/etc/pihole/*.domains" ${method})")
+  
+  if [[ -z "$results" ]]; then
+    [[ -n "$exact" ]] && exact="exact "
+    echo "::: No ${exact}results found for ${domain} found within block lists"
+    exit 0
   fi
+  
+  # Get adlist content as array
+  if [[ "$adlist" == true ]]; then
+    for url in $(< /etc/pihole/adlists.list); do
+      if [[ "${url:0:4}" == "http" ]] || [[ "${url:0:3}" == "www" ]]; then
+        adlists+=("$url")
+      fi
+    done
+  fi
+  
+  for result in ${results[@]}; do
+    res_file="${result/:*/}"
+    if [[ "$adlist" == true ]]; then
+      num=("${res_file/*list./}")
+      num=("${num/.*/}")
+      res_file="${adlists[$num]}"
+    fi
+    
+    if [[ "$exact" == true ]]; then
+      printf "Exact result found in %s\n" "$res_file"
+    else
+      # Standard search output
+      if [[ -z "$res_file_prev" ]] || [[ "$res_file" != "$res_file_prev" ]]; then
+        unset res_count skip_res
+        printf "%s:\n" "$res_file"
+      elif [[ "$skip_res" == "true" ]]; then
+        continue
+      else
+        let res_count++
+      fi
+      
+      [[ -n "$count_all" ]] && max_count="9999" || max_count="10"
+      if [[ "$res_count" -ge "$max_count" ]]; then
+        echo "  Over $res_count results found, skipping rest of file"
+        res_file_prev="$res_file"
+        skip_res="true"
+        unset res_count
+      else
+        res_domain="${result/*:/}"
+        printf "  %s\n" "$res_domain"
+        res_file_prev="$res_file"
+      fi
+    fi
+  done
 
   exit 0
 }
@@ -328,7 +413,7 @@ Options:
   -l, logging         Specify whether the Pi-hole log should be used
                         Add '-h' for more info on logging usage
   -q, query           Query the adlists for a specified domain
-                        Add '-exact' AFTER a specified domain for exact match
+                        Add '-h' for more info on query usage
   -up, updatePihole   Update Pi-hole subsystems
   -v, version         Show installed versions of Pi-hole, Admin Console & FTL
                         Add '-h' for more info on version usage

--- a/pihole
+++ b/pihole
@@ -89,9 +89,9 @@ scanList() {
   cd "/etc/pihole"
   
   if [[ -n "${method}" ]]; then
-    grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} 2> /dev/null
+    grep -i -E -l -o "(^|\s|\/)${domain}($|\s|\/)" ${list} 2> /dev/null
   else
-    grep -i "${domain}" ${list} 2> /dev/null
+    grep -i -o "${domain}" ${list} 2> /dev/null
   fi
 }
 
@@ -214,12 +214,12 @@ Options:
   lists_raw=(/etc/pihole/*.domains)
   IFS_OLD=$IFS
   IFS=$'\n'
-  lists=$(sort -t . -k 2 -g <<< "${lists_raw[*]}")
+  lists=$(sort -t . -k 2 -g <<< "${lists_raw[*]//\/etc\/pihole\//}")
   IFS=$IFS_OLD
   
   # Scan Domains files
   results=("$(scanList "${domain}" "${lists}" "${method}")")
-  
+
   if [[ -z "$results" ]]; then
     echo "::: No ${method/t/t }results found for ${domain} found within block lists"
     exit 0
@@ -228,7 +228,7 @@ Options:
     echo "::: Over 1000 ${method/t/t }results found for ${domain} found within block lists"
     exit 0
   fi
-
+  
   # Get adlist content as array
   if [[ -n "$adlist" ]] || [[ -n "$bp" ]]; then
     for url in $(< /etc/pihole/adlists.list); do

--- a/pihole
+++ b/pihole
@@ -89,9 +89,9 @@ scanList() {
   cd "/etc/pihole"
   
   if [[ -n "${method}" ]]; then
-    grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} 2> /dev/null
+    grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} /dev/null 2> /dev/null
   else
-    grep -i "${domain}" ${list} 2> /dev/null
+    grep -i "${domain}" ${list} /dev/null 2> /dev/null
   fi
 }
 
@@ -229,8 +229,12 @@ Options:
     exit 0
   fi
   
-  # Remove IP address/space/tab from HOSTS format list on general queries
-  [[ -z "$method" ]] && results=$(sed "s/:.*[ \t]/:/g" <<< "$results")
+  # Remove unwanted content from results
+  if [[ -z "$method" ]]; then
+    results=$(sed "/:#/d" <<< "$results") # Delete comments
+    results=$(sed "s/:.*[ \t]/:/g" <<< "$results") # Remove IP address/space/tab
+    results=$(sed "s/[ \t]#.*//g" <<< "$results") # Remove comments after match
+  fi
   
   # Get adlist content as array
   if [[ -n "$adlist" ]] || [[ -n "$bp" ]]; then

--- a/pihole
+++ b/pihole
@@ -264,8 +264,8 @@ Options:
         let res_count++
       fi
       
-      [[ -n "$all" ]] && max_count="10"
-      if [[ -n "$all" ]] && [[ "$res_count" -ge "$max_count" ]]; then
+      [[ -z "$all" ]] && max_count="10"
+      if [[ -z "$all" ]] && [[ "$res_count" -ge "$max_count" ]]; then
         echo "  Over $res_count results found, skipping rest of file"
         res_file_prev="$file"
         skip_res="true"

--- a/pihole
+++ b/pihole
@@ -89,9 +89,9 @@ scanList() {
   cd "/etc/pihole"
   
   if [[ -n "${method}" ]]; then
-    grep -i -E -l -o "(^|\s|\/)${domain}($|\s|\/)" ${list} 2> /dev/null
+    grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} 2> /dev/null
   else
-    grep -i -o "${domain}" ${list} 2> /dev/null
+    grep -i "${domain}" ${list} 2> /dev/null
   fi
 }
 
@@ -225,9 +225,12 @@ Options:
     exit 0
   elif [[ -z "$all" ]] && [[ "${#results}" -ge 16000 ]]; then
     # 16000 chars is 15 chars X 1000 lines worth of results, overridden with -all option
-    echo "::: Over 1000 ${method/t/t }results found for ${domain} found within block lists"
+    echo "::: Hundreds of ${method/t/t }results found for ${domain} found within block lists"
     exit 0
   fi
+  
+  # Remove IP address/space/tab from HOSTS format list on general queries
+  [[ -z "$method" ]] && results=$(sed "s/:.*[ \t]/:/g" <<< "$results")
   
   # Get adlist content as array
   if [[ -n "$adlist" ]] || [[ -n "$bp" ]]; then
@@ -238,7 +241,6 @@ Options:
     done
   fi
   
-  # Loop through each scanList line to print title when necessary
   for result in ${results[@]}; do
     file="${result/:*/}"
     

--- a/pihole
+++ b/pihole
@@ -8,6 +8,9 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
+colfile="/opt/pihole/COL_TABLE"
+source ${colfile}
+
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 readonly wildcardlist="/etc/dnsmasq.d/03-pihole-wildcard.conf"
 
@@ -17,7 +20,7 @@ if [[ ! $EUID -eq 0 ]];then
     exec sudo bash "$0" "$@"
     exit $?
   else
-    echo "::: sudo is needed to run pihole commands.  Please run this script as root or install sudo."
+    echo -e "  ${CROSS} sudo is needed to run pihole commands.  Please run this script as root or install sudo."
     exit 1
   fi
 fi
@@ -84,14 +87,10 @@ scanList(){
   domain="${1}"
   list="${2}"
   method="${3}"
-  
-  # Switch folder, preventing grep from printing file path
-  cd "/etc/pihole"
-  
-  if [[ -n "${method}" ]]; then
-    grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} /dev/null 2> /dev/null
+  if [[ ${method} == "-exact" ]] ; then
+    grep -i -E "(^|\s)${domain}($|\s)" "${list}"
   else
-    grep -i "${domain}" ${list} /dev/null 2> /dev/null
+    grep -i "${domain}" "${list}"
   fi
 }
 
@@ -111,181 +110,46 @@ processWildcards() {
 }
 
 queryFunc() {
-  options="$@"
+  domain="${2}"
   
-  if [[ "$options" == "-q -h"* ]] || [[ "$options" == "-q --help"* ]]; then
-    echo "Usage: pihole -q [option] <domain>
-Example: 'pihole -q -exact domain.com'
-Query the adlists for a specified domain
-
-Options:
-  -adlist             Print the name of the block list URL
-  -exact              Search the block lists for exact domain matches
-  -all                Return all query matches within a block list
-  -h, --help          Show this help dialog"
-    exit 0
-  fi
-  
-  if [[ "$options" == *"-exact"* ]]; then
-    method="exact"
-    exact=true
-    options="${options/-exact/}"
-  fi
-  
-  if [[ "$options" == *"-adlist"* ]]; then
-    adlist=true
-    options="${options/-adlist/}"
-  fi
-  
-  if [[ "$options" == *"-bp"* ]]; then
-    method="exact"
-    bp=true
-    options="${options/-bp/}"
-  fi
-  
-  if [[ "$options" == *"-all"* ]]; then
-    all=true
-    options="${options/-all/}"
-  fi
-  options="$(tr -d "[:space:]" <<< "${options/-q/}")"
-  
-  # If domain contains non ASCII characters, convert domain to punycode if python is available
-  # Cr: https://serverfault.com/a/335079
-  if [[ -z "$options" ]]; then
-    echo "::: No domain specified"
+  if [[ -z "${domain}" ]]; then
+    echo -e "  ${COL_LIGHT_RED}Invalid option${COL_NC}
+  Try 'pihole query --help' for more information."
     exit 1
-  elif [[ "$options" = *[![:ascii:]]* ]]; then
-    [[ "$(which python)" ]] && domain=$(python -c 'import sys;print sys.argv[1].decode("utf-8").encode("idna")' "$options")
-  else
-    domain="$options"
   fi
   
-  # Scan Whitelist and Blacklist
-  lists="whitelist.txt blacklist.txt"
-  results=$(scanList "${domain}" "${lists}" "${method}")
-  results="${results//\/etc\/dnsmasq.d\//}" # Remove file path
-  
-  if [[ -n "$results" ]]; then
-    # Loop through each scanList line to print appropriate title
-    for result in ${results[@]}; do
-      file="${result/:*/}"
-      if [[ -n "$exact" ]] || [[ -n "$bp" ]]; then
-        if [[ -n "$bp" ]]; then
-          printf "  [i] %s\n" "$file"
-        else
-          printf "Exact result in %s\n" "$file"
-        fi
-      else
-        match="${result/*:/}"
-        printf "Result from %s\n  %s\n" "$file" "$match"
+  method="${3}"
+  lists=( /etc/pihole/list.* /etc/pihole/blacklist.txt)
+  for list in ${lists[@]}; do
+    if [ -e "${list}" ]; then
+      result=$(scanList ${domain} ${list} ${method})
+      # Remove empty lines before couting number of results
+      count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
+      echo "${list} (${count} results)"
+      if [[ ${count} > 0 ]]; then
+        echo "${result}"
       fi
-    done
-    
-    # If command is called from Block Page, exit upon matching result
-    [[ -n "$bp" ]] && exit 0
-  fi
-  
-  # Scan Wildcards
-  if [[ -e "$wildcardlist" ]]; then
-    wildcards=($(processWildcards "${domain}"))
-    
-    for match in ${wildcards[@]}; do
-      result=$(scanList "\/${match}\/" ${wildcardlist})
-      
-      if [[ -n "$result" ]]; then
-        # Remove empty lines before couting number of results
-        count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
-        if [[ "${count}" > 0 ]]; then
-          if [[ -n "$bp" ]]; then
-           printf "  [i] %s\n" "$match"
-          elif [[ -n "$exact" ]]; then
-            printf "Wildcard result in ${wildcardlist/\/etc\/dnsmasq.d\//}\n"
-          else
-            printf "Result from ${wildcardlist/\/etc\/dnsmasq.d\//}\n  *.%s\n" "$match"
-          fi
-        fi
-        
-        [[ -n "$bp" ]] && exit 0
-      fi
-    done
-  fi
-  
-  # Glob *.domains file names, remove file paths and sort by list number
-  lists_raw=(/etc/pihole/*.domains)
-  IFS_OLD=$IFS
-  IFS=$'\n'
-  lists=$(sort -t . -k 2 -g <<< "${lists_raw[*]//\/etc\/pihole\//}")
-  IFS=$IFS_OLD
-  
-  # Scan Domains files
-  results=("$(scanList "${domain}" "${lists}" "${method}")")
-
-  if [[ -z "$results" ]]; then
-    echo "::: No ${method/t/t }results found for ${domain} found within block lists"
-    exit 0
-  elif [[ -z "$all" ]] && [[ "${#results}" -ge 16000 ]]; then
-    # 16000 chars is 15 chars X 1000 lines worth of results, overridden with -all option
-    echo "::: Hundreds of ${method/t/t }results found for ${domain} found within block lists"
-    exit 0
-  fi
-  
-  # Remove unwanted content from results
-  if [[ -z "$method" ]]; then
-    results=$(sed "/:#/d" <<< "$results") # Delete comments
-    results=$(sed "s/:.*[ \t]/:/g" <<< "$results") # Remove IP address/space/tab
-    results=$(sed "s/[ \t]#.*//g" <<< "$results") # Remove comments after match
-  fi
-  
-  # Get adlist content as array
-  if [[ -n "$adlist" ]] || [[ -n "$bp" ]]; then
-    for url in $(< /etc/pihole/adlists.list); do
-      if [[ "${url:0:4}" == "http" ]] || [[ "${url:0:3}" == "www" ]]; then
-        adlists+=("$url")
-      fi
-    done
-  fi
-  
-  for result in ${results[@]}; do
-    file="${result/:*/}"
-    
-    # Convert file name to URL name for -adlist or -bp options
-    if [[ -n "$adlist" ]] || [[ -n "$bp" ]]; then
-      file_num=("${file/list./}")
-      file_num=("${file_num/.*/}")
-      file="${adlists[$file_num]}"
-    fi
-    
-    if [[ -n "$exact" ]] || [[ -n "$bp" ]]; then
-      if [[ -n "$bp" ]]; then
-        printf "  [%s] %s\n" "$file_num" "$file"
-      else
-        printf "Exact result in %s\n" "$file"
-      fi
+      echo ""
     else
-      # Standard search output
-      if [[ -z "$res_file_prev" ]] || [[ "$file" != "$res_file_prev" ]]; then
-        unset res_count skip_res
-        printf "Result from %s\n" "$file"
-      elif [[ "$skip_res" == "true" ]]; then
-        continue
-      else
-        let res_count++
-      fi
-      
-      [[ -z "$all" ]] && max_count="10"
-      if [[ -z "$all" ]] && [[ "$res_count" -ge "$max_count" ]]; then
-        echo "  Over $res_count results found, skipping rest of file"
-        res_file_prev="$file"
-        skip_res="true"
-        unset res_count
-      else
-        res_domain="${result/*:/}"
-        printf "  %s\n" "$res_domain"
-        res_file_prev="$file"
-      fi
+      echo -e "  ${CROSS} List does not exist"
+      echo ""
     fi
   done
-  
+
+  # Scan for possible wildcard matches
+  if [ -e "${wildcardlist}" ]; then
+    local wildcards=($(processWildcards "${domain}"))
+    for domain in ${wildcards[@]}; do
+      result=$(scanList "\/${domain}\/" ${wildcardlist})
+      # Remove empty lines before couting number of results
+      count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
+      if [[ ${count} > 0 ]]; then
+        echo -e "  ${TICK} Wildcard blocking ${domain} (${count} results)"
+        echo "${result}"
+        echo ""
+      fi
+    done
+  fi
   exit 0
 }
 
@@ -311,18 +175,22 @@ restartDNS() {
   dnsmasqPid=$(pidof dnsmasq)
   if [[ "${dnsmasqPid}" ]]; then
     # Service already running - reload config
+    echo -ne "  ${INFO} Restarting dnsmasq"
     if [[ -x "$(command -v systemctl)" ]]; then
       systemctl restart dnsmasq
     else
       service dnsmasq restart
     fi
+    [[ "$?" == 0 ]] && echo -e "${OVER}  ${TICK} Restarted dnsmasq" || echo -e "${OVER}  ${CROSS} Failed to restart dnsmasq"
   else
     # Service not running, start it up
+    echo -ne "  ${INFO} Starting dnsmasq"
     if [[ -x "$(command -v systemctl)" ]]; then
       systemctl start dnsmasq
     else
       service dnsmasq start
     fi
+    [[ "$?" == 0 ]] && echo -e "${OVER}  ${TICK} Restarted dnsmasq" || echo -e "${OVER}  ${CROSS} Failed to restart dnsmasq"
   fi
 }
 
@@ -336,6 +204,7 @@ Time:
   #s                  Disable Pi-hole functionality for # second(s)
   #m                  Disable Pi-hole functionality for # minute(s)"
     exit 0
+
   elif [[ "${1}" == "0" ]]; then
     # Disable Pi-hole
     sed -i 's/^addn-hosts=\/etc\/pihole\/gravity.list/#addn-hosts=\/etc\/pihole\/gravity.list/' /etc/dnsmasq.d/01-pihole.conf
@@ -343,34 +212,57 @@ Time:
     if [[ -e "$wildcardlist" ]]; then
       mv "$wildcardlist" "/etc/pihole/wildcard.list"
     fi
-    echo "::: Blocking has been disabled!"
     if [[ $# > 1 ]]; then
-      if [[ "${2}" == *"s"* ]]; then
+      local error=false
+      if [[ "${2}" == *"s" ]]; then
         tt=${2%"s"}
-        echo "::: Blocking will be re-enabled in ${tt} seconds"
-        nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
-      elif [[ "${2}" == *"m"* ]]; then
+        if [[ "${tt}" =~ ^-?[0-9]+$ ]];then
+          local str="Disabling blocking for ${tt} seconds"
+          echo -e "  ${INFO} ${str}..."
+          local str="Blocking will be re-enabled in ${tt} seconds"
+          nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
+        else
+          local error=true
+        fi
+      elif [[ "${2}" == *"m" ]]; then
         tt=${2%"m"}
-        echo "::: Blocking will be re-enabled in ${tt} minutes"
-        tt=$((${tt}*60))
-        nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
+          if [[ "${tt}" =~ ^-?[0-9]+$ ]];then
+          local str="Disabling blocking for ${tt} minutes"
+          echo -e "  ${INFO} ${str}..."
+          local str="Blocking will be re-enabled in ${tt} minutes"
+          tt=$((${tt}*60))
+          nohup bash -c "sleep ${tt}; pihole enable" </dev/null &>/dev/null &
+        else
+          local error=true
+        fi
+      elif [[ -n "${2}" ]]; then
+        local error=true
       else
-        echo "::: Unknown format for delayed reactivation of the blocking!"
-        echo "::: Example:"
-        echo ":::    pihole disable 5s    -    will disable blocking for 5 seconds"
-        echo ":::    pihole disable 7m    -    will disable blocking for 7 minutes"
-        echo "::: Blocking will not automatically be re-enabled!"
+        echo -e "  ${INFO} Disabling blocking"
       fi
+
+      if [[ ${error} == true ]];then
+        echo -e "  ${COL_LIGHT_RED}Unknown format for delayed reactivation of the blocking!${COL_NC}"
+        echo -e "  Try 'pihole disable --help' for more information."
+        exit 1
+      fi
+
+      local str="Pi-hole Disabled"
     fi
   else
     # Enable Pi-hole
-    echo "::: Blocking has been enabled!"
+    echo -e "  ${INFO} Enabling blocking"
+    local str="Pi-hole Enabled"
+    
     sed -i 's/^#addn-hosts/addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
     if [[ -e "/etc/pihole/wildcard.list" ]]; then
       mv "/etc/pihole/wildcard.list" "$wildcardlist"
     fi
   fi
+  
   restartDNS
+  
+  echo -e "${OVER}  ${TICK} ${str}"
 }
 
 piholeLogging() {
@@ -389,29 +281,33 @@ Options:
     sed -i 's/^log-queries/#log-queries/' /etc/dnsmasq.d/01-pihole.conf
     sed -i 's/^QUERY_LOGGING=true/QUERY_LOGGING=false/' /etc/pihole/setupVars.conf
     pihole -f
-    echo "::: Logging has been disabled!"
+    echo -e "  ${INFO} Disabling logging..."
+    local str="Logging has been disabled!"
   elif [[ "${1}" == "on" ]]; then
     # Enable logging
     sed -i 's/^#log-queries/log-queries/' /etc/dnsmasq.d/01-pihole.conf
     sed -i 's/^QUERY_LOGGING=false/QUERY_LOGGING=true/' /etc/pihole/setupVars.conf
-    echo "::: Logging has been enabled!"
+    echo -e "  ${INFO} Enabling logging..."
+    local str="Logging has been enabled!"
   else
-    echo "::: Invalid option passed, please pass 'on' or 'off'"
+    echo -e "  ${COL_LIGHT_RED}Invalid option${COL_NC}
+  Try 'pihole logging --help' for more information."
     exit 1
   fi
   restartDNS
+  echo -e "${OVER}  ${TICK} ${str}"
 }
 
 piholeStatus() {
   if [[ "$(netstat -plnt | grep -c ':53 ')" -gt "0" ]]; then
     if [[ "${1}" != "web" ]]; then
-      echo "::: DNS service is running"
+      echo -e "  ${TICK} DNS service is running"
     fi
   else
     if [[ "${1}" == "web" ]]; then
       echo "-1";
     else
-      echo "::: DNS service is NOT running"
+      echo -e "  ${CROSS} DNS service is NOT running"
     fi
     return
   fi
@@ -421,21 +317,21 @@ piholeStatus() {
     if [[ "${1}" == "web" ]]; then
       echo 0;
     else
-      echo "::: Pi-hole blocking is Disabled";
+      echo -e "  ${CROSS} Pi-hole blocking is Disabled";
     fi
   elif [[ "$(grep -i "^addn-hosts=/" /etc/dnsmasq.d/01-pihole.conf)" ]]; then
     # List set
     if [[ "${1}" == "web" ]]; then
       echo 1;
     else
-      echo "::: Pi-hole blocking is Enabled";
+      echo -e "  ${TICK} Pi-hole blocking is Enabled";
     fi
   else
     # Addn-host not found
     if [[ "${1}" == "web" ]]; then
       echo 99
     else
-      echo ":::  No hosts file linked to dnsmasq, adding it in enabled state"
+      echo -e "  ${INFO} No hosts file linked to dnsmasq, adding it in enabled state"
     fi
     # Add addn-host= to dnsmasq
     echo "addn-hosts=/etc/pihole/gravity.list" >> /etc/dnsmasq.d/01-pihole.conf
@@ -444,7 +340,7 @@ piholeStatus() {
 }
 
 tailFunc() {
-  echo "Press Ctrl-C to exit"
+  echo -e "  ${INFO} Press Ctrl-C to exit"
   tail -F /var/log/pihole.log
   exit 0
 }
@@ -472,12 +368,12 @@ Branches:
 
 tricorderFunc() {
   if [[ ! -p "/dev/stdin" ]]; then
-    echo "Please do not call Tricorder directly."
+    echo -e "  ${INFO} Please do not call Tricorder directly"
     exit 1
   fi
 
   if ! timeout 2 nc -z tricorder.pi-hole.net 9998 &> /dev/null; then
-    echo "Unable to connect to Pi-hole's Tricorder server."
+    echo -e "  ${CROSS} Unable to connect to Pi-hole's Tricorder server"
     exit 1
   fi
 
@@ -485,9 +381,10 @@ tricorderFunc() {
     openssl s_client -quiet -connect tricorder.pi-hole.net:9998 2> /dev/null < /dev/stdin
     exit "$?"
   else
-    echo "Your debug log will be transmitted unencrypted via plain-text"
-    echo "There is a possibility that this could be intercepted by a third party"
-    echo "If you wish to cancel, press Ctrl-C to exit within 10 seconds"
+    echo -e "  ${INFO} ${COL_YELLOW}Security Notice${COL_NC}: ${COL_WHITE}openssl${COL_NC} is not installed
+       Your debug log will be transmitted unencrypted via plain-text
+       There is a possibility that this could be intercepted by a third party
+       If you wish to cancel, press Ctrl-C to exit within 10 seconds"
     secs="10"
     while [[ "$secs" -gt "0" ]]; do
        echo -ne "."
@@ -528,7 +425,7 @@ Options:
   -l, logging         Specify whether the Pi-hole log should be used
                         Add '-h' for more info on logging usage
   -q, query           Query the adlists for a specified domain
-                        Add '-h' for more info on query usage
+                        Add '-exact' AFTER a specified domain for exact match
   -up, updatePihole   Update Pi-hole subsystems
   -v, version         Show installed versions of Pi-hole, Admin Console & FTL
                         Add '-h' for more info on version usage

--- a/pihole
+++ b/pihole
@@ -198,6 +198,8 @@ Options:
         if [[ "${count}" > 0 ]]; then
           if [[ -n "$bp" ]]; then
            printf "  [i] %s\n" "$match"
+          elif [[ -n "$exact" ]]; then
+            printf "Wildcard result in ${wildcardlist/\/etc\/dnsmasq.d\//} *.%s\n" "$match"
           else
             printf "Result from ${wildcardlist/\/etc\/dnsmasq.d\//}\n  *.%s\n" "$match"
           fi

--- a/pihole
+++ b/pihole
@@ -83,16 +83,31 @@ updateGravityFunc() {
 scanList() {
   domain="${1}"
   list="${2}"
-  [[ "$@" == *"-exact"* ]] && exact=true
+  method="${3}"
   
-  if [[ "$exact" == true ]]; then
-    grep="$(grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} 2> /dev/null)"
-    sort -t . -k 2 -g <<< "$grep"
+  # Switch folder, preventing grep from printing file path
+  cd "/etc/pihole"
+  
+  if [[ -n "${method}" ]]; then
+    grep -i -E -l "(^|\s|\/)${domain}($|\s|\/)" ${list} 2> /dev/null
   else
-    grep="$(grep -i "${domain}" ${list} 2> /dev/null)"
-    # Do not perform list number sort on gigantic matches
-    [[ "$(wc -l <<< "$grep")" -le "100" ]] && sort -t . -k 2 -g <<< "$grep" || echo "$grep"
+    grep -i "${domain}" ${list} 2> /dev/null
   fi
+}
+
+processWildcards() {
+  IFS="." read -r -a array <<< "${1}"
+  for (( i=${#array[@]}-1; i>=0; i-- )); do
+    ar=""
+    for (( j=${#array[@]}-1; j>${#array[@]}-i-2; j-- )); do
+      if [[ $j == $((${#array[@]}-1)) ]]; then
+        ar="${array[$j]}"
+      else
+        ar="${array[$j]}.${ar}"
+      fi
+    done
+    echo "${ar}"
+  done
 }
 
 queryFunc() {
@@ -112,6 +127,7 @@ Options:
   fi
   
   if [[ "$options" == *"-exact"* ]]; then
+    method="exact"
     exact=true
     options="${options/-exact/}"
   fi
@@ -121,13 +137,19 @@ Options:
     options="${options/-adlist/}"
   fi
   
+  if [[ "$options" == *"-bp"* ]]; then
+    method="exact"
+    bp=true
+    options="${options/-bp/}"
+  fi
+  
   if [[ "$options" == *"-all"* ]]; then
-    count_all=true
+    all=true
     options="${options/-all/}"
   fi
   options="$(tr -d "[:space:]" <<< "${options/-q/}")"
   
-  # If domain contains non ASCII characters, convert domain to punycode if python exists
+  # If domain contains non ASCII characters, convert domain to punycode if python is available
   # Cr: https://serverfault.com/a/335079
   if [[ -z "$options" ]]; then
     echo "::: No domain specified"
@@ -138,34 +160,75 @@ Options:
     domain="$options"
   fi
   
-  # Scan Whitelist, Blacklist and Wildcards
-  lists="/etc/pihole/whitelist.txt /etc/pihole/blacklist.txt $wildcardlist"
-  results=($(scanList ${domain} "${lists}" ${method}))
+  # Scan Whitelist and Blacklist
+  lists="whitelist.txt blacklist.txt"
+  results=$(scanList "${domain}" "${lists}" "${method}")
+  results="${results//\/etc\/dnsmasq.d\//}" # Remove file path
   
   if [[ -n "$results" ]]; then
-    for result in "${results[@]}"; do
-      if [[ "$exact" == true ]]; then
-        printf "Exact result found in %s\n" "${result/*\//}"
+    # Loop through each scanList line to print appropriate title
+    for result in ${results[@]}; do
+      file="${result/:*/}"
+      if [[ -n "$exact" ]] || [[ -n "$bp" ]]; then
+        if [[ -n "$bp" ]]; then
+          printf "  [i] %s\n" "$file"
+        else
+          printf "Exact result in %s\n" "$file"
+        fi
       else
-        file="${result/:*/}"
         match="${result/*:/}"
-        printf "%s:\n  %s\n" "$file" "$match"
+        printf "Result from %s\n  %s\n" "$file" "$match"
       fi
     done
-    [[ ! -t 1 ]] && exit 0
+    
+    # If command is called from Block Page, exit upon matching result
+    [[ -n "$bp" ]] && exit 0
   fi
+  
+  # Scan Wildcards
+  if [[ -e "$wildcardlist" ]]; then
+    wildcards=($(processWildcards "${domain}"))
+    
+    for match in ${wildcards[@]}; do
+      result=$(scanList "\/${match}\/" ${wildcardlist})
+      
+      if [[ -n "$result" ]]; then
+        # Remove empty lines before couting number of results
+        count=$(sed '/^\s*$/d' <<< "$result" | wc -l)
+        if [[ "${count}" > 0 ]]; then
+          if [[ -n "$bp" ]]; then
+           printf "  [i] %s\n" "$match"
+          else
+            printf "Result from ${wildcardlist/\/etc\/dnsmasq.d\//}\n  *.%s\n" "$match"
+          fi
+        fi
+        
+        [[ -n "$bp" ]] && exit 0
+      fi
+    done
+  fi
+  
+  # Glob *.domains file names, remove file paths and sort by list number
+  lists_raw=(/etc/pihole/*.domains)
+  IFS_OLD=$IFS
+  IFS=$'\n'
+  lists=$(sort -t . -k 2 -g <<< "${lists_raw[*]//\/etc\/pihole\//}")
+  IFS=$IFS_OLD
   
   # Scan Domains files
-  results=("$(scanList ${domain} "/etc/pihole/*.domains" ${method})")
+  results=("$(scanList "${domain}" "${lists}" "${method}")")
   
   if [[ -z "$results" ]]; then
-    [[ -n "$exact" ]] && exact="exact "
-    echo "::: No ${exact}results found for ${domain} found within block lists"
+    echo "::: No ${method/t/t }results found for ${domain} found within block lists"
+    exit 0
+  elif [[ -z "$all" ]] && [[ "${#results}" -ge 16000 ]]; then
+    # 16000 chars is 15 chars X 1000 lines worth of results, overridden with -all option
+    echo "::: Over 1000 ${method/t/t }results found for ${domain} found within block lists"
     exit 0
   fi
-  
+
   # Get adlist content as array
-  if [[ "$adlist" == true ]]; then
+  if [[ -n "$adlist" ]] || [[ -n "$bp" ]]; then
     for url in $(< /etc/pihole/adlists.list); do
       if [[ "${url:0:4}" == "http" ]] || [[ "${url:0:3}" == "www" ]]; then
         adlists+=("$url")
@@ -173,41 +236,48 @@ Options:
     done
   fi
   
+  # Loop through each scanList line to print title when necessary
   for result in ${results[@]}; do
-    res_file="${result/:*/}"
-    if [[ "$adlist" == true ]]; then
-      num=("${res_file/*list./}")
-      num=("${num/.*/}")
-      res_file="${adlists[$num]}"
+    file="${result/:*/}"
+    
+    # Convert file name to URL name for -adlist or -bp options
+    if [[ -n "$adlist" ]] || [[ -n "$bp" ]]; then
+      file_num=("${file/*list./}")
+      file_num=("${file_num/.*/}")
+      file="${adlists[$file_num]}"
     fi
     
-    if [[ "$exact" == true ]]; then
-      printf "Exact result found in %s\n" "$res_file"
+    if [[ -n "$exact" ]] || [[ -n "$bp" ]]; then
+      if [[ -n "$bp" ]]; then
+        printf "  [%s] %s\n" "$file_num" "$file"
+      else
+        printf "Exact result in %s\n" "$file"
+      fi
     else
       # Standard search output
-      if [[ -z "$res_file_prev" ]] || [[ "$res_file" != "$res_file_prev" ]]; then
+      if [[ -z "$res_file_prev" ]] || [[ "$file" != "$res_file_prev" ]]; then
         unset res_count skip_res
-        printf "%s:\n" "$res_file"
+        printf "Result from %s\n" "$file"
       elif [[ "$skip_res" == "true" ]]; then
         continue
       else
         let res_count++
       fi
       
-      [[ -n "$count_all" ]] && max_count="9999" || max_count="10"
-      if [[ "$res_count" -ge "$max_count" ]]; then
+      [[ -n "$all" ]] && max_count="10"
+      if [[ -n "$all" ]] && [[ "$res_count" -ge "$max_count" ]]; then
         echo "  Over $res_count results found, skipping rest of file"
-        res_file_prev="$res_file"
+        res_file_prev="$file"
         skip_res="true"
         unset res_count
       else
         res_domain="${result/*:/}"
         printf "  %s\n" "$res_domain"
-        res_file_prev="$res_file"
+        res_file_prev="$file"
       fi
     fi
   done
-
+  
   exit 0
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Features:
 * User friendly query output, similar to master branch behaviour
 * Speedy query results (1.35s to perform `pihole -q doubleclick.net -exact` on 38MB of block lists compared to 1.33s on current dev branch and 7.59s on master)
 * `-adlist` option, to return the URL's of the block lists that contain the query
 * Positions of -exact and -adlist can be placed before or after the query
 * If a general query has over 10 matches in one file, the rest of the file is skipped
 * `-all` option, to remove match limit
 * `pihole -q --help` text
 * Grep errors are silenced

Tests:
 * `pihole -q -h`
 * `pihole -q doubleclick.com`
 * `pihole -q -exact doubleclick.com`
 * `pihole -q doubleclick.com -exact`
 * `pihole -q doubleclick.com -adlist -exact`
 * `pihole -q <whitelisted domain>`
 * `pihole -q <blacklisted domain>`
 * `pihole -q <wildcard domain>`
 
Output:
 
`pihole -q -h`
```
Usage: pihole -q [option] <domain>
Example: 'pihole -q -exact domain.com'
Query the adlists for a specified domain

Options:
  -adlist             Print the name of the block list URL
  -exact              Search the block lists for exact domain matches
  -all                Return all query matches within a block list
  -h, --help          Show this help dialog
```

`pihole -q doubleclick.com`
```
Result from list.5.v.firebog.net.domains
  doubleclick.com
  www.doubleclick.com
Result from list.14.v.firebog.net.domains
  ad-apac.doubleclick.com
  ad-emea.doubleclick.com
  ad.doubleclick.com
  ads.doubleclick.com
  advertisers.doubleclick.com
  advertisersapitest.doubleclick.com
  amazon.doubleclick.com
  betareportcentral.doubleclick.com
  click.comms.doubleclick.com
  doubleclick.com
  Over 10 results found, skipping rest of file
Result from list.52.v.firebog.net.domains
  doubleclick.com
```

`pihole -q -exact doubleclick.com` (and `pihole -q doubleclick.com -exact`)
```
Exact result in list.5.v.firebog.net.domains
Exact result in list.14.v.firebog.net.domains
Exact result in list.52.v.firebog.net.domains
```

`pihole -q doubleclick.com -adlist -exact`
```
Exact result in https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
Exact result in http://sysctl.org/cameleon/hosts
Exact result in https://hosts-file.net/ad_servers.txt
```

`pihole -q <whitelist>`
```
Result from whitelist.txt
  www.dshield.org
::: No results found for www.dshield.org found within block lists
```

`pihole -q <blacklist>`
```
Result from blacklist.txt
  fullstory.com
Result from list.3.v.firebog.net.domains
  fullstory.com
Result from list.15.v.firebog.net.domains
  fullstory.com
```

`pihole -q <wildcard>`
```
Result from whitelist.txt
  3879194.fls.doubleclick.net
Result from 03-pihole-wildcard.conf
  *.doubleclick.net
::: Over 1000 results found for doubleclick.net found within block lists
```

`pihole -q <wildcard> -exact`
```
Wildcard result in 03-pihole-wildcard.conf *.doubleclick.net
Exact result in list.1.v.firebog.net.domains
Exact result in list.5.v.firebog.net.domains
```

`pihole -q -foo`
```
::: No results found for -foo found within block lists
```