### PR TITLE
Disable password field on block page if no password is set

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -218,6 +218,7 @@ if (explode("-", $phVersion)[1] != "0")
         // Enable password input if necessary
         if (!empty($svPasswd)) {
           echo '$("#bpWLPassword").attr("placeholder", "Password");';
+          echo '$("#bpWLPassword").css("display", "inline-block");';
           echo '$("#bpWLPassword").prop("disabled", false);';
         }
       }
@@ -273,7 +274,7 @@ if (explode("-", $phVersion)[1] != "0")
     
     <form id="bpWLButtons" class="buttons">
       <input id="bpWLDomain" type="text" value="<?=$serverName ?>" disabled/>
-      <input id="bpWLPassword" type="password" placeholder="<?=$wlPlaceHolder ?>" disabled/><button id="bpWhitelist" type="button" disabled></button>
+      <input id="bpWLPassword" type="password" placeholder="<?=$wlPlaceHolder ?>" disabled style="display: none"/><button id="bpWhitelist" type="button" disabled></button>
     </form>
   </div>
 </main>

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -98,9 +98,6 @@ if ($serverName === "pi.hole") {
 
 /* Start processing Block Page from here */
 
-// Determine placeholder text based off $svPasswd presence
-$wlPlaceHolder = empty($svPasswd) ? "" : "Javascript disabled";
-
 // Define admin email address text based off $svEmail presence
 $bpAskAdmin = !empty($svEmail) ? '<a href="mailto:'.$svEmail.'?subject=Site Blocked: '.$serverName.'"></a>' : "<span/>";
 
@@ -304,7 +301,7 @@ setHeader();
 
     <form id="bpWLButtons" class="buttons">
       <input id="bpWLDomain" type="text" value="<?=$serverName ?>" disabled/>
-      <input id="bpWLPassword" type="password" placeholder="<?=$wlPlaceHolder ?>" disabled/><button id="bpWhitelist" type="button" disabled></button>
+      <input id="bpWLPassword" type="password" placeholder="Javascript disabled" disabled/><button id="bpWhitelist" type="button" disabled></button>
     </form>
   </div>
 </main>

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -99,7 +99,7 @@ if ($serverName === "pi.hole") {
 /* Start processing Block Page from here */
 
 // Determine placeholder text based off $svPasswd presence
-$wlPlaceHolder = empty($svPasswd) ? "No admin password set" : "Javascript disabled";
+$wlPlaceHolder = empty($svPasswd) ? "" : "Javascript disabled";
 
 // Define admin email address text based off $svEmail presence
 $bpAskAdmin = !empty($svEmail) ? '<a href="mailto:'.$svEmail.'?subject=Site Blocked: '.$serverName.'"></a>' : "<span/>";
@@ -246,6 +246,10 @@ setHeader();
         if (!empty($svPasswd)) {
           echo '$("#bpWLPassword").attr("placeholder", "Password");';
           echo '$("#bpWLPassword").prop("disabled", false);';
+        }
+        // Otherwise hide the input
+        else {
+          echo '$("#bpWLPassword").hide();';
         }
       }
       ?>

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -245,7 +245,6 @@ setHeader();
         // Enable password input if necessary
         if (!empty($svPasswd)) {
           echo '$("#bpWLPassword").attr("placeholder", "Password");';
-          echo '$("#bpWLPassword").css("display", "inline-block");';
           echo '$("#bpWLPassword").prop("disabled", false);';
         }
       }
@@ -301,7 +300,7 @@ setHeader();
 
     <form id="bpWLButtons" class="buttons">
       <input id="bpWLDomain" type="text" value="<?=$serverName ?>" disabled/>
-      <input id="bpWLPassword" type="password" placeholder="<?=$wlPlaceHolder ?>" disabled style="display: none"/><button id="bpWhitelist" type="button" disabled></button>
+      <input id="bpWLPassword" type="password" placeholder="<?=$wlPlaceHolder ?>" disabled/><button id="bpWhitelist" type="button" disabled></button>
     </form>
   </div>
 </main>

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -209,11 +209,17 @@ if (explode("-", $phVersion)[1] != "0")
     window.onload = function () {
       <?php
       // Remove href fallback from "Back to safety" button
-      if ($featuredTotal > 0) echo '$("#bpBack").removeAttr("href");';
-      // Enable whitelisting if $svPasswd is present & JS is available
-      if (!empty($svPasswd) && $featuredTotal > 0) {
-          echo '$("#bpWLPassword, #bpWhitelist").prop("disabled", false);';
+      if ($featuredTotal > 0) {
+        echo '$("#bpBack").removeAttr("href");';
+
+        // Enable whitelisting if JS is available
+        echo '$("#bpWhitelist").prop("disabled", false);';
+
+        // Enable password input if necessary
+        if (!empty($svPasswd)) {
           echo '$("#bpWLPassword").attr("placeholder", "Password");';
+          echo '$("#bpWLPassword").prop("disabled", false);';
+        }
       }
       ?>
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

For when you want to whitelist a domain and no password is set.
Requires pi-hole/AdminLTE#597

![screenshot from 2017-10-07 16-50-02](https://user-images.githubusercontent.com/4417660/31312942-8ba3f348-aba0-11e7-859b-157e5ffe6513.png)

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
