### PR TITLE
tests: assert user in docker group or root

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,7 +28,7 @@ def Pihole(Docker):
 @pytest.fixture
 def Docker(request, args, image, cmd):
     ''' combine our fixtures into a docker run command and setup finalizer to cleanup '''
-    assert 'docker' in check_output('id'), "Are you in the docker group?"
+    assert (('root' in check_output('id')) or ('docker' in check_output('id'))), "Are you in the docker group?"
     docker_run = "docker run {} {} {}".format(args, image, cmd)
     docker_id = check_output(docker_run)
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**
7
_{replace this text with a number from 1 to 10, with 1 being not familiar, and 10 being very familiar}_

---
Tests should execute successfully with `docker` group membership **or** the `root` user. 
This change will allow contributors to:
 - Perform tests inside `docker` without the need to implement users and groups inside containers.
 - Compatibility with alternative CI

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
