### PR TITLE
Prevent Web Admin from printing restartdns colour codes

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -218,18 +218,18 @@ Reboot() {
 }
 
 RestartDNS() {
-  local str="Restarting dnsmasq"
-  echo -ne "  ${INFO} ${str}..."
-  if [[ -x "$(command -v systemctl)" ]]; then
-    systemctl restart dnsmasq
+  local str="Restarting DNS service"
+  [[ -t 1 ]] && echo -ne "  ${INFO} ${str}"
+  if command -v systemctl &> /dev/null; then
+    output=$( { systemctl restart dnsmasq; } 2>&1 )
   else
-    service dnsmasq restart
+    output=$( { service dnsmasq restart; } 2>&1 )
   fi
-  
-  if [[ "$?" == 0 ]]; then
-    echo -e "${OVER}  ${TICK} ${str}"
+  if [[ -z "${output}" ]]; then
+    [[ -t 1 ]] && echo -e "${OVER}  ${TICK} ${str}"
   else
-    echo -e "${OVER}  ${CROSS} ${str}"
+    [[ ! -t 1 ]] && OVER=""
+    echo -e "${OVER}  ${CROSS} ${output}"
   fi
 }
 

--- a/pihole
+++ b/pihole
@@ -173,24 +173,32 @@ versionFunc() {
 
 restartDNS() {
   dnsmasqPid=$(pidof dnsmasq)
+  local str="Restarting DNS service"
+  echo -ne "  ${INFO} ${str}"
   if [[ "${dnsmasqPid}" ]]; then
     # Service already running - reload config
-    echo -ne "  ${INFO} Restarting dnsmasq"
     if [[ -x "$(command -v systemctl)" ]]; then
-      systemctl restart dnsmasq
+      output=$( { systemctl restart dnsmasq; } 2>&1 )
     else
-      service dnsmasq restart
+      output=$( { service dnsmasq restart; } 2>&1 )
     fi
-    [[ "$?" == 0 ]] && echo -e "${OVER}  ${TICK} Restarted dnsmasq" || echo -e "${OVER}  ${CROSS} Failed to restart dnsmasq"
+    if [[ -z "${output}" ]]; then
+      echo -e "${OVER}  ${TICK} ${str}"
+    else
+      echo -e "${OVER}  ${CROSS} ${output}"
+    fi
   else
     # Service not running, start it up
-    echo -ne "  ${INFO} Starting dnsmasq"
     if [[ -x "$(command -v systemctl)" ]]; then
-      systemctl start dnsmasq
+      output=$( { systemctl start dnsmasq; } 2>&1 )
     else
-      service dnsmasq start
+      output=$( { service dnsmasq start; } 2>&1 )
     fi
-    [[ "$?" == 0 ]] && echo -e "${OVER}  ${TICK} Restarted dnsmasq" || echo -e "${OVER}  ${CROSS} Failed to restart dnsmasq"
+    if [[ -z "${output}" ]]; then
+      echo -e "${OVER}  ${TICK} ${str}"
+    else
+      echo -e "${OVER}  ${CROSS} ${output}"
+    fi
   fi
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

9

---

Resolves [this issue](https://github.com/pi-hole/pi-hole/issues/1548#issuecomment-312292933):
![image](https://user-images.githubusercontent.com/28313514/27741666-274f8890-5db6-11e7-8e6e-e00ef996903d.jpg)

Test by changing interface listening behaviour, it should not print anything. Then perform `echo "asdsad" | sudo tee "/etc/dnsmasq.d/foobar.conf"` and attempt again. Should print `dnsmasq` error message.
