### PR TITLE
[DevPatch] Stop an extra `h` being added to leasetime of DHCP server. 

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -264,7 +264,7 @@ ProcessDHCPSettings() {
       leasetime="24h"
       change_setting "DHCP_LEASETIME" "${leasetime}"
     else
-      leasetime="${DHCP_LEASETIME}h"
+      leasetime="${DHCP_LEASETIME}"
     fi
 
     # Write settings to file


### PR DESCRIPTION
Same as  #1646 , but into the development branch rather than `release/3.2`