### PR TITLE
Count non-static DHCP leases from available range

### DIFF
--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -285,7 +285,15 @@ get_sys_stats() {
   fi
   
   if [[ "$DHCP_ACTIVE" == "true" ]]; then
-    ph_dhcp_num=$(wc -l 2> /dev/null < "/etc/pihole/dhcp.leases")
+    local ph_dhcp_range
+    ph_dhcp_num="0"
+    
+    for num in $(seq "${DHCP_START##*.}" "${DHCP_END##*.}"); do
+      ph_dhcp_range="$ph_dhcp_range|${DHCP_START%.*}.$num"
+    done
+
+    # Count dynamic leases from available range, and not static leases
+    ph_dhcp_num=$(grep -cE "${ph_dhcp_range:1}" "/etc/pihole/dhcp.leases")
   fi
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

Instead of counting the total lines of `/etc/pihole/dhcp.leases` (which could include static IPv4/IPv6 leases), we check how many leases are listed between the values of `DHCP_START` and `DHCP_END` within `setupVars.conf`.
