### PR TITLE
Wildcarding doesn't restart dnsmasq

### DIFF
--- a/pihole
+++ b/pihole
@@ -336,7 +336,7 @@ restartDNS() {
   if [[ "${svcOption}" =~ "reload" ]]; then
     # Using SIGHUP will NOT re-read any *.conf files
     svc="killall -s SIGHUP dnsmasq"
-  elif [[ -z "${svcOption}" ]]; then
+  else
     # Get PID of dnsmasq to determine if it needs to start or restart
     if pidof dnsmasq &> /dev/null; then
       svcOption="restart"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

10

---

When wildcarding a domain, `dnsmasq` is not restarted as `$dnsRestartType` in `gravity.sh` was passing `restart` through to `restartDNS()`.