### PR TITLE
Replace superseded netstat command

### DIFF
--- a/pihole
+++ b/pihole
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Pi-hole: A black hole for Internet advertisements
 # (c) 2017 Pi-hole, LLC (https://pi-hole.net)
 # Network-wide ad blocking via your own hardware.
@@ -8,11 +9,11 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
-colfile="/opt/pihole/COL_TABLE"
-source ${colfile}
-
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 readonly wildcardlist="/etc/dnsmasq.d/03-pihole-wildcard.conf"
+readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
+
+source ${colfile}
 
 # Must be root to use this tool
 if [[ ! $EUID -eq 0 ]];then
@@ -481,41 +482,41 @@ Options:
   echo -e "${OVER}  ${TICK} ${str}"
 }
 
-piholeStatus() {
-  if [[ "$(netstat -plnt | grep -c ':53 ')" -gt "0" ]]; then
-    if [[ "${1}" != "web" ]]; then
-      echo -e "  ${TICK} DNS service is running"
-    fi
+statusFunc() {
+  local addnConfigs
+
+  # Determine if service is running on port 53
+  if nc -z 127.0.0.1 53; then
+    [[ "${1}" != "web" ]] && echo -e "  ${TICK} DNS service is running"
   else
-    if [[ "${1}" == "web" ]]; then
-      echo "-1";
-    else
-      echo -e "  ${CROSS} DNS service is NOT running"
-    fi
-    return
+    case "${1}" in
+      "web") echo "-1";;
+      *) echo -e "  ${CROSS} DNS service is NOT running";;
+    esac
+    return 0
   fi
 
-  if [[ "$(grep -i "^#addn-hosts=/" /etc/dnsmasq.d/01-pihole.conf)" ]]; then
-    # List is commented out
-    if [[ "${1}" == "web" ]]; then
-      echo 0;
-    else
-      echo -e "  ${CROSS} Pi-hole blocking is Disabled";
-    fi
-  elif [[ "$(grep -i "^addn-hosts=/" /etc/dnsmasq.d/01-pihole.conf)" ]]; then
-    # List set
-    if [[ "${1}" == "web" ]]; then
-      echo 1;
-    else
-      echo -e "  ${TICK} Pi-hole blocking is Enabled";
-    fi
+  # Determine if any of Pi-hole's addn-hosts configs are commented out
+  addnConfigs=$(grep -i "addn-hosts=/" /etc/dnsmasq.d/01-pihole.conf)
+  
+  if [[ "${addnConfigs}" =~ "#" ]]; then
+    # A config is commented out
+    case "${1}" in
+      "web") echo 0;;
+      *) echo -e "  ${CROSS} Pi-hole blocking is Disabled";;
+    esac
+  elif [[ -n "${addnConfigs}" ]]; then
+    # Configs are set
+    case "${1}" in
+      "web") echo 1;;
+      *) echo -e "  ${TICK} Pi-hole blocking is Enabled";;
+    esac
   else
-    # Addn-host not found
-    if [[ "${1}" == "web" ]]; then
-      echo 99
-    else
-      echo -e "  ${INFO} No hosts file linked to dnsmasq, adding it in enabled state"
-    fi
+    # No configs were found
+    case "${1}" in
+      "web") echo 99;;
+      *) echo -e "  ${INFO} No hosts file linked to dnsmasq, adding it in enabled state";;
+    esac
     # Add addn-host= to dnsmasq
     echo "addn-hosts=/etc/pihole/gravity.list" >> /etc/dnsmasq.d/01-pihole.conf
     restartDNS
@@ -651,7 +652,7 @@ case "${1}" in
   "uninstall"                   ) uninstallFunc;;
   "enable"                      ) piholeEnable 1;;
   "disable"                     ) piholeEnable 0 "$2";;
-  "status"                      ) piholeStatus "$2";;
+  "status"                      ) statusFunc "$2";;
   "restartdns"                  ) restartDNS;;
   "-a" | "admin"                ) webpageFunc "$@";;
   "-t" | "tail"                 ) tailFunc;;

--- a/pihole
+++ b/pihole
@@ -485,9 +485,11 @@ Options:
 statusFunc() {
   local addnConfigs
 
-  # Determine if service is running on port 53
-  if nc -z 127.0.0.1 53; then
-    [[ "${1}" != "web" ]] && echo -e "  ${TICK} DNS service is running"
+  # Determine if service is running on port 53 (Cr: https://superuser.com/a/806331)
+  if (echo > /dev/tcp/localhost/53) >/dev/null 2>&1; then
+    if [[ "${1}" != "web" ]]; then
+      echo -e "  ${TICK} DNS service is running"
+    fi
   else
     case "${1}" in
       "web") echo "-1";;
@@ -496,7 +498,7 @@ statusFunc() {
     return 0
   fi
 
-  # Determine if any of Pi-hole's addn-hosts configs are commented out
+  # Determine if Pi-hole's addn-hosts configs are commented out
   addnConfigs=$(grep -i "addn-hosts=/" /etc/dnsmasq.d/01-pihole.conf)
   
   if [[ "${addnConfigs}" =~ "#" ]]; then
@@ -562,7 +564,7 @@ tricorderFunc() {
     exit 1
   fi
 
-  if ! timeout 2 nc -z tricorder.pi-hole.net 9998 &> /dev/null; then
+  if ! (echo > /dev/tcp/tricorder.pi-hole.net/9998) >/dev/null 2>&1; then
     echo -e "  ${CROSS} Unable to connect to Pi-hole's Tricorder server"
     exit 1
   fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

9

---

* Make colfile readonly, and use path of PI_HOLE_SCRIPT_DIR
* Rename piholeStatus function to statusFunc for function name consistency
* Replace superseded `netstat` command with `nc`
* Perform addn-hosts check using a single `grep` subshell