### PR TITLE
Randomize update checker time

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -39,6 +39,10 @@ git describe --long --dirty --tags || return 1
 
 if [[ "$2" == "remote" ]]; then
 
+  if [[ "$3" == "reboot" ]]; then
+    sleep 30
+  fi
+
   GITHUB_CORE_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/pi-hole/releases/latest' 2> /dev/null)")"
   GITHUB_WEB_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null)")"
   GITHUB_FTL_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null)")"

--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -34,4 +34,4 @@
 
 # Pi-hole: Grab remote version every 24 hours
 59 17  * * *   root    PATH="$PATH:/usr/local/bin/" pihole updatechecker remote
-@reboot root    PATH="$PATH:/usr/local/bin/" pihole updatechecker remote
+@reboot root    PATH="$PATH:/usr/local/bin/" pihole updatechecker remote reboot

--- a/advanced/pihole.cron
+++ b/advanced/pihole.cron
@@ -33,4 +33,5 @@
 */10 *  * * *   root    PATH="$PATH:/usr/local/bin/" pihole updatechecker local
 
 # Pi-hole: Grab remote version every 24 hours
-00 00  * * *   root    PATH="$PATH:/usr/local/bin/" pihole updatechecker remote
+59 17  * * *   root    PATH="$PATH:/usr/local/bin/" pihole updatechecker remote
+@reboot root    PATH="$PATH:/usr/local/bin/" pihole updatechecker remote

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1368,7 +1368,9 @@ installCron() {
   # Copy the cron file over from the local repo
   cp ${PI_HOLE_LOCAL_REPO}/advanced/pihole.cron /etc/cron.d/pihole
   # Randomize gravity update time
-  sed -i "s/59 1/$((1 + RANDOM % 58)) $((3 + RANDOM % 2))/" /etc/cron.d/pihole
+  sed -i "s/59 1 /$((1 + RANDOM % 58)) $((3 + RANDOM % 2))/" /etc/cron.d/pihole
+  # Randomize update checker time
+  sed -i "s/59 17/$((1 + RANDOM % 58)) $((12 + RANDOM % 8))/" /etc/cron.d/pihole
   echo -e "${OVER}  ${TICK} ${str}"
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Randomize the time we query GitHub's API for updates to a time between 12:00 - 19:59. As most Pi-holes should be running at this time (not all machines are running 24/7).
In addition, we query once on boot up (just in case the Pi-hole is always shut down at the randomized time we injected into the `cron` script). @jacobsalmela may want to comment on whether we want this extra bit or not. 

**How does this PR accomplish the above?:**

- `basic-install.sh` randomizes the update checker times on *each* new install and *also* on updates or repairs
- Added `sleep 30` for `pihole updatechecker remote reboot`
