### PR TITLE
Add "pihole logging off noflush" command

### DIFF
--- a/pihole
+++ b/pihole
@@ -444,13 +444,17 @@ Specify whether the Pi-hole log should be used
 
 Options:
   on                  Enable the Pi-hole log at /var/log/pihole.log
-  off                 Disable the Pi-hole log at /var/log/pihole.log"
+  off                 Disable and flush the Pi-hole log at /var/log/pihole.log
+  off noflush         Disable the Pi-hole log at /var/log/pihole.log"
     exit 0
   elif [[ "${1}" == "off" ]]; then
     # Disable logging
     sed -i 's/^log-queries/#log-queries/' /etc/dnsmasq.d/01-pihole.conf
     sed -i 's/^QUERY_LOGGING=true/QUERY_LOGGING=false/' /etc/pihole/setupVars.conf
-    pihole -f
+    if [[ "${2}" != "noflush" ]]; then
+      # Flush logs
+      pihole -f
+    fi
     echo -e "  ${INFO} Disabling logging..."
     local str="Logging has been disabled!"
   elif [[ "${1}" == "on" ]]; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

I heard quite often the request of being able to (temporarily) disable Pi-hole's logging without automatically nuking the log. This was not possible as `pihole -f` was forcefully applied whenever `pihole logging disable` was called.

**How does this PR accomplish the above?:**

Add another option `noflush` that can be used as `pihole logging off noflush` to skip the `pihole -f` step. If the option is left off, `pihole -f` is run and as such the default behavior doesn't change.

**What documentation changes (if any) are needed to support this PR?:**

None required, only if we want to mention this somewhere.