### PR TITLE
check NetworkManager status prior to using the cli (#1653)

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -709,8 +709,8 @@ setStaticIPv4() {
       }> "${IFCFG_FILE}"
       # Use ip to immediately set the new address
       ip addr replace dev "${PIHOLE_INTERFACE}" "${IPV4_ADDRESS}"
-      # If NetworkMangler command line interface exists,
-      if command -v nmcli &> /dev/null;then
+      # If NetworkMangler command line interface exists and ready to mangle,
+      if command -v nmcli &> /dev/null && nmcli general status &> /dev/null; then
         # Tell NetworkManagler to read our new sysconfig file
         nmcli con load "${IFCFG_FILE}" > /dev/null
       fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Install script checks for `nmcli` prior to reloading sysconfig interface files but fails when NetworkManager is not running.

Closes #1653

**How does this PR accomplish the above?:**

Instead of changing the state of the `NetworkManager` service, we will check the status via `nmcli`.
The reasoning for this approach:
 -  protect users who do not want to use `NetworkManager`.
 - `NetworkManager` is not a requirement of the project and does not need to be enabled
 - We only want to reload the network information from the sysconfig files if `NetworkManager` is enabled.
 - We already checked for the `nmcli` command, so check the status using `nmcli`. (avoid checking `systemctl` vs `service`)

**What documentation changes (if any) are needed to support this PR?:**

Line comment has been updated.

