### PR TITLE
Add comment for include_shell feature

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -2,12 +2,10 @@
 # (c) 2017 Pi-hole, LLC (https://pi-hole.net)
 # Network-wide ad blocking via your own hardware.
 #
-# lighttpd config for Pi-hole
+# Lighttpd config for Pi-hole
 #
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
-
-
 
 ###############################################################################
 #     FILE AUTOMATICALLY OVERWRITTEN BY PI-HOLE INSTALL/UPDATE PROCEDURE.     #
@@ -39,7 +37,6 @@ server.port                 = 80
 accesslog.filename          = "/var/log/lighttpd/access.log"
 accesslog.format            = "%{%s}t|%V|%r|%s|%b"
 
-
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny             = ( "~", ".inc", ".md", ".yml", ".ini" )
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
@@ -50,16 +47,19 @@ compress.filetype           = ( "application/javascript", "text/css", "text/html
 # default listening port for IPv6 falls back to the IPv4 port
 include_shell "/usr/share/lighttpd/use-ipv6.pl " + server.port
 include_shell "/usr/share/lighttpd/create-mime.assign.pl"
+
+# Prevent Lighttpd from enabling Let's Encrypt SSL for every blocked domain
 #include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 include_shell "find /etc/lighttpd/conf-enabled -name '*.conf' -a ! -name 'letsencrypt.conf' -printf 'include \"%p\"\n' 2>/dev/null"
 
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
-	# Create a response header for debugging using curl -I
+    # Create a response header for debugging using curl -I
     setenv.add-response-header = (
         "X-Pi-hole" => "The Pi-hole Web interface is working!",
         "X-Frame-Options" => "DENY"
     )
+
     $HTTP["url"] =~ ".ttf$" {
         # Allow Block Page access to local fonts
         setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )

--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -11,7 +11,7 @@
 #     FILE AUTOMATICALLY OVERWRITTEN BY PI-HOLE INSTALL/UPDATE PROCEDURE.     #
 # ANY CHANGES MADE TO THIS FILE AFTER INSTALL WILL BE LOST ON THE NEXT UPDATE #
 #                                                                             #
-#              CHANGES SHOULD BE MADE IN A SEPERATE CONFIG FILE:              #
+#              CHANGES SHOULD BE MADE IN A SEPARATE CONFIG FILE:              #
 #                         /etc/lighttpd/external.conf                         #
 ###############################################################################
 

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -7,8 +7,6 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
-
-
 ###############################################################################
 #     FILE AUTOMATICALLY OVERWRITTEN BY PI-HOLE INSTALL/UPDATE PROCEDURE.     #
 # ANY CHANGES MADE TO THIS FILE AFTER INSTALL WILL BE LOST ON THE NEXT UPDATE #
@@ -74,11 +72,12 @@ fastcgi.server = ( ".php" =>
 
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
-	# Create a response header for debugging using curl -I
+	  # Create a response header for debugging using curl -I
     setenv.add-response-header = (
         "X-Pi-hole" => "The Pi-hole Web interface is working!",
         "X-Frame-Options" => "DENY"
     )
+
     $HTTP["url"] =~ ".ttf$" {
         # Allow Block Page access to local fonts
         setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -13,7 +13,7 @@
 #     FILE AUTOMATICALLY OVERWRITTEN BY PI-HOLE INSTALL/UPDATE PROCEDURE.     #
 # ANY CHANGES MADE TO THIS FILE AFTER INSTALL WILL BE LOST ON THE NEXT UPDATE #
 #                                                                             #
-#              CHANGES SHOULD BE MADE IN A SEPERATE CONFIG FILE:              #
+#              CHANGES SHOULD BE MADE IN A SEPARATE CONFIG FILE:              #
 #                         /etc/lighttpd/external.conf                         #
 ###############################################################################
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

9

---
The code `include_shell "find /etc/lighttpd/conf-enabled -name '*.conf' -a ! -name 'letsencrypt.conf' -printf 'include \"%p\"\n' 2>/dev/null"` was included with #1420, but does not include a clear comment as to why this line is important.

* Capitalise first letter for Lighttpd
* Fix spacing
* Add comment for include_shell feature
* Fix SEPARATE typo