### PR TITLE
Use full path for git on install

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -122,8 +122,8 @@ fully_fetch_repo() {
 
   cd "${directory}" || return 1
   if is_repo "${directory}"; then
-    git remote set-branches origin '*' || return 1
-    git fetch --quiet || return 1
+    /usr/bin/git remote set-branches origin '*' || return 1
+    /usr/bin/git fetch --quiet || return 1
   else
     return 1
   fi
@@ -138,7 +138,7 @@ get_available_branches() {
 
   cd "${directory}" || return 1
   # Get reachable remote branches, but store STDERR as STDOUT variable
-  output=$( { git remote show origin | grep 'tracked' | sed 's/tracked//;s/ //g'; } 2>&1 )
+  output=$( { /usr/bin/git remote show origin | grep 'tracked' | sed 's/tracked//;s/ //g'; } 2>&1 )
   echo "$output"
   return
 }
@@ -152,10 +152,10 @@ fetch_checkout_pull_branch() {
 
   # Set the reference for the requested branch, fetch, check it put and pull it
   cd "${directory}" || return 1
-  git remote set-branches origin "${branch}" || return 1
-  git stash --all --quiet &> /dev/null || true
-  git clean --quiet --force -d || true
-  git fetch --quiet || return 1
+  /usr/bin/git remote set-branches origin "${branch}" || return 1
+  /usr/bin/git stash --all --quiet &> /dev/null || true
+  /usr/bin/git clean --quiet --force -d || true
+  /usr/bin/git fetch --quiet || return 1
   checkout_pull_branch "${directory}" "${branch}" || return 1
 }
 
@@ -169,19 +169,19 @@ checkout_pull_branch() {
 
   cd "${directory}" || return 1
 
-  oldbranch="$(git symbolic-ref HEAD)"
+  oldbranch="$(/usr/bin/git symbolic-ref HEAD)"
 
   str="Switching to branch: '${branch}' from '${oldbranch}'"
   echo -ne "  ${INFO} $str"
-  git checkout "${branch}" --quiet || return 1
+  /usr/bin/git checkout "${branch}" --quiet || return 1
   echo -e "${OVER}  ${TICK} $str"
 
 
-  if [[ "$(git diff "${oldbranch}" | grep -c "^")" -gt "0" ]]; then
+  if [[ "$(/usr/bin/git diff "${oldbranch}" | grep -c "^")" -gt "0" ]]; then
     update="true"
   fi
 
-  git_pull=$(git pull || return 1)
+  git_pull=$(/usr/bin/git pull || return 1)
 
   if [[ "$git_pull" == *"up-to-date"* ]]; then
     echo -e "  ${INFO} ${git_pull}"
@@ -335,7 +335,7 @@ checkout() {
         FTLinstall "${binary}" "${path}"
     else
         echo "  ${CROSS} Requested branch \"${2}\" is not available"
-        ftlbranches=( $(git ls-remote https://github.com/pi-hole/ftl | grep 'heads' | sed 's/refs\/heads\///;s/ //g' | awk '{print $2}') )
+        ftlbranches=( $(/usr/bin/git ls-remote https://github.com/pi-hole/ftl | grep 'heads' | sed 's/refs\/heads\///;s/ //g' | awk '{print $2}') )
         echo -e "  ${INFO} Available branches for FTL are:"
         for e in "${ftlbranches[@]}"; do echo "      - $e"; done
         exit 1

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -244,7 +244,7 @@ is_repo() {
     cd "${directory}"
     # Use git to check if the folder is a repo
     # git -C is not used here to support git versions older than 1.8.4
-    git status --short &> /dev/null || rc=$?
+    /usr/bin/git status --short &> /dev/null || rc=$?
   # If the command was not successful,
   else
     # Set a non-zero return code if directory does not exist
@@ -271,7 +271,7 @@ make_repo() {
     rm -rf "${directory}"
   fi
   # Clone the repo and return the return code from this command
-  git clone -q --depth 1 "${remoteRepo}" "${directory}" &> /dev/null || return $?
+  /usr/bin/git clone -q --depth 1 "${remoteRepo}" "${directory}" &> /dev/null || return $?
   # Show a colored message showing it's status
   echo -e "${OVER}  ${TICK} ${str}"
   # Always return 0? Not sure this is correct
@@ -299,10 +299,10 @@ update_repo() {
   # Let the user know what's happening
   echo -ne "  ${INFO} ${str}..."
   # Stash any local commits as they conflict with our working code
-  git stash --all --quiet &> /dev/null || true # Okay for stash failure
-  git clean --quiet --force -d || true # Okay for already clean directory
+  /usr/bin/git stash --all --quiet &> /dev/null || true # Okay for stash failure
+  /usr/bin/git clean --quiet --force -d || true # Okay for already clean directory
   # Pull the latest commits
-  git pull --quiet &> /dev/null || return $?
+  /usr/bin/git pull --quiet &> /dev/null || return $?
   # Show a completion message
   echo -e "${OVER}  ${TICK} ${str}"
   # Move back into the oiginal directory
@@ -351,7 +351,7 @@ resetRepo() {
   # Show the message
   echo -ne "  ${INFO} ${str}"
   # Use git to remove the local changes
-  git reset --hard &> /dev/null || return $?
+  /usr/bin/git reset --hard &> /dev/null || return $?
   # And show the status
   echo -e "${OVER}  ${TICK} ${str}"
   # Returning success anyway?


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

1

---
Some versions of git do not like running as root (as actual root or with
sudo) when invoked from cli with just `$ git`. However using git from
default path (i.e. `$ /usr/bin/git`) works fine with root privileges.


_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
