### PR TITLE
Move wildcards file if blocking is disabled

### DIFF
--- a/pihole
+++ b/pihole
@@ -180,7 +180,6 @@ Time:
       mv "$wildcardlist" "/etc/pihole/wildcard.list"
     fi
     echo "::: Blocking has been disabled!"
-
     if [[ $# > 1 ]]; then
       if [[ "${2}" == *"s"* ]]; then
         tt=${2%"s"}

--- a/pihole
+++ b/pihole
@@ -176,7 +176,11 @@ Time:
   elif [[ "${1}" == "0" ]]; then
     # Disable Pi-hole
     sed -i 's/^addn-hosts=\/etc\/pihole\/gravity.list/#addn-hosts=\/etc\/pihole\/gravity.list/' /etc/dnsmasq.d/01-pihole.conf
+    if [[ -e "$wildcardlist" ]]; then
+      mv "$wildcardlist" "/etc/pihole/wildcard.list"
+    fi
     echo "::: Blocking has been disabled!"
+
     if [[ $# > 1 ]]; then
       if [[ "${2}" == *"s"* ]]; then
         tt=${2%"s"}
@@ -199,6 +203,9 @@ Time:
     # Enable Pi-hole
     echo "::: Blocking has been enabled!"
     sed -i 's/^#addn-hosts/addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
+    if [[ -e "/etc/pihole/wildcard.list" ]]; then
+      mv "/etc/pihole/wildcard.list" "$wildcardlist"
+    fi
   fi
   restartDNS
 }
@@ -305,7 +312,7 @@ tricorderFunc() {
     echo "Please do not call Tricorder directly."
     exit 1
   fi
-  
+
   if ! timeout 2 nc -z tricorder.pi-hole.net 9998 &> /dev/null; then
     echo "Unable to connect to Pi-hole's Tricorder server."
     exit 1


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Move wildcard blocking file out of `dnsmasq`'s config directory when blocking is disabled (e.g. `pihole disable`). Move it back when blocking is re-enabled.

Fixes bug on [Discourse](https://discourse.pi-hole.net/t/disable-klappt-nicht-bei-eintraegen-auf-der-blacklist/3034/11)

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
