### PR TITLE
added sleep before gravity for slower hardware 

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -983,7 +983,8 @@ runGravity() {
     cp ${PI_HOLE_LOCAL_REPO}/adlists.default /etc/pihole/adlists.default
   fi
   echo "::: Running gravity.sh"
-  { /opt/pihole/gravity.sh; }
+  sleep 15s
+ { /opt/pihole/gravity.sh; }
 }
 
 create_pihole_user() {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_{5}_

---
_{attempt to sleep for 15s to allow dnsmasq to fully start before calling gravity 
use case is pi2B or lower with anything more than 900K domains}_

users with faster hardware will still be slept as im not sure how to code this on a per use case 

ALSO no clue why the hotfix is showing in this PR but if someone with the ability could delete that from it i would appreciate it 
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
