### PR TITLE
Fix query option handling

### DIFF
--- a/pihole
+++ b/pihole
@@ -154,7 +154,7 @@ Options:
 
   # Strip valid options, leaving only the domain and invalid options
   # This allows users to place the options before or after the domain
-  options=$(sed -E 's/ ?-(bp|adlists?|all|exact)//g' <<< "${options}")
+  options=$(sed -E 's/ ?-(bp|adlists?|all|exact) ?//g' <<< "${options}")
 
   # Handle remaining options
   # If $options contain non ASCII characters, convert to punycode

--- a/pihole
+++ b/pihole
@@ -85,7 +85,8 @@ updateGravityFunc() {
 
 # Scan an array of files for matching strings
 scanList(){
-  local domain="${1}" lists="${2}" type="${3:-}"
+  # Escape full stops
+  local domain="${1//./\\.}" lists="${2}" type="${3:-}"
 
   # Prevent grep from printing file path
   cd "/etc/pihole" || exit 1


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---
Before:
```
pihole -q asd -exact
  [i] No exact results found for asd found within block lists
pihole -q -exact asd
Unknown query option specified
Try 'pihole -q --help' for more information.
```

After:
```
pihole -q asd -exact
  [i] No exact results found for asd found within block lists
pihole -q -exact asd
  [i] No exact results found for asd found within block lists
```