### PR TITLE
Add ignore-case switch to sort (domains)

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -296,7 +296,7 @@ gravity_unique() {
   local str="Removing duplicate domains"
   echo -ne "  ${INFO} ${str}..."
 
-  sort -u  ${piholeDir}/${supernova} > ${piholeDir}/${preEventHorizon}
+  sort -u -f ${piholeDir}/${supernova} > ${piholeDir}/${preEventHorizon}
 
   echo -e "${OVER}  ${TICK} ${str}"
   numberOf=$(wc -l < ${piholeDir}/${preEventHorizon})


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

3

---
Added "ignore-case" switch to the sort domains command, in gravity.sh
This is a bug fix. Duplicate domains are passed into the gravity list, if one of them contain any capitals. Like so:
```
::: /etc/pihole/list.preEventHorizon (2 results)
adsatt.abcnews.starwave.com
Adsatt.ABCNews.starwave.com

```


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._