### PR TITLE
Fix queryFunc if adlists URLs have been removed

### DIFF
--- a/pihole
+++ b/pihole
@@ -288,7 +288,7 @@ Options:
         filenum=("${filename/list./}")
         filenum=("${filenum/.*/}")
         filename="${adlists[$filenum]}"
-        
+
         # If gravity has generated associated .domains files
         # but adlists.list has been modified since
         if [[ -z "${filename}" ]]; then
@@ -436,15 +436,15 @@ Time:
     # Enable Pi-hole
     echo -e "  ${INFO} Enabling blocking"
     local str="Pi-hole Enabled"
-    
+
     sed -i 's/^#addn-hosts/addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
     if [[ -e "/etc/pihole/wildcard.list" ]]; then
       mv "/etc/pihole/wildcard.list" "$wildcardlist"
     fi
   fi
-  
+
   restartDNS
-  
+
   echo -e "${OVER}  ${TICK} ${str}"
 }
 
@@ -542,6 +542,7 @@ Switch Pi-hole subsystems to a different Github branch
 Repositories:
   core [branch]       Change the branch of Pi-hole's core subsystem
   web [branch]        Change the branch of Admin Console subsystem
+  ftl [branch]        Change the branch of Pi-hole's FTL subsystem
 
 Branches:
   master              Update subsystems to the latest stable release

--- a/pihole
+++ b/pihole
@@ -287,7 +287,7 @@ Options:
         filenum=("${filename/list./}")
         filenum=("${filenum/.*/}")
         filename="${adlists[$filenum]}"
-        
+
         # If gravity has generated domains files from one adlists.list
         # but the content of adlists.list has been drastically modified since
         if [[ -z "${filename}" ]]; then
@@ -435,15 +435,15 @@ Time:
     # Enable Pi-hole
     echo -e "  ${INFO} Enabling blocking"
     local str="Pi-hole Enabled"
-    
+
     sed -i 's/^#addn-hosts/addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
     if [[ -e "/etc/pihole/wildcard.list" ]]; then
       mv "/etc/pihole/wildcard.list" "$wildcardlist"
     fi
   fi
-  
+
   restartDNS
-  
+
   echo -e "${OVER}  ${TICK} ${str}"
 }
 
@@ -541,6 +541,7 @@ Switch Pi-hole subsystems to a different Github branch
 Repositories:
   core [branch]       Change the branch of Pi-hole's core subsystem
   web [branch]        Change the branch of Admin Console subsystem
+  ftl [branch]        Change the branch of Pi-hole's FTL subsystem
 
 Branches:
   master              Update subsystems to the latest stable release

--- a/pihole
+++ b/pihole
@@ -188,7 +188,7 @@ Options:
       if [[ -n "$exact" ]]; then
         printf "  Exact result in %s\n" "${filename}"
       elif [[ -n "$blockpage" ]]; then
-        printf "  [i] %s\n" "${filename}"
+        printf "π %s\n" "${filename}"
       else
         domain="${result/*:/}"
         if [[ ! "${filename}" == "${filename_prev:-}" ]]; then
@@ -217,7 +217,7 @@ Options:
           fi
 
           if [[ -n "${blockpage}" ]]; then
-            echo "  ${INFO} ${match}"
+            echo "π ${wildcardlist/*\/}"
           else
             echo "    *.${match}"
           fi
@@ -288,9 +288,9 @@ Options:
         filenum=("${filename/list./}")
         filenum=("${filenum/.*/}")
         filename="${adlists[$filenum]}"
-
-        # If gravity has generated domains files from one adlists.list
-        # but the content of adlists.list has been drastically modified since
+        
+        # If gravity has generated associated .domains files
+        # but adlists.list has been modified since
         if [[ -z "${filename}" ]]; then
           filename="${COL_LIGHT_RED}Error: no associated adlists URL found${COL_NC}"
         fi
@@ -299,7 +299,7 @@ Options:
       if [[ -n "${exact}" ]]; then
         printf "    %s\n" "${filename}"
       elif [[ -n "${blockpage}" ]]; then
-        printf "  [%s] %s\n" "${filenum}" "${filename}"
+        printf "%s %s\n" "${filenum}" "${filename}"
       else # Standard query output
 
         # Print filename heading once per file, not for every match
@@ -436,15 +436,15 @@ Time:
     # Enable Pi-hole
     echo -e "  ${INFO} Enabling blocking"
     local str="Pi-hole Enabled"
-
+    
     sed -i 's/^#addn-hosts/addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
     if [[ -e "/etc/pihole/wildcard.list" ]]; then
       mv "/etc/pihole/wildcard.list" "$wildcardlist"
     fi
   fi
-
+  
   restartDNS
-
+  
   echo -e "${OVER}  ${TICK} ${str}"
 }
 
@@ -542,7 +542,6 @@ Switch Pi-hole subsystems to a different Github branch
 Repositories:
   core [branch]       Change the branch of Pi-hole's core subsystem
   web [branch]        Change the branch of Admin Console subsystem
-  ftl [branch]        Change the branch of Pi-hole's FTL subsystem
 
 Branches:
   master              Update subsystems to the latest stable release

--- a/pihole
+++ b/pihole
@@ -181,6 +181,7 @@ Options:
   results=($(scanList "${query}" "${lists}" "${method}"))
 
   if [[ -n "${results[*]}" ]]; then
+    blResult=true
     # Loop through each scanList line to print appropriate title
     for result in "${results[@]}"; do
       filename="${result/:*/}"

--- a/pihole
+++ b/pihole
@@ -149,7 +149,7 @@ Options:
   fi
 
   # Strip valid options, leaving only the domain and invalid options
-  options=$(sed 's/ \?-\(exact\|adlist\|bp\|all\) \?//g' <<< "$options")
+  options=$(sed 's/ \?-\(exact\|adlist\(s\)\?\|bp\|all\) \?//g' <<< "$options")
 
   # Handle errors
   if [[ "${options}" == *" "* ]]; then
@@ -287,6 +287,12 @@ Options:
         filenum=("${filename/list./}")
         filenum=("${filenum/.*/}")
         filename="${adlists[$filenum]}"
+        
+        # If gravity has generated domains files from one adlists.list
+        # but the content of adlists.list has been drastically modified since
+        if [[ -z "${filename}" ]]; then
+          filename="${COL_LIGHT_RED}Error: no associated adlists URL found${COL_NC}"
+        fi
       fi
 
       if [[ -n "${exact}" ]]; then
@@ -429,15 +435,15 @@ Time:
     # Enable Pi-hole
     echo -e "  ${INFO} Enabling blocking"
     local str="Pi-hole Enabled"
-
+    
     sed -i 's/^#addn-hosts/addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
     if [[ -e "/etc/pihole/wildcard.list" ]]; then
       mv "/etc/pihole/wildcard.list" "$wildcardlist"
     fi
   fi
-
+  
   restartDNS
-
+  
   echo -e "${OVER}  ${TICK} ${str}"
 }
 
@@ -535,7 +541,6 @@ Switch Pi-hole subsystems to a different Github branch
 Repositories:
   core [branch]       Change the branch of Pi-hole's core subsystem
   web [branch]        Change the branch of Admin Console subsystem
-  ftl [branch]        Change the branch of Pi-hole's FTL subsystem
 
 Branches:
   master              Update subsystems to the latest stable release


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

* Allow for -adlists command line switch (where the "s" is a typo)
* Add error message when unable to find associated adlists URL