### PR TITLE
Add FTL tests to the test suite

### DIFF
--- a/test/FTL-test.sh
+++ b/test/FTL-test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+FTL_communicate() {
+  # Open connection to FTL
+  exec 3<>"/dev/tcp/localhost/4711"
+
+  # Test if connection is open
+  if { "true" >&3; } 2> /dev/null; then
+    # Send command to FTL
+    echo -e ">$1" >&3
+
+    # Read input
+    read -r -t 1 LINE <&3
+    until [[ ! $? ]] || [[ "$LINE" == *"EOM"* ]]; do
+       echo "$LINE" >&1
+       read -r -t 1 LINE <&3
+    done
+
+    # Close connection
+    exec 3>&-
+    exec 3<&-
+  fi
+}
+
+FTL_get_version() {
+  FTL_communicate "version"
+}
+
+FTL_prepare_files() {
+  ts=$(dnsmasq_pre)
+cat <<EOT >> /var/log/pihole.log
+${ts} query[AAAA] raspberrypi from 127.0.0.1
+${ts} /etc/pihole/local.list raspberrypi is fda2:2001:5647:0:ba27:ebff:fe37:4205
+${ts} query[A] checkip.dyndns.org from 127.0.0.1
+${ts} forwarded checkip.dyndns.org to 2001:1608:10:25::9249:d69b
+${ts} forwarded checkip.dyndns.org to 2001:1608:10:25::1c04:b12f
+${ts} forwarded checkip.dyndns.org to 2620:0:ccd::2
+${ts} forwarded checkip.dyndns.org to 2620:0:ccc::2
+${ts} reply checkip.dyndns.org is <CNAME>
+${ts} reply checkip.dyndns.com is 216.146.38.70
+${ts} reply checkip.dyndns.com is 216.146.43.71
+${ts} reply checkip.dyndns.com is 91.198.22.70
+${ts} reply checkip.dyndns.com is 216.146.43.70
+${ts} query[A] pi.hole from 10.8.0.2
+${ts} /etc/pihole/local.list pi.hole is 192.168.2.10
+${ts} query[A] play.google.com from 192.168.2.208
+${ts} forwarded play.google.com to 2001:1608:10:25::9249:d69b
+${ts} forwarded play.google.com to 2001:1608:10:25::1c04:b12f
+${ts} forwarded play.google.com to 2620:0:ccd::2
+${ts} forwarded play.google.com to 2620:0:ccc::2
+${ts} reply play.google.com is <CNAME>
+${ts} reply play.l.google.com is 216.58.208.110
+${ts} reply play.l.google.com is 216.58.208.110
+${ts} reply play.l.google.com is 216.58.208.110
+${ts} reply play.google.com is <CNAME>
+${ts} query[AAAA] play.google.com from 192.168.2.208
+${ts} forwarded play.google.com to 2620:0:ccd::2
+${ts} reply play.l.google.com is 2a00:1450:4017:802::200e
+EOT
+}
+
+dnsmasq_pre() {
+  echo -n $(date +"%b %e %H:%M:%S")
+  echo -n "dnsmasq[123]:"
+}

--- a/test/FTL-test.sh
+++ b/test/FTL-test.sh
@@ -25,6 +25,18 @@ FTL_get_version() {
   FTL_communicate "version"
 }
 
