### PR TITLE
Send SIGHUP to pihole-FTL when restarting/reloading dnsmasq

### DIFF
--- a/pihole
+++ b/pihole
@@ -346,9 +346,6 @@ restartDNS() {
     svc="service dnsmasq ${svcOption}"
   fi
 
-  # Send signal to FTL to have it re-parse the gravity files
-  killall -s SIGHUP pihole-FTL
-
   # Print output to Terminal, but not to Web Admin
   str="${svcOption^}ing DNS service"
   [[ -t 1 ]] && echo -ne "  ${INFO} ${str}..."
@@ -362,6 +359,9 @@ restartDNS() {
     [[ ! -t 1 ]] && local OVER=""
     echo -e "${OVER}  ${CROSS} ${output}"
   fi
+
+  # Send signal to FTL to have it re-parse the gravity files
+  killall -s SIGHUP pihole-FTL
 }
 
 piholeEnable() {

--- a/pihole
+++ b/pihole
@@ -200,7 +200,7 @@ Options:
 
   # Scan Wildcards
   if [[ -e "${wildcardlist}" ]]; then
-    # Determine all subdomains, domain and TLDs 
+    # Determine all subdomains, domain and TLDs
     mapfile -t wildcards <<< "$(processWildcards "${domainQuery}")"
 
     for match in "${wildcards[@]}"; do
@@ -346,6 +346,9 @@ restartDNS() {
     svc="service dnsmasq ${svcOption}"
   fi
 
+  # Send signal to FTL to have it re-parse the gravity files
+  killall -s SIGHUP pihole-FTL
+
   # Print output to Terminal, but not to Web Admin
   str="${svcOption^}ing DNS service"
   [[ -t 1 ]] && echo -ne "  ${INFO} ${str}..."
@@ -483,7 +486,7 @@ statusFunc() {
 
   # Determine if Pi-hole's addn-hosts configs are commented out
   addnConfigs=$(grep -i "addn-hosts=/" /etc/dnsmasq.d/01-pihole.conf)
-  
+
   if [[ "${addnConfigs}" =~ "#" ]]; then
     # A config is commented out
     case "${1}" in


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

See title. Due to a breaking change in commit https://github.com/pi-hole/pi-hole/commit/a2825be81961cee4ddbb37f9e984fe6a27faa99a, we have to inform `FTL` of the fact that we restarted `dnsmasq` resp. had it reload its files as `FTL` cannot detect this. The actual bug fix is in https://github.com/pi-hole/FTL/pull/151

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
