### PR TITLE
Randomize gravity update time

### DIFF
--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -14,8 +14,8 @@
 # is updated or re-installed. Please make any changes to the appropriate crontab
 # or other cron file snippets.
 
-# Pi-hole: Update the ad sources once a week on Sunday at 01:59
-#          Download any updates from the adlists
+# Pi-hole: Update the ad sources once a week on Sunday at a random time in the
+#          early morning. Download any updates from the adlists
 59 1    * * 7   root    PATH="$PATH:/usr/local/bin/" pihole updateGravity
 
 # Pi-hole: Update Pi-hole! Uncomment to enable auto update

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1356,6 +1356,8 @@ installCron() {
   echo -ne "  ${INFO} ${str}..."
   # Copy the cron file over from the local repo
   cp ${PI_HOLE_LOCAL_REPO}/advanced/pihole.cron /etc/cron.d/pihole
+  # Randomize gravity update time
+  sed -i "s/59 1/$((RANDOM % 60)) $((RANDOM % 2))/" /etc/cron.d/pihole
   echo -e "${OVER}  ${TICK} ${str}"
 }
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1357,7 +1357,7 @@ installCron() {
   # Copy the cron file over from the local repo
   cp ${PI_HOLE_LOCAL_REPO}/advanced/pihole.cron /etc/cron.d/pihole
   # Randomize gravity update time
-  sed -i "s/59 1/$((RANDOM % 60)) $((2 + RANDOM % 2))/" /etc/cron.d/pihole
+  sed -i "s/59 1/$((1 + RANDOM % 58)) $((3 + RANDOM % 2))/" /etc/cron.d/pihole
   echo -e "${OVER}  ${TICK} ${str}"
 }
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1357,7 +1357,7 @@ installCron() {
   # Copy the cron file over from the local repo
   cp ${PI_HOLE_LOCAL_REPO}/advanced/pihole.cron /etc/cron.d/pihole
   # Randomize gravity update time
-  sed -i "s/59 1/$((RANDOM % 60)) $((RANDOM % 2))/" /etc/cron.d/pihole
+  sed -i "s/59 1/$((RANDOM % 60)) $((2 + RANDOM % 2))/" /etc/cron.d/pihole
   echo -e "${OVER}  ${TICK} ${str}"
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

See title. This PR implements a [feature request on Discourse](https://discourse.pi-hole.net/t/randomize-time-of-crons-pihole-g-process-for-getting-all-files/4452).
Instead of updating at a fixed local time of 01:59, we randomize the time on each update from 03:01 to 04:58.

Edit: We run the job after 3 AM to circumvent DST issues.

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
