### PR TITLE
Revert parsing method to that of 3.1.4. New Method is allowing illega…

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -281,8 +281,8 @@ gravity_ParseFileIntoDomains() {
     #Awk -F splits on given IFS, we grab the right hand side (chops trailing #coments and /'s to grab the domain only.
     #Last awk command takes non-commented lines and if they have 2 fields, take the left field (the domain) and leave
     #+ the right (IP address), otherwise grab the single field.
-    cat ${source} | \
-    awk -F '#' '{print $1}' | \
+
+    < ${source} awk -F '#' '{print $1}' | \
     awk -F '/' '{print $1}' | \
     awk '($1 !~ /^#/) { if (NF>1) {print $2} else {print $1}}' | \
     sed -nr -e 's/\.{2,}/./g' -e '/\./p' >  ${destination}


### PR DESCRIPTION
…l lists through, and that is causing issues such as blocking www.google.com. This method will just throw away invalid list entries.

Signed-off-by: Adam Warner <adamw@rner.email>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'development' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fixes #1802, and stops gravity from parsing "illegal" lists and including them in the main list.

**How does this PR accomplish the above?:**

Revert to method used previously

**What documentation changes (if any) are needed to support this PR?:**

N/A
