### PR TITLE
Fix URL extension parsing

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -21,8 +21,9 @@ if ($serverName === 'pi.hole')
 }
 
 // Retrieve server URI extension (EG: jpg, exe, php)
+// strtok($uri, '\?') splits the querystring from the path (if there is a querystring)
 ini_set('pcre.recursion_limit',100);
-$uriExt = pathinfo($uri, PATHINFO_EXTENSION);
+$uriExt = pathinfo(strtok($uri,'\?'), PATHINFO_EXTENSION);
 
 // Define which URL extensions get rendered as "Website Blocked"
 $webExt = array('asp', 'htm', 'html', 'php', 'rss', 'xml');


### PR DESCRIPTION
when there is a querystring Pi-hole sometimes parsed a wrong extension

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_3_

---
_fixing the bug that if the url has a querystring the extrension was wrong parsed_
_fixes bug of issue #1598_


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
