### PR TITLE
Store fourth entry in versions/branches files

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -47,6 +47,7 @@ if [[ "$2" == "remote" ]]; then
   GITHUB_WEB_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null)")"
   GITHUB_FTL_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null)")"
 
+  # Have to store an extra dummy character at the end, see https://github.com/pi-hole/pi-hole/pull/1866
   echo "${GITHUB_CORE_VERSION} ${GITHUB_WEB_VERSION} ${GITHUB_FTL_VERSION} X" > "/etc/pihole/GitHubVersions"
 
 else
@@ -55,12 +56,14 @@ else
   WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
   FTL_BRANCH="$(pihole-FTL branch)"
 
+  # Have to store an extra dummy character at the end, see https://github.com/pi-hole/pi-hole/pull/1866
   echo "${CORE_BRANCH} ${WEB_BRANCH} ${FTL_BRANCH} X" > "/etc/pihole/localbranches"
 
   CORE_VERSION="$(get_local_version /etc/.pihole)"
   WEB_VERSION="$(get_local_version /var/www/html/admin)"
   FTL_VERSION="$(pihole-FTL version)"
 
+  # Have to store an extra dummy character at the end, see https://github.com/pi-hole/pi-hole/pull/1866
   echo "${CORE_VERSION} ${WEB_VERSION} ${FTL_VERSION} X" > "/etc/pihole/localversions"
 
 fi

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -47,8 +47,7 @@ if [[ "$2" == "remote" ]]; then
   GITHUB_WEB_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null)")"
   GITHUB_FTL_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null)")"
 
-  # Have to store an extra dummy character at the end, see https://github.com/pi-hole/pi-hole/pull/1866
-  echo "${GITHUB_CORE_VERSION} ${GITHUB_WEB_VERSION} ${GITHUB_FTL_VERSION} X" > "/etc/pihole/GitHubVersions"
+  echo -n "${GITHUB_CORE_VERSION} ${GITHUB_WEB_VERSION} ${GITHUB_FTL_VERSION}" > "/etc/pihole/GitHubVersions"
 
 else
 
@@ -56,14 +55,12 @@ else
   WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
   FTL_BRANCH="$(pihole-FTL branch)"
 
-  # Have to store an extra dummy character at the end, see https://github.com/pi-hole/pi-hole/pull/1866
-  echo "${CORE_BRANCH} ${WEB_BRANCH} ${FTL_BRANCH} X" > "/etc/pihole/localbranches"
+  echo -n "${CORE_BRANCH} ${WEB_BRANCH} ${FTL_BRANCH}" > "/etc/pihole/localbranches"
 
   CORE_VERSION="$(get_local_version /etc/.pihole)"
   WEB_VERSION="$(get_local_version /var/www/html/admin)"
   FTL_VERSION="$(pihole-FTL version)"
 
-  # Have to store an extra dummy character at the end, see https://github.com/pi-hole/pi-hole/pull/1866
-  echo "${CORE_VERSION} ${WEB_VERSION} ${FTL_VERSION} X" > "/etc/pihole/localversions"
+  echo -n "${CORE_VERSION} ${WEB_VERSION} ${FTL_VERSION}" > "/etc/pihole/localversions"
 
 fi

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -47,7 +47,7 @@ if [[ "$2" == "remote" ]]; then
   GITHUB_WEB_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null)")"
   GITHUB_FTL_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null)")"
 
-  echo "${GITHUB_CORE_VERSION} ${GITHUB_WEB_VERSION} ${GITHUB_FTL_VERSION}" > "/etc/pihole/GitHubVersions"
+  echo "${GITHUB_CORE_VERSION} ${GITHUB_WEB_VERSION} ${GITHUB_FTL_VERSION} X" > "/etc/pihole/GitHubVersions"
 
 else
 
@@ -55,12 +55,12 @@ else
   WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
   FTL_BRANCH="$(pihole-FTL branch)"
 
-  echo "${CORE_BRANCH} ${WEB_BRANCH} ${FTL_BRANCH}" > "/etc/pihole/localbranches"
+  echo "${CORE_BRANCH} ${WEB_BRANCH} ${FTL_BRANCH} X" > "/etc/pihole/localbranches"
 
   CORE_VERSION="$(get_local_version /etc/.pihole)"
   WEB_VERSION="$(get_local_version /var/www/html/admin)"
   FTL_VERSION="$(pihole-FTL version)"
 
-  echo "${CORE_VERSION} ${WEB_VERSION} ${FTL_VERSION}" > "/etc/pihole/localversions"
+  echo "${CORE_VERSION} ${WEB_VERSION} ${FTL_VERSION} X" > "/etc/pihole/localversions"
 
 fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'development' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix https://github.com/pi-hole/AdminLTE/issues/652

**How does this PR accomplish the above?:**

Add extra entry to the end of the saved branches and versions such that PHP's `explode()` subroutine can correctly disentangle the first three entries and does not get confused by the newline character at the end of the FTL version/branch...
