### PR TITLE
Fix minor pihole checkout bug

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -87,7 +87,7 @@ warning1() {
   echo "  Please note that changing branches severely alters your Pi-hole subsystems"
   echo "  Features that work on the master branch, may not on a development branch"
   echo -e "  ${red}This feature is NOT supported unless a Pi-hole developer explicitly asks!${def}"
-  read -r -p "  Have you read and understood this? [Y/N] " response
+  read -r -p "  Have you read and understood this? [y/N] " response
   case ${response} in
   [yY][eE][sS]|[yY])
     echo "::: Continuing with branch change."


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
## 10

---

We should make clear that NO is the default if the user just hits return.

Current display:
```
  This feature is NOT supported unless a Pi-hole developer explicitly asks!
  Have you read and understood this? [Y/N]
```

Should be (fixed by this PR, note the small `y` int the brackets):
```
  This feature is NOT supported unless a Pi-hole developer explicitly asks!
  Have you read and understood this? [y/N]
```


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
