### PR TITLE
Switch the order in which black.list and local.list are read into dnsmasq

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -21,8 +21,8 @@
 ###############################################################################
 
 addn-hosts=/etc/pihole/gravity.list
-addn-hosts=/etc/pihole/local.list
 addn-hosts=/etc/pihole/black.list
+addn-hosts=/etc/pihole/local.list
 
 domain-needed
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X])Failure to fill the template will close your PR:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

- [x] 10 (very familiar)

---

Prevents whatever is at the top of `black.list` being returned in place of the devices hostname...

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._