+FTL_get_stats() {
+  FTL_communicate "stats"
+}
+
+FTL_get_top_clients() {
+  FTL_communicate "top-clients"
+}
+
+FTL_get_top_domains() {
+  FTL_communicate "top-domains"
+}
+
 FTL_prepare_files() {
   ts=$(dnsmasq_pre)
 cat <<EOT >> /var/log/pihole.log

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -435,6 +435,21 @@ def test_FTL_telnet_statistics(Pihole):
     assert 'queries_forwarded 3' in FTLtest.stdout
     assert 'queries_cached 2' in FTLtest.stdout
 
+def test_FTL_telnet_top_clients(Pihole):
+    ''' confirms FTL binary is copied and functional in installed location and through telnet '''
+    FTLtest = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    source /etc/.pihole/test/FTL-test.sh
+    FTL_prepare_files
+    FTLdetect
+    pihole-FTL
+    sleep 1
+    FTL_get_stats
+    ''')
+    assert '0 2 192.168.2.208' in FTLtest.stdout
+    assert '1 2 127.0.0.1' in FTLtest.stdout
+    assert '2 1 10.8.0.2' in FTLtest.stdout
+
 # Helper functions
 def mock_command(script, args, container):
     ''' Allows for setup of commands we don't really want to have to run for real in unit tests '''

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -402,6 +402,22 @@ def test_FTL_binary_installed_and_responsive_no_errors(Pihole):
 #     assert '644 /run/pihole-FTL.pid' in support_files.stdout
 #     assert '644 /var/log/pihole-FTL.log' in support_files.stdout
 
+
+def test_FTL_binary_installed_and_listening_on_telnet(Pihole):
+    ''' confirms FTL binary is copied and functional in installed location and through telnet '''
+    FTLtest = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    source /etc/.pihole/test/FTL-test.sh
+    FTL_prepare_files
+    FTLdetect
+    pihole-FTL
+    FTL_get_version
+    ''')
+    assert 'version' in FTLtest.stdout
+    assert 'tag' in FTLtest.stdout
+    assert 'branch' in FTLtest.stdout
+    assert 'date' in FTLtest.stdout
+
 # Helper functions
 def mock_command(script, args, container):
     ''' Allows for setup of commands we don't really want to have to run for real in unit tests '''

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -402,7 +402,7 @@ def test_FTL_binary_installed_and_responsive_no_errors(Pihole):
 #     assert '644 /run/pihole-FTL.pid' in support_files.stdout
 #     assert '644 /var/log/pihole-FTL.log' in support_files.stdout
 
-def test_FTL_binary_installed_and_listening_on_telnet(Pihole):
+def test_FTL_telnet_version(Pihole):
     ''' confirms FTL binary is copied and functional in installed location and through telnet '''
     FTLtest = Pihole.run('''
     source /opt/pihole/basic-install.sh
@@ -417,6 +417,23 @@ def test_FTL_binary_installed_and_listening_on_telnet(Pihole):
     assert 'tag' in FTLtest.stdout
     assert 'branch' in FTLtest.stdout
     assert 'date' in FTLtest.stdout
+
+def test_FTL_telnet_statistics(Pihole):
+    ''' confirms FTL binary is copied and functional in installed location and through telnet '''
+    FTLtest = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    source /etc/.pihole/test/FTL-test.sh
+    FTL_prepare_files
+    FTLdetect
+    pihole-FTL
+    sleep 1
+    FTL_get_stats
+    ''')
+    assert 'domains_being_blocked' in FTLtest.stdout
+    assert 'dns_queries_today 5' in FTLtest.stdout
+    assert 'unique_domains 4' in FTLtest.stdout
+    assert 'queries_forwarded 3' in FTLtest.stdout
+    assert 'queries_cached 2' in FTLtest.stdout
 
 # Helper functions
 def mock_command(script, args, container):

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -402,7 +402,6 @@ def test_FTL_binary_installed_and_responsive_no_errors(Pihole):
 #     assert '644 /run/pihole-FTL.pid' in support_files.stdout
 #     assert '644 /var/log/pihole-FTL.log' in support_files.stdout
 
-
 def test_FTL_binary_installed_and_listening_on_telnet(Pihole):
     ''' confirms FTL binary is copied and functional in installed location and through telnet '''
     FTLtest = Pihole.run('''
@@ -411,6 +410,7 @@ def test_FTL_binary_installed_and_listening_on_telnet(Pihole):
     FTL_prepare_files
     FTLdetect
     pihole-FTL
+    sleep 1
     FTL_get_version
     ''')
     assert 'version' in FTLtest.stdout

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -444,11 +444,27 @@ def test_FTL_telnet_top_clients(Pihole):
     FTLdetect
     pihole-FTL
     sleep 1
-    FTL_get_stats
+    FTL_get_top_clients
     ''')
     assert '0 2 192.168.2.208' in FTLtest.stdout
     assert '1 2 127.0.0.1' in FTLtest.stdout
     assert '2 1 10.8.0.2' in FTLtest.stdout
+
+def test_FTL_telnet_top_domains(Pihole):
+    ''' confirms FTL binary is copied and functional in installed location and through telnet '''
+    FTLtest = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    source /etc/.pihole/test/FTL-test.sh
+    FTL_prepare_files
+    FTLdetect
+    pihole-FTL
+    sleep 1
+    FTL_get_top_domains
+    ''')
+    assert '0 2 play.google.com' in FTLtest.stdout
+    assert '1 1 pi.hole' in FTLtest.stdout
+    assert '2 1 checkip.dyndns.org' in FTLtest.stdout
+    assert '3 1 raspberrypi' in FTLtest.stdout
 
 # Helper functions
 def mock_command(script, args, container):


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---


Add `FTL` tests. We create an artifical `pihole.log` file and start `pihole-FTL`. Afterwards, we try to get some details from `pihole-FTL` over the `telnet` interface and compare it to the expected results:
```
>version
[ test only if all fields are present as their values are subject to change ]

>stats
domains_being_blocked 110470 [ <--- subject to change, not tested ]
dns_queries_today 5
ads_blocked_today 0
ads_percentage_today 0.000000
unique_domains 4
queries_forwarded 3
queries_cached 2

>top-clients
0 2 192.168.2.208 dominik-desktop.local
1 2 127.0.0.1 localhost
2 1 10.8.0.2

>top-domains
0 2 play.google.com
1 1 pi.hole
2 1 checkip.dyndns.org
3 1 raspberrypi
```

Result:
<pre>
test/test_automated_install.py::test_FTL_telnet_version[debian] <strong>PASSED</strong>
test/test_automated_install.py::test_FTL_telnet_version[centos] <strong>PASSED</strong>
test/test_automated_install.py::test_FTL_telnet_statistics[debian] <strong>PASSED</strong>
test/test_automated_install.py::test_FTL_telnet_statistics[centos] <strong>PASSED</strong>
test/test_automated_install.py::test_FTL_telnet_top_clients[debian] <strong>PASSED</strong>
test/test_automated_install.py::test_FTL_telnet_top_clients[centos] <strong>PASSED</strong>
test/test_automated_install.py::test_FTL_telnet_top_domains[debian] <strong>PASSED</strong>
test/test_automated_install.py::test_FTL_telnet_top_domains[centos] <strong>PASSED</strong>
</pre>

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
