### PR TITLE
Add Clean Tail Function

### DIFF
--- a/pihole
+++ b/pihole
@@ -529,7 +529,7 @@ tailFunc() {
   exit 0
 }
 
-cleanTailFunc() {
+tailDomainsFunc() {
   echo -e "Press Ctrl-C to exit"
 
   # Filter out non-blocking messages
@@ -671,7 +671,7 @@ case "${1}" in
   "restartdns"                  ) restartDNS "$2";;
   "-a" | "admin"                ) webpageFunc "$@";;
   "-t" | "tail"                 ) tailFunc;;
-  "-ct" | "cleantail"           ) cleanTailFunc;;
+  "-td" | "tailDomains"         ) tailDomainsFunc;;
   "checkout"                    ) piholeCheckoutFunc "$@";;
   "tricorder"                   ) tricorderFunc;;
   "updatechecker"               ) updateCheckFunc "$@";;

--- a/pihole
+++ b/pihole
@@ -615,6 +615,7 @@ Debugging Options:
   -f, flush           Flush the Pi-hole log
   -r, reconfigure     Reconfigure or Repair Pi-hole subsystems
   -t, tail            View the live output of the Pi-hole log
+  -td, tailDomains    View blocked domains live from the Pi-hole log
 
 Options:
   -a, admin           Admin Console options

--- a/pihole
+++ b/pihole
@@ -538,11 +538,6 @@ tailDomainsFunc() {
   tail -f /var/log/pihole.log | grep --line-buffered -E 'gravity.list|black.list' | sed -u -E \
     -e "s,.*(gravity.list |black.list ),," \
     -e "s, .*,,"
-
-  # Get rid of everything up to and including gravity.list or black.list, and match everything until there is a space
-  # Also does not highlight the match, which would be gravity.list or black.list
-  # NOTE: Uses perl-regexp, which is experimental and might not always work
-  # tail -f /var/log/pihole.log | grep --color=never -Po "(gravity\.list |black\.list )\K(.*?)(?= )"
 }
 
 piholeCheckoutFunc() {

--- a/pihole
+++ b/pihole
@@ -540,6 +540,7 @@ tailDomainsFunc() {
     -e "s, .*,,"
 
   # Get rid of everything up to and including gravity.list or black.list, and match everything until there is a space
+  # Also does not highlight the match, which would be gravity.list or black.list
   # NOTE: Uses perl-regexp, which is experimental and might not always work
   # tail -f /var/log/pihole.log | grep --color=never -Po "(gravity\.list |black\.list )\K(.*?)(?= )"
 }

--- a/pihole
+++ b/pihole
@@ -529,6 +529,21 @@ tailFunc() {
   exit 0
 }
 
+cleanTailFunc() {
+  echo -e "Press Ctrl-C to exit"
+
+  # Filter out non-blocking messages
+  # Remove everthing in front of the domain
+  # Remove everthing after the domain
+  tail -f /var/log/pihole.log | grep --line-buffered -E 'gravity.list|black.list' | sed -u -E \
+    -e "s,.*(gravity.list |black.list ),," \
+    -e "s, .*,,"
+
+  # Get rid of everything up to and including gravity.list or black.list, and match everything until there is a space
+  # NOTE: Uses perl-regexp, which is experimental and might not always work
+  # tail -f /var/log/pihole.log | grep --color=never -Po "(gravity\.list |black\.list )\K(.*?)(?= )"
+}
+
 piholeCheckoutFunc() {
   if [[ "$2" == "-h" ]] || [[ "$2" == "--help" ]]; then
     echo "Usage: pihole checkout [repo] [branch]
@@ -656,6 +671,7 @@ case "${1}" in
   "restartdns"                  ) restartDNS "$2";;
   "-a" | "admin"                ) webpageFunc "$@";;
   "-t" | "tail"                 ) tailFunc;;
+  "-ct" | "cleantail"           ) cleantail;;
   "checkout"                    ) piholeCheckoutFunc "$@";;
   "tricorder"                   ) tricorderFunc;;
   "updatechecker"               ) updateCheckFunc "$@";;

--- a/pihole
+++ b/pihole
@@ -671,7 +671,7 @@ case "${1}" in
   "restartdns"                  ) restartDNS "$2";;
   "-a" | "admin"                ) webpageFunc "$@";;
   "-t" | "tail"                 ) tailFunc;;
-  "-ct" | "cleantail"           ) cleantail;;
+  "-ct" | "cleantail"           ) cleanTailFunc;;
   "checkout"                    ) piholeCheckoutFunc "$@";;
   "tricorder"                   ) tricorderFunc;;
   "updatechecker"               ) updateCheckFunc "$@";;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'development' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**
Add a way to watch what domains are being blocked in real time. 
`pihole -t` felt like it had too much information, and I just wanted to see the domains being blocked.
Inspired by [this video](https://www.reddit.com/r/pihole/comments/43cecp/viewing_in_realtime_what_ads_are_being_blocked/czh9vcw/)

**How does this PR accomplish the above?:**

This creates a new function using `grep` (and maybe `sed`) to filter out other information in the log

**What documentation changes (if any) are needed to support this PR?:**

* Add a note in the list of commands for the new function

**Note:** I've put in two ways to do it: with `grep -E` and `sed -E`, or with `grep -P`. I'm not sure if `grep -P` is supposed to be supported (the `man` page says it's experimental), but it is much cleaner to do it that way.