### PR TITLE
Allow underscore ( _ ) in domains

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -62,11 +62,14 @@ EscapeRegexp() {
 }
 
 HandleOther() {
-  # First, convert everything to lowercase
-  domain=$(sed -e "y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/" <<< "$1")
+  # Convert to lowercase
+  domain="${1,,}"
 
   # Check validity of domain
-  validDomain=$(echo "${domain}" | perl -lne 'print if /(?!.*[^a-z0-9-\._].*)^((?=[a-z0-9-_]{1,63}\.)(xn--)?[a-z0-9-]+\._)*[a-z]{2,63}/')
+  validDomain=$(perl -lne 'print if /^((-|_)*[a-z\d]((-|_)*[a-z\d])*(-|_)*)(\.(-|_)*([a-z\d]((-|_)*[a-z\d])*))*$/' <<< "${domain}") # Valid chars check
+  validDomain=$(perl -lne 'print if /^.{1,253}$/' <<< "${validDomain}") # Overall length check
+  validDomain=$(perl -lne 'print if /^[^\.]{1,63}(\.[^\.]{1,63})*$/' <<< "${validDomain}") # Length of each label
+  
   if [[ -z "${validDomain}" ]]; then
     echo -e "  ${CROSS} $1 is not a valid argument or domain name!"
   else

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -66,7 +66,7 @@ HandleOther() {
   domain=$(sed -e "y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/" <<< "$1")
 
   # Check validity of domain
-  validDomain=$(echo "${domain}" | perl -lne 'print if /(?!.*[^a-z0-9-\.].*)^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9-]+\.)*[a-z]{2,63}/')
+  validDomain=$(echo "${domain}" | perl -lne 'print if /(?!.*[^a-z0-9-\._].*)^((?=[a-z0-9-_]{1,63}\.)(xn--)?[a-z0-9-]+\._)*[a-z]{2,63}/')
   if [[ -z "${validDomain}" ]]; then
     echo -e "  ${CROSS} $1 is not a valid argument or domain name!"
   else
@@ -98,7 +98,7 @@ PoplistFile() {
 AddDomain() {
   list="$2"
   domain=$(EscapeRegexp "$1")
-  
+
   [[ "${list}" == "${whitelist}" ]] && listname="whitelist"
   [[ "${list}" == "${blacklist}" ]] && listname="blacklist"
   [[ "${list}" == "${wildcardlist}" ]] && listname="wildcard blacklist"
@@ -151,7 +151,7 @@ AddDomain() {
 RemoveDomain() {
   list="$2"
   domain=$(EscapeRegexp "$1")
-  
+
   [[ "${list}" == "${whitelist}" ]] && listname="whitelist"
   [[ "${list}" == "${blacklist}" ]] && listname="blacklist"
   [[ "${list}" == "${wildcardlist}" ]] && listname="wildcard blacklist"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Fixes unreported issue with adding domains like `pv6_1-cxl0-c012.1.uvw.xyz.net` using the command line.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
