### PR TITLE
Append ".vpn" TLD for OpenVPN host names

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -503,7 +503,7 @@ gravity_ParseLocalDomains() {
 
   # Add additional LAN hosts provided by OpenVPN (if available)
   if [[ -f "${VPNList}" ]]; then
-    awk -F, '{printf $2"\t"$1"\n"}' "${VPNList}" >> "${localList}"
+    awk -F, '{printf $2"\t"$1".vpn\n"}' "${VPNList}" >> "${localList}"
   fi
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---
When using the Pi-hole DHCP server, local host names are augmented by the TLD `.local`.
This PR append host names of clients that are connected via VPN by a similar TLD ".vpn".

before:
<pre>
echo ">client-names" | nc pi.hole 4711
0 2841 10.8.0.2 cuda
1 9329 127.0.0.1 localhost
2 1027 10.8.0.6 Thinkpad
3 322 192.168.2.2 android-phone.local
4 4142 192.168.2.3 desktop.local
5 638 192.168.2.5 android-tablet.local
6 914 192.168.2.4 desktop2.local
7 452 192.168.2.6 ThinkPad.local
---EOM---
</pre>

With this PR:
<pre>
echo ">client-names" | nc pi.hole 4711
0 2841 10.8.0.2 cuda<b>.vpn</b>
1 9329 127.0.0.1 localhost
2 1027 10.8.0.6 Thinkpad<b>.vpn</b>
3 322 192.168.2.2 android-phone.local
4 4142 192.168.2.3 desktop.local
5 638 192.168.2.5 android-tablet.local
6 914 192.168.2.4 desktop2.local
7 452 192.168.2.6 ThinkPad.local
---EOM---
</pre>

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
