### PR TITLE
Enable dnsmasq's extra logging feature

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -39,7 +39,7 @@ interface=@INT@
 
 cache-size=10000
 
-log-queries
+log-queries=extra
 log-facility=/var/log/pihole.log
 
 local-ttl=2


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Enable dnsmasq's extra logging feature

**How does this PR accomplish the above?:**

Add `extra` to `01-oihole.conf`

This PR is connected to https://github.com/pi-hole/FTL/pull/174 It is required for the next-generation of `FTL` to be able to read the log. Furthermore, it will prevent the "older" versions of `FTL` from being able to read the logs any longer.