### PR TITLE
Silence non-numeric domains_being_blocked output

### DIFF
--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -302,7 +302,8 @@ get_sys_stats() {
 
   # Determine whether to display CPU clock speed as MHz or GHz
   if [[ -n "$cpu_mhz" ]]; then
-    [[ "$cpu_mhz" -le "999" ]] && cpu_freq="$cpu_mhz MHz" || cpu_freq="$(calcFunc "$cpu_mhz"/1000) GHz"
+    [[ "$cpu_mhz" -le "999" ]] && cpu_freq="$cpu_mhz MHz" || cpu_freq="$(printf "%.1f" $(calcFunc "$cpu_mhz"/1000)) GHz"
+    [[ "${cpu_freq}" == *".0"* ]] && cpu_freq="${cpu_freq/.0/}"
   fi
 
   # Determine colour for temperature
@@ -380,7 +381,7 @@ get_ftl_stats() {
     local top_domain_raw
     local top_client_raw
 
-    domains_being_blocked=$(printf "%.0f\\n" "${domains_being_blocked_raw}")
+    domains_being_blocked=$(printf "%.0f\\n" "${domains_being_blocked_raw}" 2> /dev/null)
     dns_queries_today=$(printf "%.0f\\n" "${dns_queries_today_raw}")
     ads_blocked_today=$(printf "%.0f\\n" "${ads_blocked_today_raw}")
     ads_percentage_today=$(printf "%'.0f\\n" "${ads_percentage_today_raw}")
@@ -403,9 +404,9 @@ get_ftl_stats() {
 get_strings() {
   # Expand or contract strings depending on screen size
   if [[ "$chrono_width" == "large" ]]; then
-    phc_str="        ${COL_DARK_GRAY}Pi-hole"
-    lte_str="         ${COL_DARK_GRAY}Admin"
-    ftl_str="           ${COL_DARK_GRAY}FTL"
+    phc_str="        ${COL_DARK_GRAY}Core"
+    lte_str="        ${COL_DARK_GRAY}Web"
+    ftl_str="        ${COL_DARK_GRAY}FTL"
     api_str="${COL_LIGHT_RED}API Offline"
 
     host_info="$sys_type"
@@ -419,7 +420,7 @@ get_strings() {
     ph_info="Blocking: $domains_being_blocked sites"
     total_str="Total: "
   else
-    phc_str="   ${COL_DARK_GRAY}PH"
+    phc_str=" ${COL_DARK_GRAY}Core"
     lte_str=" ${COL_DARK_GRAY}Web"
     ftl_str=" ${COL_DARK_GRAY}FTL"
     api_str="${COL_LIGHT_RED}API Down"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

9

---
Primarily a fix for https://github.com/pi-hole/FTL/pull/143, with some other minor changes.

* Round $cpu_mhz to 1 decimal place
* Remove ".0" from $cpu_freq
* Silence non-numeric domains_being_blocked output
* Use "Core" and "Web" as appropriate