### PR TITLE
piholeDebug.sh: Correct typo mistake

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -547,7 +547,7 @@ detect_ip_addresses() {
     log_write ""
   else
     # If there are no IPs detected, explain that the protocol is not configured
-    log_write "${CROSS} ${COL_RED}No IPv${protocol} address(es) found on the ${PIHOLE_INTERFACE}${COL_NC} interace.\n"
+    log_write "${CROSS} ${COL_RED}No IPv${protocol} address(es) found on the ${PIHOLE_INTERFACE}${COL_NC} interface.\n"
     return 1
   fi
   # If the protocol is v6


### PR DESCRIPTION
Signed-off-by: Vasilis Gerakaris <vgerak@gmail.com>

**By submitting this pull request, I confirm the following:** 
`{please fill any appropriate checkboxes, e.g: [X]}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---

**What does this PR aim to accomplish?:**

Correct a typographical mistake in the piholeDebug.sh script's output.

**How does this PR accomplish the above?:**

Change the word "interace" to "interface".

**What documentation changes (if any) are needed to support this PR?:**

None
