### PR TITLE
Fix gravity generation when IPv6 CIDR is present

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -43,9 +43,9 @@ else
   exit 1
 fi
 
-# Remove the /* from the end of the IPv4addr.
+# Remove the /* from the end of the IP addresses
 IPV4_ADDRESS=${IPV4_ADDRESS%/*}
-IPV6_ADDRESS=${IPV6_ADDRESS}
+IPV6_ADDRESS=${IPV6_ADDRESS%/*}
 
 # Variables for various stages of downloading and formatting the list
 basename=pihole


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
10

---

Fixes Discourse issue: https://discourse.pi-hole.net/t/ipv6-aaaa-dns-issue/3830
Since IPv6 CIDR is not needed anyways, we can also look into removing it in the installer.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
