### PR TITLE
Add wildcard support to adlists.list URL

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -264,7 +264,7 @@ gravity_ParseFileIntoDomains() {
   local source="${1}" destination="${2}" commentPattern firstLine abpFilter
 
   # Determine if we are parsing a consolidated list
-  if [[ "${source}" == "${piholeDir}/${matterAndLight}" ]] | [[ "${source}" == "${piholeDir}/${quasar}" ]]; then
+  if [[ "${source}" == "${piholeDir}/${matterAndLight}" ]] || [[ "${source}" == "${piholeDir}/${quasar}" ]]; then
     # Define symbols used as comments: #;@![/
     commentPattern="[#;@![\\/]"
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -458,13 +458,12 @@ gravity_Whitelist() {
   str="Whitelisting ${num} ${4}${plural}"
   echo -ne "  ${INFO} ${str}..."
 
+  # Print everything from preEventHorizon into whitelistMatter EXCEPT domains in $whitelistFile
   if [[ -z "${3}" ]]; then
     mv "${piholeDir}/${2}" "${piholeDir}/${2}.tmp"
     grep -F -x -v -f "${1}" "${piholeDir}/${2}.tmp" > "${piholeDir}/${2}"
     rm "${piholeDir}/${2}.tmp"
   else
-    # Print everything from preEventHorizon into whitelistMatter EXCEPT domains in $whitelistFile
-#  grep -F -x -v -f "${whitelistFile}" "${piholeDir}/${preEventHorizon}" > "${piholeDir}/${whitelistMatter}"
     grep -F -x -v -f "${1}" "${piholeDir}/${2}" > "${piholeDir}/${3}"
   fi
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -264,7 +264,7 @@ gravity_ParseFileIntoDomains() {
   local source="${1}" destination="${2}" commentPattern firstLine abpFilter
 
   # Determine if we are parsing a consolidated list
-  if [[ "${source}" == "${piholeDir}/${matterAndLight}" ]]; then
+  if [[ "${source}" == "${piholeDir}/${matterAndLight}" ]] | [[ "${source}" == "${piholeDir}/${quasar}" ]]; then
     # Define symbols used as comments: #;@![/
     commentPattern="[#;@![\\/]"
 
@@ -388,10 +388,10 @@ gravity_Schwarzschild() {
     if [[ -r "${i}" ]] & [[ ${listExtension} = ${2} ]]; then
       # Remove windows CRs from file, and append into $matterAndLight/$wildDuckCluster
       tr -d '\r' < "${i}" | tr '[:upper:]' '[:lower:]' >> "${piholeDir}/${1}"
+      
       # Ensure that the first line of a new list is on a new line
       lastLine=$(tail -1 "${piholeDir}/${1}")
-      countLines=$(wc -l < "${piholeDir}/${1}")
-      if [[ "${#lastLine}" -gt 0 ]] & [[ ${countLines} < 2 ]]; then
+      if [[ "${#lastLine}" -gt 0 ]]; then
         echo "" >> "${piholeDir}/${1}"
       fi
     fi

--- a/gravity.sh
+++ b/gravity.sh
@@ -391,7 +391,7 @@ gravity_Schwarzschild() {
       # Ensure that the first line of a new list is on a new line
       lastLine=$(tail -1 "${piholeDir}/${1}")
       countLines=$(wc -l < "${piholeDir}/${1}")
-      if [[ "${#lastLine}" -gt 0 ]] & [[ countLines < 2 ]]; then
+      if [[ "${#lastLine}" -gt 0 ]] & [[ ${countLines} < 2 ]]; then
         echo "" >> "${piholeDir}/${1}"
       fi
     fi

--- a/gravity.sh
+++ b/gravity.sh
@@ -396,7 +396,6 @@ gravity_Schwarzschild() {
       fi
     fi
   done
-  
 
   echo -e "${OVER}  ${TICK} ${str}"
 }

--- a/gravity.sh
+++ b/gravity.sh
@@ -369,7 +369,7 @@ gravity_ParseFileIntoDomains() {
     fi
   fi
 }
-      
+
 # Create (unfiltered) "Matter and Light" or "Wild Duck Cluster" consolidated list
 gravity_Schwarzschild() {
   local str lastLine


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

4

---
## Summary
 * Add backend support for wildcard domains in adlists.list. Simply add " w" after a URL in adlists.list
 * Hosts domains that exist in wildcard domains will be removed to keep hosts file free of redundant entries.
 * Refactored some functions to enable reuse with wildcard BL files as well
 
### Tested:
 * Add " w" to end of url in adslist.list will be wildcard blocked
 * Verify domains in wildcard BL don't exist in host BL
 * Verify whitelisted domains don't exist in wildcard BL as well
 * If example.com is whitelisted and ab.example.com is is in wildcardBL, *.example.com is accessible except *.ab.example.com
 * If ab.example.com is whitelisted and example.com is in wildcardBL, ab.example.com is blocked

### Notable changes:

gravity_Collapse
 * after mapfile, process lines as columns to parse wildcard indicator -- url followed by " w"
 * savelocation extension variable
 * Depending on wildcard switch (or lack of), downloaded lists will have extension from new variable blockListType
    
gravity_Supernova
 * Dynamic saveLocation extension for host/wildcard lists -- domains/sdomains
  
gravity_Cleanup
 * Add ${wildcardExtension} extension

gravity_ParseFileIntoDomains
 * Add to IF, ${quasar} for wildcard source

gravity_Schwarzschild
 * Refactoring - replace filename with parameters, for use with both hosts and wildcard files
 * Determine correct file extension (to process) for appropriate host/wildcard temp file

gravity_Filter
 * Refactoring - replaced filenames with parameters, for use with both hosts and wildcard files
 * echo count message Replace "domain" with parameter (domain/subdomain)
 
 gravity_Whitelist()
  * Refactoring - replaced filenames with parameters
  * Console output uses parameter to dynamically output domain/sub-domain

New gravity_ParseSubdomainsIntoConfig (borrowed from gravity_ParseDomainsIntoHosts)
 * Parse list of sub-domains into config format (address=)

New gravity_ReducePreEventHorizon
 * De-duplicate wildcarded sub-domains that exist in hosts list
 
### To do:
 * Correct WebGUI numbers and stats
 * Adjust console outputs
 * Add/edit comments
 * Remove user wildcard domains (03-pihole-wildcard.conf) that exist in adlist-wildcard domains
 * Allow adslist.list wildcard column "w" to be caseinsensitive (?)
 * Add back-end support for wildcard whitelist ".example.com" or "*.example.com"
 
### Suitable wildcard BL urls
  * https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
  * https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
  * https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt
  * https://pgl.yoyo.org/adservers/serverlist.php?hostformat=nohtml
_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
