### PR TITLE
Grammar change in debug script

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -215,14 +215,14 @@ copy_to_debug_log() {
   sed 's/\[[0-9;]\{1,5\}m//g' > "${PIHOLE_DEBUG_LOG_SANITIZED}" <<< cat "${PIHOLE_DEBUG_LOG}"
 }
 
-initiate_debug() {
+initialize_debug() {
   # Clear the screen so the debug log is readable
   clear
   show_disclaimer
   # Display that the debug process is beginning
   log_write "${COL_PURPLE}*** [ INITIALIZING ]${COL_NC}"
   # Timestamp the start of the log
-  log_write "${INFO} $(date "+%Y-%m-%d:%H:%M:%S") debug log has been initiated."
+  log_write "${INFO} $(date "+%Y-%m-%d:%H:%M:%S") debug log has been initialized."
 }
 
 # This is a function for visually displaying the curent test that is being run.
@@ -1149,7 +1149,7 @@ upload_to_tricorder() {
 
 # Run through all the functions we made
 make_temporary_log
-initiate_debug
+initialize_debug
 # setupVars.conf needs to be sourced before the networking so the values are
 # available to the other functions
 source_setup_variables


### PR DESCRIPTION
Signed-off-by: Adam Warner <adamw@rner.email>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'development' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Something looked off to me about the word "initiated" in the debug log, I think "initialized" (despite  American spelling 😉) is better suited

Function name also changed to reflect this.

Discuss.
