### PR TITLE
Add fallback interface in DNS settings

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -175,7 +175,13 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
 		add_dnsmasq_setting "local-service"
 	else
 		# Listen only on one interface
-		add_dnsmasq_setting "interface" "${PIHOLE_INTERFACE}"
+		interface=$(grep 'PIHOLE_INTERFACE=' /etc/pihole/setupVars.conf | sed "s/.*=//")
+		# Use eth0 as fallback interface if interface is missing in setupVars.conf
+		if [ -z "${interface}" ]; then
+			interface="eth0"
+		fi
+
+		add_dnsmasq_setting "interface" "${interface}"
 	fi
 
 }

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -175,13 +175,12 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
 		add_dnsmasq_setting "local-service"
 	else
 		# Listen only on one interface
-		interface=$(grep 'PIHOLE_INTERFACE=' /etc/pihole/setupVars.conf | sed "s/.*=//")
 		# Use eth0 as fallback interface if interface is missing in setupVars.conf
-		if [ -z "${interface}" ]; then
-			interface="eth0"
+		if [ -z "${PIHOLE_INTERFACE}" ]; then
+			PIHOLE_INTERFACE="eth0"
 		fi
 
-		add_dnsmasq_setting "interface" "${interface}"
+		add_dnsmasq_setting "interface" "${PIHOLE_INTERFACE}"
 	fi
 
 }
@@ -247,7 +246,7 @@ ProcessDHCPSettings() {
 	source "${setupVars}"
 
 	if [[ "${DHCP_ACTIVE}" == "true" ]]; then
-    interface=$(grep 'PIHOLE_INTERFACE=' /etc/pihole/setupVars.conf | sed "s/.*=//")
+    interface="${PIHOLE_INTERFACE}"
 
     # Use eth0 as fallback interface
     if [ -z ${interface} ]; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Fix a rare issue where `dnsmasq` fails to start when
- `PIHOLE_INTERFACE` is unset (for whatever reason) in `setupVars.conf`, and 
- a user changes DNS settings on the Settings page

**How does this PR accomplish the above?:**

In case `PIHOLE_INTERFACE` is unset we use `eth0` as fallback solution. This may be wrong but at least it would prevent `dnsmasq` from failing to start.

**How has this PR been tested?:**

- Set `PIHOLE_INTERFACE=` in `setupVars.conf`
- Saved DNS Settings on the web frontend
- Verified that `interface=eth0` was set in `/etc/dnsmasq.d/01-pihole.conf` :white_check_mark: 