### PR TITLE
Stop an extra `h` being added to leasetime of DHCP server. 

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -264,7 +264,7 @@ ProcessDHCPSettings() {
       leasetime="24h"
       change_setting "DHCP_LEASETIME" "${leasetime}"
     else
-      leasetime="${DHCP_LEASETIME}h"
+      leasetime="${DHCP_LEASETIME}"
     fi
 
     # Write settings to file

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -263,6 +263,11 @@ ProcessDHCPSettings() {
     elif [[ "${DHCP_LEASETIME}" == "" ]]; then
       leasetime="24"
       change_setting "DHCP_LEASETIME" "${leasetime}"
+    elif [[ "${DHCP_LEASETIME}" == "24h" ]]; then
+      #Installation is affected by known bug, introduced in a previous version.
+      #This will automatically clean up setupVars.conf and remove the unnecessary "h"
+      leasetime="24"
+      change_setting "DHCP_LEASETIME" "${leasetime}"
     else
       leasetime="${DHCP_LEASETIME}h"
     fi

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -261,10 +261,10 @@ ProcessDHCPSettings() {
     if [[ "${DHCP_LEASETIME}" == "0" ]]; then
       leasetime="infinite"
     elif [[ "${DHCP_LEASETIME}" == "" ]]; then
-      leasetime="24h"
+      leasetime="24"
       change_setting "DHCP_LEASETIME" "${leasetime}"
     else
-      leasetime="${DHCP_LEASETIME}"
+      leasetime="${DHCP_LEASETIME}h"
     fi
 
     # Write settings to file


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have written tests and verified that they fail without my change.
- [x] I have squashed any insignificant commits.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership. It is compatible with the EUPL 1.2 license.
- [x] I have Signed Off all commits. (`git commit --signoff`)

***Please explain what you have done and wish to accomplish with this Pull Request***

1. What does this change do, exactly?
    Prevents an extra `h` being added to the DHCP config
2. Please link to the relevant issues.
    [Issue on Discourse](https://discourse.pi-hole.net/t/pihole-stopped-working-after-pihole-up-dns-service-not-running/4250)

3. Which documentation changes (if any) need to be made because of this PR?
