### PR TITLE
 Use != to support international number formats

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -114,7 +114,7 @@ gravity_DNSLookup() {
   echo -ne "  ${INFO} Waiting up to ${secs} seconds before continuing..."
   until timeout 1 getent hosts "${lookupDomain}" &> /dev/null; do
     [[ "${secs:-}" -eq 0 ]] && break
-    [[ "${secs:-}" != 1 ]] && f="s"
+    [[ "${secs:-}" != 1 ]] && plural="s"
     echo -ne "${OVER}  ${INFO} Waiting up to ${secs} second${plural} before continuing..."
     : $((secs--))
     sleep 1

--- a/gravity.sh
+++ b/gravity.sh
@@ -111,11 +111,11 @@ gravity_DNSLookup() {
 
   # Ensure DNS server is given time to be resolvable
   secs="120"
-  echo -ne "  ${INFO} Waiting up to ${secs} seconds before continuing..."
+  echo -ne "  ${INFO} Waiting up to $(printf "%'.0f" "$secs") seconds before continuing..."
   until timeout 1 getent hosts "${lookupDomain}" &> /dev/null; do
-    [[ "${secs:-}" -eq 0 ]] && break
+    [[ "${secs:-}" == 0 ]] && break
     [[ "${secs:-}" != 1 ]] && plural="s"
-    echo -ne "${OVER}  ${INFO} Waiting up to ${secs} second${plural} before continuing..."
+    echo -ne "${OVER}  ${INFO} Waiting up to $(printf "%'.0f" "$secs") second${plural} before continuing..."
     : $((secs--))
     sleep 1
   done
@@ -418,9 +418,9 @@ gravity_Filter() {
   gravity_ParseFileIntoDomains "${piholeDir}/${matterAndLight}" "${piholeDir}/${parsedMatter}"
 
   # Format $parsedMatter line total as currency
-  num=$(printf "%'.0f" "$(wc -l < "${piholeDir}/${parsedMatter}")")
+  num=$(wc -l < "${piholeDir}/${parsedMatter}")
   echo -e "${OVER}  ${TICK} ${str}
-  ${INFO} ${COL_BLUE}${num}${COL_NC} domains being pulled in by gravity"
+  ${INFO} ${COL_BLUE}$(printf "%'.0f" "$num")${COL_NC} domains being pulled in by gravity"
 
   str="Removing duplicate domains"
   echo -ne "  ${INFO} ${str}..."
@@ -428,8 +428,8 @@ gravity_Filter() {
   echo -e "${OVER}  ${TICK} ${str}"
 
   # Format $preEventHorizon line total as currency
-  num=$(printf "%'.0f" "$(wc -l < "${piholeDir}/${preEventHorizon}")")
-  echo -e "  ${INFO} ${COL_BLUE}${num}${COL_NC} unique domains trapped in the Event Horizon"
+  num=$(wc -l < "${piholeDir}/${preEventHorizon}")
+  echo -e "  ${INFO} ${COL_BLUE}$(printf "%'.0f" "$num")${COL_NC} unique domains trapped in the Event Horizon"
 }
 
 # Whitelist unique blocklist domain sources
@@ -460,9 +460,9 @@ gravity_Whitelist() {
     return 0
   fi
 
-  num=$(wc -l < "${whitelistFile}")
+  num=$(printf "%'.0f" "$(wc -l < "${whitelistFile}")")
   [[ "${num}" != 1 ]] && plural="s"
-  str="Whitelisting ${num} domain${plural}"
+  str="Whitelisting $(printf "%'.0f" "$num") domain${plural}"
   echo -ne "  ${INFO} ${str}..."
 
   # Print everything from preEventHorizon into whitelistMatter EXCEPT domains in $whitelistFile
@@ -476,9 +476,9 @@ gravity_ShowBlockCount() {
   local num plural
 
   if [[ -f "${blacklistFile}" ]]; then
-    num=$(printf "%'.0f" "$(wc -l < "${blacklistFile}")")
+    num=$(wc -l < "${blacklistFile}")
     plural=; [[ "${num}" != 1 ]] && plural="s"
-    echo -e "  ${INFO} Blacklisted ${num} domain${plural}"
+    echo -e "  ${INFO} Blacklisted $(printf "%'.0f" "$num") domain${plural}"
   fi
 
   if [[ -f "${wildcardFile}" ]]; then
@@ -488,7 +488,7 @@ gravity_ShowBlockCount() {
       num=$(( num/2 ))
     fi
     plural=; [[ "${num}" != 1 ]] && plural="s"
-    echo -e "  ${INFO} Wildcard blocked ${num} domain${plural}"
+    echo -e "  ${INFO} Wildcard blocked $(printf "%'.0f" "$num") domain${plural}"
   fi
 }
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -114,7 +114,7 @@ gravity_DNSLookup() {
   echo -ne "  ${INFO} Waiting up to ${secs} seconds before continuing..."
   until timeout 1 getent hosts "${lookupDomain}" &> /dev/null; do
     [[ "${secs:-}" -eq 0 ]] && break
-    [[ "${secs:-}" -ne 1 ]] && plural="s"
+    [[ "${secs:-}" != 1 ]] && f="s"
     echo -ne "${OVER}  ${INFO} Waiting up to ${secs} second${plural} before continuing..."
     : $((secs--))
     sleep 1
@@ -440,7 +440,7 @@ gravity_WhitelistBLD() {
 
   # Create array of unique $sourceDomains
   mapfile -t uniqDomains <<< "$(awk '{ if(!a[$1]++) { print $1 } }' <<< "$(printf '%s\n' "${sourceDomains[@]}")")"
-  [[ "${#uniqDomains[@]}" -ne 1 ]] && plural="s"
+  [[ "${#uniqDomains[@]}" != 1 ]] && plural="s"
 
   str="Adding ${#uniqDomains[@]} blocklist source domain${plural} to the whitelist"
   echo -ne "  ${INFO} ${str}..."
@@ -461,7 +461,7 @@ gravity_Whitelist() {
   fi
 
   num=$(wc -l < "${whitelistFile}")
-  [[ "${num}" -ne 1 ]] && plural="s"
+  [[ "${num}" != 1 ]] && plural="s"
   str="Whitelisting ${num} domain${plural}"
   echo -ne "  ${INFO} ${str}..."
 
@@ -477,7 +477,7 @@ gravity_ShowBlockCount() {
 
   if [[ -f "${blacklistFile}" ]]; then
     num=$(printf "%'.0f" "$(wc -l < "${blacklistFile}")")
-    plural=; [[ "${num}" -ne 1 ]] && plural="s"
+    plural=; [[ "${num}" != 1 ]] && plural="s"
     echo -e "  ${INFO} Blacklisted ${num} domain${plural}"
   fi
 
@@ -487,7 +487,7 @@ gravity_ShowBlockCount() {
     if [[ -n "${IPV4_ADDRESS}" ]] && [[ -n "${IPV6_ADDRESS}" ]];then
       num=$(( num/2 ))
     fi
-    plural=; [[ "${num}" -ne 1 ]] && plural="s"
+    plural=; [[ "${num}" != 1 ]] && plural="s"
     echo -e "  ${INFO} Wildcard blocked ${num} domain${plural}"
   fi
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix #1808

**How does this PR accomplish the above?:**

Use the != operator instead of -ne when comparing numbers, such as when we determine plural output.

**What documentation changes (if any) are needed to support this PR?:**

None