### PR TITLE
Prevent redundant entries from being added to Adlists.list

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -182,6 +182,10 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
 
 		add_dnsmasq_setting "interface" "${PIHOLE_INTERFACE}"
 	fi
+	if [[ "${CONDITIONAL_FORWARDING}" == true ]]; then
+		add_dnsmasq_setting "server=/${CONDITIONAL_FORWARDING_DOMAIN}/${CONDITIONAL_FORWARDING_IP}"
+		add_dnsmasq_setting "server=/${CONDITIONAL_FORWARDING_REVERSE}/${CONDITIONAL_FORWARDING_IP}"
+	fi
 
 }
 
@@ -210,6 +214,17 @@ SetDNSServers() {
 		change_setting "DNSSEC" "true"
 	else
 		change_setting "DNSSEC" "false"
+	fi
+	if [[ "${args[6]}" == "conditional_forwarding" ]]; then
+		change_setting "CONDITIONAL_FORWARDING" "true"
+		change_setting "CONDITIONAL_FORWARDING_IP" "${args[7]}"
+		change_setting "CONDITIONAL_FORWARDING_DOMAIN" "${args[8]}"
+		change_setting "CONDITIONAL_FORWARDING_REVERSE" "${args[9]}"
+	else
+		change_setting "CONDITIONAL_FORWARDING" "false"
+		delete_setting "CONDITIONAL_FORWARDING_IP"
+		delete_setting "CONDITIONAL_FORWARDING_DOMAIN"
+		delete_setting "CONDITIONAL_FORWARDING_REVERSE"
 	fi
 
 	ProcessDNSSettings

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -346,7 +346,7 @@ CustomizeAdLists() {
 	elif [[ "${args[2]}" == "disable" ]]; then
 		sed -i "\\@${args[3]}@s/^http/#http/g" "${list}"
 	elif [[ "${args[2]}" == "add" ]]; then
-		if [[ $(grep -c "${args[3]}" "${list}") -eq 0 ]] ; then
+		if [[ $(grep -c "^${args[3]}$" "${list}") -eq 0 ]] ; then
 			echo "${args[3]}" >> ${list}
 		fi
 	elif [[ "${args[2]}" == "del" ]]; then

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -254,7 +254,7 @@ ProcessDHCPSettings() {
     fi
 
     if [[ "${PIHOLE_DOMAIN}" == "" ]]; then
-      PIHOLE_DOMAIN="lan"
+      PIHOLE_DOMAIN="local"
       change_setting "PIHOLE_DOMAIN" "${PIHOLE_DOMAIN}"
     fi
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -182,10 +182,6 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
 
 		add_dnsmasq_setting "interface" "${PIHOLE_INTERFACE}"
 	fi
-	if [[ "${CONDITIONAL_FORWARDING}" == true ]]; then
-		add_dnsmasq_setting "server=/${CONDITIONAL_FORWARDING_DOMAIN}/${CONDITIONAL_FORWARDING_IP}"
-		add_dnsmasq_setting "server=/${CONDITIONAL_FORWARDING_REVERSE}/${CONDITIONAL_FORWARDING_IP}"
-	fi
 
 }
 
@@ -214,17 +210,6 @@ SetDNSServers() {
 		change_setting "DNSSEC" "true"
 	else
 		change_setting "DNSSEC" "false"
-	fi
-	if [[ "${args[6]}" == "conditional_forwarding" ]]; then
-		change_setting "CONDITIONAL_FORWARDING" "true"
-		change_setting "CONDITIONAL_FORWARDING_IP" "${args[7]}"
-		change_setting "CONDITIONAL_FORWARDING_DOMAIN" "${args[8]}"
-		change_setting "CONDITIONAL_FORWARDING_REVERSE" "${args[9]}"
-	else
-		change_setting "CONDITIONAL_FORWARDING" "false"
-		delete_setting "CONDITIONAL_FORWARDING_IP"
-		delete_setting "CONDITIONAL_FORWARDING_DOMAIN"
-		delete_setting "CONDITIONAL_FORWARDING_REVERSE"
 	fi
 
 	ProcessDNSSettings
@@ -269,7 +254,7 @@ ProcessDHCPSettings() {
     fi
 
     if [[ "${PIHOLE_DOMAIN}" == "" ]]; then
-      PIHOLE_DOMAIN="local"
+      PIHOLE_DOMAIN="lan"
       change_setting "PIHOLE_DOMAIN" "${PIHOLE_DOMAIN}"
     fi
 
@@ -361,7 +346,9 @@ CustomizeAdLists() {
 	elif [[ "${args[2]}" == "disable" ]]; then
 		sed -i "\\@${args[3]}@s/^http/#http/g" "${list}"
 	elif [[ "${args[2]}" == "add" ]]; then
-		echo "${args[3]}" >> ${list}
+		if [[ $(grep -c "${args[3]}" "${list}") -eq 0 ]] ; then
+			echo "${args[3]}" >> ${list}
+		fi
 	elif [[ "${args[2]}" == "del" ]]; then
 	  var=$(echo "${args[3]}" | sed 's/\//\\\//g')
 	  sed -i "/${var}/Id" "${list}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'development' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Presently a user can add redundant entries to adlists.list, each of which Gravity will check for updates.

**How does this PR accomplish the above?:**

A simple grep for the proposed change. If true, do nothing.

**What documentation changes (if any) are needed to support this PR?:**

None needed.

