### PR TITLE
Fix the hotfix (3.1.1)

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -26,8 +26,6 @@ PH_TEST=true
 #shellcheck disable=SC1090
 source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
 
-source "/opt/pihole/COL_TABLE"
-
 # is_repo() sourced from basic-install.sh
 # make_repo() sourced from basic-install.sh
 # update_repo() source from basic-install.sh


### PR DESCRIPTION
COLTABLE does not exist yet, so running `pihole -up` after updating to 3.1.1 will fall over.