### PR TITLE
basic-install.sh - no CIDR in ifcfg-*

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -684,13 +684,13 @@ setStaticIPv4() {
   elif [[ -f "/etc/sysconfig/network-scripts/ifcfg-${PIHOLE_INTERFACE}" ]];then
     # If it exists,
     IFCFG_FILE=/etc/sysconfig/network-scripts/ifcfg-${PIHOLE_INTERFACE}
+    IPADDR=$(echo "${IPV4_ADDRESS}" | cut -f1 -d/)
     # check if the desired IP is already set
-    if grep -q "${IPV4_ADDRESS}" "${IFCFG_FILE}"; then
+    if grep -q "${IPADDR}" "${IFCFG_FILE}"; then
       echo -e "  ${INFO} Static IP already configured"
     # Otherwise,
     else
       # Put the IP in variables without the CIDR notation
-      IPADDR=$(echo "${IPV4_ADDRESS}" | cut -f1 -d/)
       CIDR=$(echo "${IPV4_ADDRESS}" | cut -f2 -d/)
       # Backup existing interface configuration:
       cp "${IFCFG_FILE}" "${IFCFG_FILE}".pihole.orig


### PR DESCRIPTION
Do not expect CIDR format IP addresses in /etc/sysconfig/network-scripts/ifcfg-* files as it is not a requirement.
Expect only:
IPADDR=10.10.10.10
Do not expect:
IPADDR=10.10.10.10/24

**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

_7_

---
_I tried to install Pi-hole on Fedora 27 today and the script died after damaging the network configuration_

1. I configured a network bridge via nmcli. This built /etc/sysconfig/network-scripts/ifcfg-br0
2. I put my IPADDR=10.10.10.10 in it without a trailing /24 because it works fine that way.
3. I ran 'curl -sSL https://install.pi-hole.net | bash'
4. The result failed to find 10.10.10.10 in /etc/sysconfig/network-scripts/ifcfg-br0 because it was looking for 10.10.10.10/24 
5. Then the installation script wrote a broken /etc/sysconfig/network-scripts/ifcfg-br0 which caused the network to go offline.
6. Finally the installation script complained it could not get _git pull ..._ to work (It's dead, Jim).
7. I updated the script to look for the IP address in the ifcfg-br0 file correctly. (I could fix a rainy day).

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
