### PR TITLE
Start and enable FTL prior to running Gravity

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2064,12 +2064,12 @@ main() {
     fi
   fi
 
-  # Download and compile the aggregated block list
-  runGravity
-
   # Enable FTL
   start_service pihole-FTL
   enable_service pihole-FTL
+
+  # Download and compile the aggregated block list
+  runGravity
 
   #
   if [[ "${useUpdateVars}" == false ]]; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

9

---

Currently, `basic-install.sh` performs the following:

* Start `dnsmasq`
* Enable `dnsmasq` on reboot
* Start `lighttpd`
* Enable `lighttpd` on reboot
* Run `gravity.sh`
* Start `FTL`
* Enable `FTL` on reboot

In the potential event that Gravity fails (e.g: Internet is not available, or user hits Ctrl-C), the user is left with an installation where FTL is not active. This fix aims to resolve that by ensuring that `gravity.sh` runs after enabling `FTL`.