### PR TITLE
Add support for local blocking lists

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -230,8 +230,7 @@ gravity_Pull() {
         else
           echo -e "${OVER}  ${CROSS} ${str} Not found / empty list"
         fi;;
-    *      )
-        echo -e "${OVER}  ${CROSS} ${str} ${url} ${httpCode}";;
+    *) echo -e "${OVER}  ${CROSS} ${str} ${url} ${httpCode}";;
   esac
 
   # Determine if the blocklist was downloaded and saved correctly

--- a/gravity.sh
+++ b/gravity.sh
@@ -228,7 +228,7 @@ gravity_Pull() {
         if [[ -s "${patternBuffer}" ]]; then
           echo -e "${OVER}  ${TICK} ${str} Retrieval successful"; success=true
         else
-          echo -e "${OVER}  ${CROSS} ${str} Not found"
+          echo -e "${OVER}  ${CROSS} ${str} Not found / empty list"
         fi;;
     *      ) echo -e "${OVER}  ${CROSS} ${str} ${url} ${httpCode}";;
   esac

--- a/gravity.sh
+++ b/gravity.sh
@@ -230,7 +230,8 @@ gravity_Pull() {
         else
           echo -e "${OVER}  ${CROSS} ${str} Not found / empty list"
         fi;;
-    *      ) echo -e "${OVER}  ${CROSS} ${str} ${url} ${httpCode}";;
+    *      )
+        echo -e "${OVER}  ${CROSS} ${str} ${url} ${httpCode}";;
   esac
 
   # Determine if the blocklist was downloaded and saved correctly

--- a/gravity.sh
+++ b/gravity.sh
@@ -138,7 +138,7 @@ gravity_Collapse() {
     # Logic: Split by folder/port
     awk -F '[/:]' '{
       # Remove URL protocol & optional username:password@
-      gsub(/(.*:\/\/|)/, "", $0)
+      gsub(/(.*:\/\/|.*:.*@)/, "", $0)
       if(length($1)>0){print $1}
       else {print "local"}
     }' <<< "$(printf '%s\n' "${sources[@]}")" 2> /dev/null


### PR DESCRIPTION
**By submitting this pull request, I confirm the following (please check boxes, eg [X]) _Failure to fill the template will close your PR_:**

***Please submit all pull requests against the `development` branch. Failure to do so will delay or deny your request***

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [X] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

## 10

---

This PR adds support for local blocking lists using the file protocol (e.g. `file:///home/pi/mylist.txt`).

Exemplary `adlists.list`:
```
https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist
https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
https://hosts-file.net/ad_servers.txt
https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
https://mirror1.malwaredomains.com/files/justdomains

file:///home/pi/test.list
file:///home/pi/test123.list
```
Note the two `file://` lists at the end of the file. The first one exists, the second one doesn't exist. Running `pihole -g` produces the following output:
```
  [i] Neutrino emissions detected...
  [✓] Pulling blocklist source list into range

  [i] Target: zeustracker.abuse.ch (blocklist.php?download=domainblocklist)
  [✓] Status: No changes detected

  [i] Target: s3.amazonaws.com (simple_tracking.txt)
  [✓] Status: No changes detected

  [i] Target: s3.amazonaws.com (simple_ad.txt)
  [✓] Status: No changes detected

  [i] Target: hosts-file.net (ad_servers.txt)
  [✓] Status: No changes detected

  [i] Target: raw.githubusercontent.com (hosts)
  [✓] Status: Retrieval successful

  [i] Target: mirror1.malwaredomains.com (justdomains)
  [✓] Status: No changes detected

  [i] Target: local (test.list)        <------------------- this file exists
  [✓] Status: Retrieval successful

  [i] Target: local (test123.list)     <------------------- this file doesn't exist
  [✗] Status: Not found / empty list
  [✗] List download failed: no cached list available

  [✓] Consolidating blocklists
  [✓] Extracting domains from blocklists
  [i] 109.715 domains being pulled in by gravity
  [✓] Removing duplicate domains
  [i] 100.825 unique domains trapped in the Event Horizon

  [✓] Adding 6 blocklist source domains to the whitelist
  [✓] Whitelisting 12 domains
  [i] Blacklisted 1 domain
  [i] Wildcard blocked 5 domains
  [✓] Parsing domains into hosts format
  [✓] Cleaning up stray matter

  [✓] DNS service is running
  [✓] Pi-hole blocking is Enabled
```

Querying also works fine:
```
$ cat /home/pi/test.list
0.0.0.0 testing.com
1.2.3.4 testing2.com

$ pihole -q testing2.com
 Match found in list.6.local.domains:
   testing2.com
```

_This template was created based on the work of [`udemy-dl`](https://github.com/nishad/udemy-dl/blob/master/LICENSE)._
