### PR TITLE
Allow passwords with spaces

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -110,7 +110,7 @@ SetWebPassword() {
   fi
 
 	if [ "${PASSWORD}" == "${CONFIRM}" ] ; then
-		hash=$(HashPassword ${PASSWORD})
+		hash=$(HashPassword "${PASSWORD}")
 		# Save hash to file
 		change_setting "WEBPASSWORD" "${hash}"
 		echo -e "  ${TICK} New password set"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md).
- [x] I have checked that [another pull request](https://github.com/pi-hole/pi-hole/pulls) for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**How familiar are you with the codebase?:**

9

---

As [reported here](https://twitter.com/chadvavra/status/933516926638313473), a user can't create a Web Interface password with spaces in it.

Behaviour expected to work:
- Either `pihole -a -p foo bar` or `pihole -a -p "foo bar"` will let you access the Web Interface with the password `foo bar`

Post-fix behaviour:
- `pihole -a -p "foo bar"` allows you to access the Web interface with the password `foo bar`