### PR TITLE
Only download FTL if a newer version than currently installed is detected (or if no version is detected)

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1817,7 +1817,7 @@ FTLinstall() {
 # Detect suitable FTL binary platform
 FTLdetect() {
   echo ""
-  echo -e "  ${INFO} Downloading latest version of FTL..."
+  echo -e "  ${INFO} FTL Checks..."
 
   # Local, named variables
   local machine

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1883,25 +1883,35 @@ FTLdetect() {
   #In the next section we check to see if FTL is already installed (in case of pihole -r).
   #If the installed version matches the latest version, then check the installed sha1sum of the binary vs the remote sha1sum. If they do not match, then download
   echo -e "  ${INFO} Checking for existing FTL binary..."
-  local FTLversion=$(/usr/bin/pihole-FTL tag)
-	local FTLlatesttag=$(curl -sI https://github.com/pi-hole/FTL/releases/latest | grep 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n')
 
-	if [[ "${FTLversion}" != "${FTLlatesttag}" ]]; then
-		# Install FTL
-    FTLinstall "${binary}" || return 1
-	else
-	  echo -e "  ${INFO} Latest FTL Binary already installed (${FTLlatesttag}). Confirming Checksum..."
+  local ftlLoc=$(which pihole-FTL)
 
-	  local remoteSha1=$(curl -sSL --fail "https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1" | cut -d ' ' -f 1)
-	  local localSha1=$(sha1sum "$(which pihole-FTL)" | cut -d ' ' -f 1)
+  if [[ ${ftlLoc} ]]; then
+    local FTLversion=$(/usr/bin/pihole-FTL tag)
+	  local FTLlatesttag=$(curl -sI https://github.com/pi-hole/FTL/releases/latest | grep 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n')
 
-	  if [[ "${remoteSha1}" != "${localSha1}" ]]; then
-	    echo -e "  ${INFO} Corruption detected..."
-	    FTLinstall "${binary}" || return 1
+	  if [[ "${FTLversion}" != "${FTLlatesttag}" ]]; then
+		  # Install FTL
+      FTLinstall "${binary}" || return 1
 	  else
-	    echo -e "  ${INFO} Checksum correct. No need to download!"
+	    echo -e "  ${INFO} Latest FTL Binary already installed (${FTLlatesttag}). Confirming Checksum..."
+
+	    local remoteSha1=$(curl -sSL --fail "https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1" | cut -d ' ' -f 1)
+	    local localSha1=$(sha1sum "$(which pihole-FTL)" | cut -d ' ' -f 1)
+
+	    if [[ "${remoteSha1}" != "${localSha1}" ]]; then
+	      echo -e "  ${INFO} Corruption detected..."
+	      FTLinstall "${binary}" || return 1
+	    else
+	      echo -e "  ${INFO} Checksum correct. No need to download!"
+	    fi
 	  fi
-	fi
+	else
+	  # Install FTL
+    FTLinstall "${binary}" || return 1
+  fi
+
+
 }
 
 main() {

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1882,6 +1882,7 @@ FTLdetect() {
 
   #In the next section we check to see if FTL is already installed (in case of pihole -r).
   #If the installed version matches the latest version, then check the installed sha1sum of the binary vs the remote sha1sum. If they do not match, then download
+  echo -e "  ${INFO} Checking for existing FTL binary..."
   local FTLversion=$(/usr/bin/pihole-FTL tag)
 	local FTLlatesttag=$(curl -sI https://github.com/pi-hole/FTL/releases/latest | grep 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n')
 
@@ -1889,15 +1890,16 @@ FTLdetect() {
 		# Install FTL
     FTLinstall "${binary}" || return 1
 	else
+	  echo -e "  ${INFO} Latest FTL Binary already installed (${FTLlatesttag}). Confirming Checksum..."
+
 	  local remoteSha1=$(curl -sSL --fail "https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1" | cut -d ' ' -f 1)
 	  local localSha1=$(sha1sum "$(which pihole-FTL)" | cut -d ' ' -f 1)
 
-    echo -e "  ${INFO} Existing FTL Binary detected. Checking sha1sum..."
 	  if [[ "${remoteSha1}" != "${localSha1}" ]]; then
 	    echo -e "  ${INFO} Corruption detected..."
 	    FTLinstall "${binary}" || return 1
 	  else
-	    echo -e "  ${INFO} sha1sums match. No need to download!"
+	    echo -e "  ${INFO} Checksum correct. No need to download!"
 	  fi
 	fi
 }

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -319,11 +319,11 @@ def test_FTL_detect_aarch64_no_errors(Pihole):
     source /opt/pihole/basic-install.sh
     FTLdetect
     ''')
-    expected_stdout = info_box + ' Downloading latest version of FTL...'
+    expected_stdout = info_box + ' FTL Checks...'
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + ' Detected ARM-aarch64 architecture'
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + ' Installing FTL'
+    expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in detectPlatform.stdout
 
 def test_FTL_detect_armv6l_no_errors(Pihole):
@@ -336,11 +336,11 @@ def test_FTL_detect_armv6l_no_errors(Pihole):
     source /opt/pihole/basic-install.sh
     FTLdetect
     ''')
-    expected_stdout = info_box + ' Downloading latest version of FTL...'
+    expected_stdout = info_box + ' FTL Checks...'
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + ' Detected ARM-hf architecture (armv6 or lower)'
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + ' Installing FTL'
+    expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in detectPlatform.stdout
 
 def test_FTL_detect_armv7l_no_errors(Pihole):
@@ -353,11 +353,11 @@ def test_FTL_detect_armv7l_no_errors(Pihole):
     source /opt/pihole/basic-install.sh
     FTLdetect
     ''')
-    expected_stdout = info_box + ' Downloading latest version of FTL...'
+    expected_stdout = info_box + ' FTL Checks...'
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + ' Detected ARM-hf architecture (armv7+)'
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + ' Installing FTL'
+    expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in detectPlatform.stdout
 
 def test_FTL_detect_x86_64_no_errors(Pihole):
@@ -366,11 +366,11 @@ def test_FTL_detect_x86_64_no_errors(Pihole):
     source /opt/pihole/basic-install.sh
     FTLdetect
     ''')
-    expected_stdout = info_box + ' Downloading latest version of FTL...'
+    expected_stdout = info_box + ' FTL Checks...'
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + ' Detected x86_64 architecture'
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + ' Installing FTL'
+    expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in detectPlatform.stdout
 
 def test_FTL_detect_unknown_no_errors(Pihole):
@@ -391,7 +391,7 @@ def test_FTL_download_aarch64_no_errors(Pihole):
     source /opt/pihole/basic-install.sh
     FTLinstall pihole-FTL-aarch64-linux-gnu
     ''')
-    expected_stdout = tick_box + ' Installing FTL'
+    expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in download_binary.stdout
     error = 'Error: Download of binary from Github failed'
     assert error not in download_binary.stdout
@@ -405,7 +405,7 @@ def test_FTL_download_unknown_fails_no_errors(Pihole):
     source /opt/pihole/basic-install.sh
     FTLinstall pihole-FTL-mips
     ''')
-    expected_stdout = cross_box + ' Installing FTL'
+    expected_stdout = cross_box + ' Downloading and Installing FTL'
     assert expected_stdout in download_binary.stdout
     error = 'Error: URL not found'
     assert error in download_binary.stdout


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have written tests and verified that they fail without my change.
- [x] I have squashed any insignificant commits.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership. It is compatible with the EUPL 1.2 license.
- [x] I have Signed Off all commits. (`git commit --signoff`)

***Please explain what you have done and wish to accomplish with this Pull Request***

1. What does this change do, exactly?
Currently, when `pihole -r` is run, FTL is downloaded regardless. This PR adds in a check for the existence of FTL, and if it detects the current version is already installs, does a sanity check of the sha1 to make sure the install is correct.

2. Please link to the relevant issues.

3. Which documentation changes (if any) need to be made because of this PR?