### PR TITLE
Add nuclear option to list.sh

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -49,7 +49,8 @@ Options:
   -nr, --noreload     Update ${type}list without refreshing dnsmasq
   -q, --quiet         Make output less verbose
   -h, --help          Show this help dialog
-  -l, --list          Display all your ${type}listed domains"
+  -l, --list          Display all your ${type}listed domains
+  --nuke              Removes all entries in a list"
 
   exit 0
 }
@@ -70,7 +71,7 @@ HandleOther() {
     validDomain=$(grep -P "^((-|_)*[a-z\d]((-|_)*[a-z\d])*(-|_)*)(\.(-|_)*([a-z\d]((-|_)*[a-z\d])*))*$" <<< "${domain}") # Valid chars check
     validDomain=$(grep -P "^[^\.]{1,63}(\.[^\.]{1,63})*$" <<< "${validDomain}") # Length of each label
   fi
-  
+
   if [[ -n "${validDomain}" ]]; then
     domList=("${domList[@]}" ${validDomain})
   else
@@ -223,6 +224,12 @@ Displaylist() {
   exit 0;
 }
 
+NukeList() {
+  if [[ -f "${listMain}" ]]; then
+    echo "" > "${listMain}"
+  fi
+}
+
 for var in "$@"; do
   case "${var}" in
     "-w" | "whitelist"   ) listMain="${whitelist}"; listAlt="${blacklist}";;
@@ -234,6 +241,7 @@ for var in "$@"; do
     "-q" | "--quiet"     ) verbose=false;;
     "-h" | "--help"      ) helpFunc;;
     "-l" | "--list"      ) Displaylist;;
+    "--nuke"             ) NukeList;;
     *                    ) HandleOther "${var}";;
   esac
 done

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -226,6 +226,9 @@ Displaylist() {
 
 NukeList() {
   if [[ -f "${listMain}" ]]; then
+    # Back up original list
+    cp "${listMain}" "${listMain}.bck"
+    # Empty out file
     echo "" > "${listMain}"
   fi
 }

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -227,7 +227,7 @@ Displaylist() {
 NukeList() {
   if [[ -f "${listMain}" ]]; then
     # Back up original list
-    cp "${listMain}" "${listMain}.bck"
+    cp "${listMain}" "${listMain}.bck~"
     # Empty out file
     echo "" > "${listMain}"
   fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

Add `--nuke` option to list.sh that can be used e.g. by Teleporter to empty out lists before importing new content. Will be used by https://github.com/pi-hole/AdminLTE/pull/595

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
