### PR TITLE
pihole -f: Flush database

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -16,9 +16,9 @@ source ${colfile}
 # Constructed to return nothing when
 # a) the setting is not present in the config file, or
 # b) the setting is commented out (e.g. "#DBFILE=...")
-DBFILE=$(sed -n -e 's/^\s^.DBFILE\s*=\s*//p' /etc/pihole/pihole-FTL.conf)
+DBFILE="$(sed -n -e 's/^\s^.DBFILE\s*=\s*//p' /etc/pihole/pihole-FTL.conf)"
 # Test for empty string. Use standard path in this case.
-if [ -z $DBFILE ]; then
+if [ -z "$DBFILE" ]; then
   DBFILE="/etc/pihole/pihole-FTL.db"
 fi
 

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -42,8 +42,11 @@ else
     fi
   fi
   # Delete most recent 24 hours from FTL's database
+  deleted=$(sqlite3 /etc/pihole/pihole-FTL.db "DELETE FROM queries WHERE timestamp >= strftime('%s','now')-86400; select changes() from queries limit 1")
+
 fi
 
 if [[ "$@" != *"quiet"* ]]; then
   echo -e "${OVER}  ${TICK} Flushed /var/log/pihole.log"
+  echo -e "  ${TICK} Deleted ${deleted} queries from database"
 fi

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -11,6 +11,17 @@
 colfile="/opt/pihole/COL_TABLE"
 source ${colfile}
 
+# Determine database location
+# Obtain DBFILE=... setting from pihole-FTL.db
+# Constructed to return nothing when
+# a) the setting is not present in the config file, or
+# b) the setting is commented out (e.g. "#DBFILE=...")
+DBFILE=$(sed -n -e 's/^\s^.DBFILE\s*=\s*//p' /etc/pihole/pihole-FTL.conf)
+# Test for empty string. Use standard path in this case.
+if [ -z $DBFILE ]; then
+  DBFILE="/etc/pihole/pihole-FTL.db"
+fi
+
 if [[ "$@" != *"quiet"* ]]; then
   echo -ne "  ${INFO} Flushing /var/log/pihole.log ..."
 fi
@@ -41,8 +52,8 @@ else
       echo " " > /var/log/pihole.log.1
     fi
   fi
-  # Delete most recent 24 hours from FTL's database
-  deleted=$(sqlite3 /etc/pihole/pihole-FTL.db "DELETE FROM queries WHERE timestamp >= strftime('%s','now')-86400; select changes() from queries limit 1")
+  # Delete most recent 24 hours from FTL's database, leave even older data intact (don't wipe out all history)
+  deleted=$(sqlite3 "${DBFILE}" "DELETE FROM queries WHERE timestamp >= strftime('%s','now')-86400; select changes() from queries limit 1")
 
 fi
 

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -41,6 +41,7 @@ else
       echo " " > /var/log/pihole.log.1
     fi
   fi
+  # Delete most recent 24 hours from FTL's database
 fi
 
 if [[ "$@" != *"quiet"* ]]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -163,7 +163,7 @@ if command -v apt-get &> /dev/null; then
   # These programs are stored in an array so they can be looped through later
   INSTALLER_DEPS=(apt-utils dialog debconf dhcpcd5 git ${iproute_pkg} whiptail)
   # Pi-hole itself has several dependencies that also need to be installed
-  PIHOLE_DEPS=(bc cron curl dnsmasq dnsutils iputils-ping lsof netcat sudo unzip wget idn2)
+  PIHOLE_DEPS=(bc cron curl dnsmasq dnsutils iputils-ping lsof netcat sudo unzip wget idn2 sqlite3)
   # The Web dashboard has some that also need to be installed
   # It's useful to separate the two since our repos are also setup as "Core" code and "Web" code
   PIHOLE_WEB_DEPS=(lighttpd ${phpVer}-common ${phpVer}-cgi ${phpVer}-${phpSqlite})


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Flush also the most recent 24 hours in `FTL`'s long-term database when the user calls `pihole -f`.

**How does this PR accomplish the above?:**

It executes `DELETE FROM queries WHERE timestamp >= strftime('%s','now')-86400` on the database file to delete all queries that are younger than 24 hours in the past.

```
pihole -f
  [✓] Flushed /var/log/pihole.log
  [✓] Deleted 5563 queries from database
```