### PR TITLE
Prefer ULA over GUA addresses [IPv6]

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -351,9 +351,12 @@ useIPv6dialog() {
   # Determine which address to be used: Prefer ULA over GUA or don't use any if none found
   if [[ ! -z "${ULA_ADDRESS}" ]]; then
     IPV6_ADDRESS="${ULA_ADDRESS}"
+    echo "::: Found IPv6 ULA address, using it for blocking IPv6 ads"
   elif [[ ! -z "${GUA_ADDRESS}" ]]; then
+    echo "::: Found IPv6 GUA address, using it for blocking IPv6 ads"
     IPV6_ADDRESS="${GUA_ADDRESS}"
   else
+    echo "::: Found neither IPv6 ULA nor GUA address, blocking IPv6 ads will not be enabled"
     IPV6_ADDRESS=""
   fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -327,15 +327,40 @@ chooseInterface() {
   fi
 }
 
+# See https://github.com/pi-hole/pi-hole/issues/1473#issuecomment-301745953
+testIPv6() {
+  first="$(cut -f1 -d":" <<< "$1")"
+  value1=$(((0x$first)/256))
+  value2=$(((0x$first)%256))
+  ((($value1&254)==252)) && echo "ULA" || true
+  ((($value1&112)==32)) && echo "GUA" || true
+  ((($value1==254) && (($value2&192)==128))) && echo "Link-local" || true
+}
+
 useIPv6dialog() {
-  # Show the IPv6 address used for blocking
-  IPV6_ADDRESS=$(ip -6 route get 2001:4860:4860::8888 | grep -v "unreachable" | awk -F " " '{ for(i=1;i<=NF;i++) if ($i == "src") print $(i+1) }')
+  # Determine the IPv6 address used for blocking
+  IPV6_ADDRESSES=($(ip -6 address | grep 'scope global' | awk '{print $2}'))
+
+  # Determine type of found IPv6 addresses
+  for i in "${IPV6_ADDRESSES[@]}"; do
+    result=$(testIPv6 "$i")
+    [[ "${result}" == "ULA" ]] && ULA_ADDRESS="$i"
+    [[ "${result}" == "GUA" ]] && GUA_ADDRESS="$i"
+  done
+
+  # Determine which address to be used: Prefer ULA over GUA or don't use any if none found
+  if [[ ! -z "${ULA_ADDRESS}" ]]; then
+    IPV6_ADDRESS="${ULA_ADDRESS}"
+  elif [[ ! -z "${GUA_ADDRESS}" ]]; then
+    IPV6_ADDRESS="${GUA_ADDRESS}"
+  else
+    IPV6_ADDRESS=""
+  fi
 
   if [[ ! -z "${IPV6_ADDRESS}" ]]; then
     whiptail --msgbox --backtitle "IPv6..." --title "IPv6 Supported" "$IPV6_ADDRESS will be used to block ads." ${r} ${c}
   fi
 }
-
 
 use4andor6() {
   local useIPv4

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -402,6 +402,17 @@ def test_FTL_binary_installed_and_responsive_no_errors(Pihole):
 #     assert '644 /run/pihole-FTL.pid' in support_files.stdout
 #     assert '644 /var/log/pihole-FTL.log' in support_files.stdout
 
+def test_IPv6_only_link_local(Pihole):
+    ''' confirms IPv6 blocking is disabled for  '''
+    # mock ip -6 address to return Link-local address
+    mock_command('ip', {'-6 address':('inet6 fe80::d210:52fa:fe00:7ad7/64 scope link', '0')}, Pihole)
+    detectPlatform = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    useIPv6dialog
+    ''')
+    expected_stdout = 'Found neither IPv6 ULA nor GUA address, blocking IPv6 ads will not be enabled'
+    assert expected_stdout in detectPlatform.stdout
+
 # Helper functions
 def mock_command(script, args, container):
     ''' Allows for setup of commands we don't really want to have to run for real in unit tests '''

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -405,7 +405,7 @@ def test_FTL_binary_installed_and_responsive_no_errors(Pihole):
 def test_IPv6_only_link_local(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'"-6 address"':('inet6 fe80::d210:52fa:fe00:7ad7/64 scope link', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('echo inet6 fe80::d210:52fa:fe00:7ad7/64 scope link', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -416,7 +416,7 @@ def test_IPv6_only_link_local(Pihole):
 def test_IPv6_only_ULA(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'"-6 address"':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('echo inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -427,7 +427,7 @@ def test_IPv6_only_ULA(Pihole):
 def test_IPv6_only_GUA(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'"-6 address"':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('echo inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -438,7 +438,7 @@ def test_IPv6_only_GUA(Pihole):
 def test_IPv6_GUA_ULA_test(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'"-6 address"':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\ninet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('echo inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\necho inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -449,7 +449,7 @@ def test_IPv6_GUA_ULA_test(Pihole):
 def test_IPv6_ULA_GUA_test(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'"-6 address"':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\ninet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('echo inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\necho inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -469,6 +469,27 @@ def mock_command(script, args, container):
         case = dedent('''
         {arg})
         echo {res}
+        exit {retcode}
+        ;;'''.format(arg=k, res=v[0], retcode=v[1]))
+        mock_script += case
+    mock_script += dedent('''
+    esac''')
+    container.run('''
+    cat <<EOF> {script}\n{content}\nEOF
+    chmod +x {script}
+    rm -f /var/log/{scriptlog}'''.format(script=full_script_path, content=mock_script, scriptlog=script))
+
+def mock_command_2(script, args, container):
+    ''' Allows for setup of commands we don't really want to have to run for real in unit tests '''
+    full_script_path = '/usr/local/bin/{}'.format(script)
+    mock_script = dedent('''\
+    #!/bin/bash -e
+    echo "\$0 \$@" >> /var/log/{script}
+    case "\$1 \$2" in'''.format(script=script))
+    for k, v in args.iteritems():
+        case = dedent('''
+        \"{arg}\")
+        {res}
         exit {retcode}
         ;;'''.format(arg=k, res=v[0], retcode=v[1]))
         mock_script += case

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -403,7 +403,7 @@ def test_FTL_binary_installed_and_responsive_no_errors(Pihole):
 #     assert '644 /var/log/pihole-FTL.log' in support_files.stdout
 
 def test_IPv6_only_link_local(Pihole):
-    ''' confirms IPv6 blocking is disabled for  '''
+    ''' confirms IPv6 blocking is disabled for Link-local address '''
     # mock ip -6 address to return Link-local address
     mock_command_2('ip', {'-6 address':('inet6 fe80::d210:52fa:fe00:7ad7/64 scope link', '0')}, Pihole)
     detectPlatform = Pihole.run('''
@@ -414,7 +414,7 @@ def test_IPv6_only_link_local(Pihole):
     assert expected_stdout in detectPlatform.stdout
 
 def test_IPv6_only_ULA(Pihole):
-    ''' confirms IPv6 blocking is disabled for  '''
+    ''' confirms IPv6 blocking is enabled for ULA addresses '''
     # mock ip -6 address to return ULA address
     mock_command_2('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
@@ -425,7 +425,7 @@ def test_IPv6_only_ULA(Pihole):
     assert expected_stdout in detectPlatform.stdout
 
 def test_IPv6_only_GUA(Pihole):
-    ''' confirms IPv6 blocking is disabled for  '''
+    ''' confirms IPv6 blocking is disabled enabled for GUA addresses '''
     # mock ip -6 address to return GUA address
     mock_command_2('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
@@ -436,7 +436,7 @@ def test_IPv6_only_GUA(Pihole):
     assert expected_stdout in detectPlatform.stdout
 
 def test_IPv6_GUA_ULA_test(Pihole):
-    ''' confirms IPv6 blocking is disabled for  '''
+    ''' confirms IPv6 blocking is enabled for GUA and ULA addresses '''
     # mock ip -6 address to return GUA and ULA addresses
     mock_command_2('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\ninet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
@@ -447,7 +447,7 @@ def test_IPv6_GUA_ULA_test(Pihole):
     assert expected_stdout in detectPlatform.stdout
 
 def test_IPv6_ULA_GUA_test(Pihole):
-    ''' confirms IPv6 blocking is disabled for  '''
+    ''' confirms IPv6 blocking is enabled for GUA and ULA addresses '''
     # mock ip -6 address to return ULA and GUA addresses
     mock_command_2('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\ninet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -425,7 +425,7 @@ def test_IPv6_only_ULA(Pihole):
     assert expected_stdout in detectPlatform.stdout
 
 def test_IPv6_only_GUA(Pihole):
-    ''' confirms IPv6 blocking is disabled enabled for GUA addresses '''
+    ''' confirms IPv6 blocking is enabled enabled for GUA addresses '''
     # mock ip -6 address to return GUA address
     mock_command_2('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -405,7 +405,7 @@ def test_FTL_binary_installed_and_responsive_no_errors(Pihole):
 def test_IPv6_only_link_local(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'-6 address':('inet6 fe80::d210:52fa:fe00:7ad7/64 scope link', '0')}, Pihole)
+    mock_command('ip', {'"-6 address"':('inet6 fe80::d210:52fa:fe00:7ad7/64 scope link', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -416,7 +416,7 @@ def test_IPv6_only_link_local(Pihole):
 def test_IPv6_only_ULA(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command('ip', {'"-6 address"':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -427,7 +427,7 @@ def test_IPv6_only_ULA(Pihole):
 def test_IPv6_only_GUA(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command('ip', {'"-6 address"':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -438,7 +438,7 @@ def test_IPv6_only_GUA(Pihole):
 def test_IPv6_GUA_ULA_test(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\ninet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command('ip', {'"-6 address"':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\ninet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -449,7 +449,7 @@ def test_IPv6_GUA_ULA_test(Pihole):
 def test_IPv6_ULA_GUA_test(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\ninet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command('ip', {'"-6 address"':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\ninet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -415,7 +415,7 @@ def test_IPv6_only_link_local(Pihole):
 
 def test_IPv6_only_ULA(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
-    # mock ip -6 address to return Link-local address
+    # mock ip -6 address to return ULA address
     mock_command_2('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
@@ -426,7 +426,7 @@ def test_IPv6_only_ULA(Pihole):
 
 def test_IPv6_only_GUA(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
-    # mock ip -6 address to return Link-local address
+    # mock ip -6 address to return GUA address
     mock_command_2('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
@@ -437,7 +437,7 @@ def test_IPv6_only_GUA(Pihole):
 
 def test_IPv6_GUA_ULA_test(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
-    # mock ip -6 address to return Link-local address
+    # mock ip -6 address to return GUA and ULA addresses
     mock_command_2('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\ninet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
@@ -448,7 +448,7 @@ def test_IPv6_GUA_ULA_test(Pihole):
 
 def test_IPv6_ULA_GUA_test(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
-    # mock ip -6 address to return Link-local address
+    # mock ip -6 address to return ULA and GUA addresses
     mock_command_2('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\ninet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -425,7 +425,7 @@ def test_IPv6_only_ULA(Pihole):
     assert expected_stdout in detectPlatform.stdout
 
 def test_IPv6_only_GUA(Pihole):
-    ''' confirms IPv6 blocking is enabled enabled for GUA addresses '''
+    ''' confirms IPv6 blocking is enabled for GUA addresses '''
     # mock ip -6 address to return GUA address
     mock_command_2('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -405,7 +405,7 @@ def test_FTL_binary_installed_and_responsive_no_errors(Pihole):
 def test_IPv6_only_link_local(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command_2('ip', {'-6 address':('echo inet6 fe80::d210:52fa:fe00:7ad7/64 scope link', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('inet6 fe80::d210:52fa:fe00:7ad7/64 scope link', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -416,7 +416,7 @@ def test_IPv6_only_link_local(Pihole):
 def test_IPv6_only_ULA(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command_2('ip', {'-6 address':('echo inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -427,7 +427,7 @@ def test_IPv6_only_ULA(Pihole):
 def test_IPv6_only_GUA(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command_2('ip', {'-6 address':('echo inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -438,7 +438,7 @@ def test_IPv6_only_GUA(Pihole):
 def test_IPv6_GUA_ULA_test(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command_2('ip', {'-6 address':('echo inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\necho inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\ninet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -449,7 +449,7 @@ def test_IPv6_GUA_ULA_test(Pihole):
 def test_IPv6_ULA_GUA_test(Pihole):
     ''' confirms IPv6 blocking is disabled for  '''
     # mock ip -6 address to return Link-local address
-    mock_command_2('ip', {'-6 address':('echo inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\necho inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    mock_command_2('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\ninet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
     useIPv6dialog
@@ -489,7 +489,7 @@ def mock_command_2(script, args, container):
     for k, v in args.iteritems():
         case = dedent('''
         \"{arg}\")
-        {res}
+        echo \"{res}\"
         exit {retcode}
         ;;'''.format(arg=k, res=v[0], retcode=v[1]))
         mock_script += case

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -435,6 +435,28 @@ def test_IPv6_only_GUA(Pihole):
     expected_stdout = 'Found IPv6 GUA address, using it for blocking IPv6 ads'
     assert expected_stdout in detectPlatform.stdout
 
+def test_IPv6_GUA_ULA_test(Pihole):
+    ''' confirms IPv6 blocking is disabled for  '''
+    # mock ip -6 address to return Link-local address
+    mock_command('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global\ninet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    detectPlatform = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    useIPv6dialog
+    ''')
+    expected_stdout = 'Found IPv6 ULA address, using it for blocking IPv6 ads'
+    assert expected_stdout in detectPlatform.stdout
+
+def test_IPv6_ULA_GUA_test(Pihole):
+    ''' confirms IPv6 blocking is disabled for  '''
+    # mock ip -6 address to return Link-local address
+    mock_command('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global\ninet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    detectPlatform = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    useIPv6dialog
+    ''')
+    expected_stdout = 'Found IPv6 ULA address, using it for blocking IPv6 ads'
+    assert expected_stdout in detectPlatform.stdout
+
 # Helper functions
 def mock_command(script, args, container):
     ''' Allows for setup of commands we don't really want to have to run for real in unit tests '''

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -413,6 +413,28 @@ def test_IPv6_only_link_local(Pihole):
     expected_stdout = 'Found neither IPv6 ULA nor GUA address, blocking IPv6 ads will not be enabled'
     assert expected_stdout in detectPlatform.stdout
 
+def test_IPv6_only_ULA(Pihole):
+    ''' confirms IPv6 blocking is disabled for  '''
+    # mock ip -6 address to return Link-local address
+    mock_command('ip', {'-6 address':('inet6 fda2:2001:5555:0:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    detectPlatform = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    useIPv6dialog
+    ''')
+    expected_stdout = 'Found IPv6 ULA address, using it for blocking IPv6 ads'
+    assert expected_stdout in detectPlatform.stdout
+
+def test_IPv6_only_GUA(Pihole):
+    ''' confirms IPv6 blocking is disabled for  '''
+    # mock ip -6 address to return Link-local address
+    mock_command('ip', {'-6 address':('inet6 2003:12:1e43:301:d210:52fa:fe00:7ad7/64 scope global', '0')}, Pihole)
+    detectPlatform = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    useIPv6dialog
+    ''')
+    expected_stdout = 'Found IPv6 GUA address, using it for blocking IPv6 ads'
+    assert expected_stdout in detectPlatform.stdout
+
 # Helper functions
 def mock_command(script, args, container):
     ''' Allows for setup of commands we don't really want to have to run for real in unit tests '''


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10
---


On installs with GUA and ULA's we should prefer ULA's as it's been demonstrated that GUA's can and often are rotated by ISPs. Fixes #1473

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
