### PR TITLE
Add SSL configuration for web interface

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -52,29 +52,42 @@ include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
 include_shell "/usr/share/lighttpd/create-mime.assign.pl"
 include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 
-# If the URL starts with /admin, it is the Web interface
-$HTTP["url"] =~ "^/admin/" {
-	# Create a response header for debugging using curl -I
-    setenv.add-response-header = (
-        "X-Pi-hole" => "The Pi-hole Web interface is working!",
-        "X-Frame-Options" => "DENY"
-    )
+$SERVER["socket"] == ":443" {
+  protocol     = "https://"
+  ssl.engine = "enable"
+  ssl.pemfile = "/etc/lighttpd/ssl/pihole.pem"
+
+  # If the URL starts with /admin, it is the Web interface
+  $HTTP["url"] =~ "^/admin/" {
+  	# Create a response header for debugging using curl -I
+      setenv.add-response-header = (
+          "X-Pi-hole" => "The Pi-hole Web interface is working!",
+          "X-Frame-Options" => "DENY"
+      )
+  }
+
+  # Rewite js requests, must be out of $HTTP block due to bug #2526
+  url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
+
+  # If the URL does not start with /admin, then it is a query for an ad domain
+  $HTTP["url"] =~ "^(?!/admin)/.*" {
+      # Create a response header for debugging using curl -I
+      setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
+  }
+
+  # Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
+  $HTTP["host"] == "pi.hole" {
+      $HTTP["url"] == "/" {
+          url.redirect = ( "" => "/admin/" )
+      }
+  }
 }
 
-# Rewite js requests, must be out of $HTTP block due to bug #2526
-url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
-
-# If the URL does not start with /admin, then it is a query for an ad domain
-$HTTP["url"] =~ "^(?!/admin)/.*" {
-    # Create a response header for debugging using curl -I
-    setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-}
-
-# Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
-$HTTP["host"] == "pi.hole" {
-    $HTTP["url"] == "/" {
-        url.redirect = ( "" => "/admin/" )
-    }
+# Redirect all requests from port 80 to 443
+$SERVER["socket"] == ":80" {
+  $HTTP["host"] =~ ".*" {
+    url.redirect = (".*" => "https://%0$0")
+  }
 }
 
 # Add user chosen options held in external file

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -72,26 +72,51 @@ fastcgi.server = ( ".php" =>
                    )
                  )
 
-# If the URL starts with /admin, it is the Web interface
-$HTTP["url"] =~ "^/admin/" {
-	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "The Pi-hole Web interface is working!" )
+# SSL Configuration from cipherli.st for strong SSL Security for all modern
+ssl.honor-cipher-order = "enable"
+ssl.cipher-list = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
+ssl.use-compression = "disable"
+setenv.add-response-header = (
+    "Strict-Transport-Security" => "max-age=63072000; includeSubDomains; preload",
+    "X-Frame-Options" => "DENY",
+    "X-Content-Type-Options" => "nosniff"
+)
+ssl.use-sslv2 = "disable"
+ssl.use-sslv3 = "disable"
+
+$SERVER["socket"] == ":443" {
+  protocol     = "https://"
+  ssl.engine = "enable"
+  ssl.pemfile = "/etc/lighttpd/ssl/pihole.pem"
+
+  # If the URL starts with /admin, it is the Web interface
+  $HTTP["url"] =~ "^/admin/" {
+  	# Create a response header for debugging using curl -I
+  	setenv.add-response-header = ( "X-Pi-hole" => "The Pi-hole Web interface is working!" )
+  }
+
+  # Rewite js requests, must be out of $HTTP block due to bug #2526
+  url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
+
+  # If the URL does not start with /admin, then it is a query for an ad domain
+  $HTTP["url"] =~ "^(?!/admin)/.*" {
+  	# Create a response header for debugging using curl -I
+  	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
+  }
+
+  # Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
+  $HTTP["host"] == "pi.hole" {
+      $HTTP["url"] == "/" {
+          url.redirect = ( "" => "/admin/" )
+      }
+  }
 }
 
-# Rewite js requests, must be out of $HTTP block due to bug #2526
-url.rewrite = ( "^(?!/admin/).*\.js$"  => "pihole/index.js"   )
-
-# If the URL does not start with /admin, then it is a query for an ad domain
-$HTTP["url"] =~ "^(?!/admin)/.*" {
-	# Create a response header for debugging using curl -I
-	setenv.add-response-header = ( "X-Pi-hole" => "A black hole for Internet advertisements." )
-}
-
-# Entering just "pi.hole" into a browser redirects to "pi.hole/admin/"
-$HTTP["host"] == "pi.hole" {
-    $HTTP["url"] == "/" {
-        url.redirect = ( "" => "/admin/" )
-    }
+# Redirect all requests from port 80 to 443
+$SERVER["socket"] == ":80" {
+  $HTTP["host"] =~ ".*" {
+    url.redirect = (".*" => "https://%0$0")
+  }
 }
 
 # Add user chosen options held in external file

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1284,6 +1284,16 @@ CreateLogFile() {
   fi
 }
 
+createWebInterfaceCert() {
+  local webInterfaceCertDir="/etc/lighttpd/ssl"
+  # Create self-signed TLS certificates for web interface
+  mkdir "${webInterfaceCertDir}"
+  openssl req -new -x509 \
+    -keyout "${webInterfaceCertDir}"/pihole.pem -out "${webInterfaceCertDir}"/pihole.pem \
+    -subj "/CN=pi.hole"
+    -days 365 -nodes
+}
+
 # Install the Web interface dashboard
 installPiholeWeb() {
   echo ""
@@ -1351,6 +1361,11 @@ installPiholeWeb() {
     fi
 
   fi
+
+  # Install admin webinterface TLS certificates
+  echo ":::"
+  echo -n "::: Creating certificate for admin interface..."
+  createWebInterfaceCert
 
   # Install Sudoers file
   echo ""
@@ -1449,6 +1464,7 @@ configureFirewall() {
       echo -e "  ${TICK} Installing new IPTables firewall rulesets"
       # Check chain first, otherwise a new rule will duplicate old ones
       iptables -C INPUT -p tcp -m tcp --dport 80 -j ACCEPT &> /dev/null || iptables -I INPUT 1 -p tcp -m tcp --dport 80 -j ACCEPT
+      iptables -C INPUT -p tcp -m tcp --dport 443 -j ACCEPT &> /dev/null || iptables -I INPUT 1 -p tcp -m tcp --dport 443 -j ACCEPT
       iptables -C INPUT -p tcp -m tcp --dport 53 -j ACCEPT &> /dev/null || iptables -I INPUT 1 -p tcp -m tcp --dport 53 -j ACCEPT
       iptables -C INPUT -p udp -m udp --dport 53 -j ACCEPT &> /dev/null || iptables -I INPUT 1 -p udp -m udp --dport 53 -j ACCEPT
       iptables -C INPUT -p tcp -m tcp --dport 4711:4720 -i lo -j ACCEPT &> /dev/null || iptables -I INPUT 1 -p tcp -m tcp --dport 4711:4720 -i lo -j ACCEPT


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

3

---

Currently the web interface is only served over HTTP.  Their are some security concerns as the admin password could be captured if an attacker is listening to packets on the network.

This PR adds configuration to lighttpd to serve requests over port 443. It also modifies the lighttpd installation in the basic-install.sh script to create self-signed SSL certificates during installation.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
