### PR TITLE
Make duplicate removal case insensitive

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -292,7 +292,7 @@ gravity_Whitelist() {
 gravity_unique() {
 	# Sort and remove duplicates
 	echo -n "::: Removing duplicate domains...."
-	sort -u  ${piholeDir}/${supernova} > ${piholeDir}/${preEventHorizon}
+	sort -u -f ${piholeDir}/${supernova} > ${piholeDir}/${preEventHorizon}
 	echo " done!"
 	numberOf=$(wc -l < ${piholeDir}/${preEventHorizon})
 	echo "::: $numberOf unique domains trapped in the event horizon."


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

3

---
Added "ignore-case" switch to sort command.
This is a bug fix. Duplicate domains are passed into the gravity list if one of then contain any capitals. Like so:
```
::: /etc/pihole/list.preEventHorizon (2 results)
adsatt.abcnews.starwave.com
Adsatt.ABCNews.starwave.com

```


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._