### PR TITLE
Relocate tricorder success/fail message in piholeDebug.sh

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -442,22 +442,22 @@ finalWork() {
 	  case ${response} in
 		  [yY][eE][sS]|[yY])
 			  tricorder=$(cat /var/log/pihole_debug.log | nc tricorder.pi-hole.net 9999)
+        # Check if tricorder.pi-hole.net is reachable and provide token.
+        if [ -n "${tricorder}" ]; then
+          echo "::: ---=== Your debug token is : ${tricorder} Please make a note of it. ===---"
+          echo "::: Contact the Pi-hole team with your token for assistance."
+          echo "::: Thank you."
+        else
+          echo "::: There was an error uploading your debug log."
+          echo "::: Please try again or contact the Pi-hole team for assistance."
+        fi
 			  ;;
 		  *)
 			  echo "::: Log will NOT be uploaded to tricorder."
 			  ;;
 	  esac
   fi
-	# Check if tricorder.pi-hole.net is reachable and provide token.
-	if [ -n "${tricorder}" ]; then
-		echo "::: ---=== Your debug token is : ${tricorder} Please make a note of it. ===---"
-		echo "::: Contact the Pi-hole team with your token for assistance."
-		echo "::: Thank you."
-	else
-		echo "::: There was an error uploading your debug log."
-		echo "::: Please try again or contact the Pi-hole team for assistance."
-	fi
-		echo "::: A local copy of the Debug log can be found at : /var/log/pihole_debug.log"
+	echo "::: A local copy of the Debug log can be found at : /var/log/pihole_debug.log"
 }
 
 ### END FUNCTIONS ###


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_1_

---

With the current code, if someone did not send their debug log to tricorder, they would receive an error message stating that there was a problem sending their log. This reorders the code to fix that. 

`lwjbl5sntq` is testing evidence that logs will still be sent. Below is testing evidence of the fix. 

```
::: The debug log can be uploaded to tricorder.pi-hole.net for sharing with developers only.
::: Would you like to upload the log? [y/N] N
::: Log will NOT be uploaded to tricorder.
::: A local copy of the Debug log can be found at : /var/log/pihole_debug.log
```

For some reason, the spacing looks a little off in the PR, however it looks fine in Atom 🤷‍♂️

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._