### PR TITLE
Trim version output when update is successful

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -197,21 +197,21 @@ main() {
   if [[ "${web_update}" == true ]]; then
     web_version_current="$(/usr/local/bin/pihole version --admin --current)"
     echo ":::"
-    echo "::: Web Admin version is now at ${web_version_current}"
+    echo "::: Web Admin version is now at ${web_version_current/* v/v}}"
     echo "::: If you had made any changes in '/var/www/html/admin/', they have been stashed using 'git stash'"
   fi
 
   if [[ "${core_update}" == true ]]; then
     pihole_version_current="$(/usr/local/bin/pihole version --pihole --current)"
     echo ":::"
-    echo "::: Pi-hole version is now at ${pihole_version_current}"
+    echo "::: Pi-hole version is now at ${pihole_version_current/* v/v}}"
     echo "::: If you had made any changes in '/etc/.pihole/', they have been stashed using 'git stash'"
   fi
 
   if [[ ${FTL_update} == true ]]; then
-    FTL_version_current="$(/usr/bin/pihole-FTL tag)"
+    FTL_version_current="$(/usr/local/bin/pihole version --ftl --current)"
     echo ":::"
-    echo "::: FTL version is now at ${FTL_version_current}"
+    echo "::: FTL version is now at ${FTL_version_current/* v/v}}"
     start_service pihole-FTL
     enable_service pihole-FTL
   fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

9

---

When running `pihole -up`, a successful update will output something similar to: `::: Web Admin version is now at   Current REPO version is v3.0-59-gc749b42`

This PR strips the `Current REPO version is ` text, and makes the FTL version output use the updated version script.