### PR TITLE
Improve update checker script

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -64,8 +64,8 @@ if [[ "$2" == "remote" ]]; then
   # We save the upstream version if either
   #  - the dnsmasq version is at least 2.73, or
   #  - the upstream version of FTL is at least v4.0
-  dnsmasqversion="$(version_cmp 2.73 $(extract_dnsmasq_version))"
-  FTLupstreamversion="$(version_cmp v4.0 ${GITHUB_FTL_VERSION})"
+  dnsmasqversion=$(version_cmp 2.73 "$(extract_dnsmasq_version)")
+  FTLupstreamversion=$(version_cmp v4.0 "${GITHUB_FTL_VERSION}")
   if [[ $dnsmasqversion == 1 && $FTLupstreamversion == 1 ]]; then
     GITHUB_CORE_VERSION="$(get_local_version /etc/.pihole)"
     GITHUB_WEB_VERSION="$(get_local_version /var/www/html/admin)"

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -32,9 +32,25 @@ function get_local_branch() {
 }
 
 function get_local_version() {
-# Return active branch
-cd "${1}" 2> /dev/null || return 1
-git describe --long --dirty --tags || return 1
+  # Return active branch
+  cd "${1}" 2> /dev/null || return 1
+  git describe --long --dirty --tags || return 1
+}
+
+function extract_dnsmasq_version() {
+  # Return version of system-wide dnsmasq daemon
+  dnsmasq -v | awk '/Dnsmasq version/{print $3}'
+  # echo "2.72"
+  # echo "2.72-3"
+  # echo "2.73"
+}
+
+# Compare versions
+function version_cmp() {
+  # Use bash string comparison
+  [[ "$1" = "$2" ]] && echo 0
+  [[ "$1" > "$2" ]] && echo 1
+  [[ "$1" < "$2" ]] && echo 2
 }
 
 if [[ "$2" == "remote" ]]; then
@@ -43,9 +59,25 @@ if [[ "$2" == "remote" ]]; then
     sleep 30
   fi
 
+    # Locally available dnsmasq version is too old, don't suggest updating
   GITHUB_CORE_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/pi-hole/releases/latest' 2> /dev/null)")"
   GITHUB_WEB_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null)")"
   GITHUB_FTL_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null)")"
+  # GITHUB_FTL_VERSION="v3.8"
+  # GITHUB_FTL_VERSION="v4.0"
+  # GITHUB_FTL_VERSION="v4.1"
+
+  # We save the upstream version if either
+  #  - the dnsmasq version is at least 2.73, or
+  #  - the upstream version of FTL is at least v4.0
+  dnsmasqversion=$(version_cmp 2.73 $(extract_dnsmasq_version))
+  FTLupstreamversion=$(version_cmp v4.0 ${GITHUB_FTL_VERSION})
+  if [[ $dnsmasqversion == 1 && $FTLupstreamversion == 1 ]]; then
+    GITHUB_CORE_VERSION="$(get_local_version /etc/.pihole)"
+    GITHUB_WEB_VERSION="$(get_local_version /var/www/html/admin)"
+    GITHUB_FTL_VERSION="$(pihole-FTL version)"
+    echo "don't save tags"
+  fi
 
   echo -n "${GITHUB_CORE_VERSION} ${GITHUB_WEB_VERSION} ${GITHUB_FTL_VERSION}" > "/etc/pihole/GitHubVersions"
 

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -54,6 +54,7 @@ function version_cmp() {
 # Compare dnsmasq version against 2.73
 dnsmasqversion=$(version_cmp 2.73 "$(extract_dnsmasq_version)")
 
+echo "raw dnsmasq output: \"$(dnsmasq -v)\""
 echo "dnsmasq version: \"$(extract_dnsmasq_version)\""
 echo "FTL version: \"$3\""
 

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -50,6 +50,20 @@ function version_cmp() {
   [[ "$1" < "$2" ]] && echo 2
 }
 
+# Compare dnsmasq version against 2.73
+dnsmasqversion=$(version_cmp 2.73 "$(extract_dnsmasq_version)")
+
+# Special section used to test the logic
+if [[ "$2" == "test" ]]; then
+  FTLupstreamversion=$(version_cmp v4.0 "$3")
+  if [[ $dnsmasqversion == 1 && $FTLupstreamversion == 1 ]]; then
+    echo "No update"
+  else
+    echo "Update"
+  fi
+  exit 0
+fi
+
 if [[ "$2" == "remote" ]]; then
 
   if [[ "$3" == "reboot" ]]; then
@@ -64,8 +78,6 @@ if [[ "$2" == "remote" ]]; then
   # We save the upstream version if either
   #  - the dnsmasq version is at least 2.73, or
   #  - the upstream version of FTL is at least v4.0
-  dnsmasqversion=$(version_cmp 2.73 "$(extract_dnsmasq_version)")
-  FTLupstreamversion=$(version_cmp v4.0 "${GITHUB_FTL_VERSION}")
   if [[ $dnsmasqversion == 1 && $FTLupstreamversion == 1 ]]; then
     GITHUB_CORE_VERSION="$(get_local_version /etc/.pihole)"
     GITHUB_WEB_VERSION="$(get_local_version /var/www/html/admin)"

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -40,6 +40,7 @@ function get_local_version() {
 function extract_dnsmasq_version() {
   # Return version of system-wide dnsmasq daemon
   dnsmasq -v | awk '/Dnsmasq version/{print $3}'
+  # echo "2.73"
 }
 
 # Compare versions
@@ -52,6 +53,9 @@ function version_cmp() {
 
 # Compare dnsmasq version against 2.73
 dnsmasqversion=$(version_cmp 2.73 "$(extract_dnsmasq_version)")
+
+echo "dnsmasq version: \"$(extract_dnsmasq_version)\""
+echo "FTL version: \"$3\""
 
 # Special section used to test the logic
 if [[ "$2" == "test" ]]; then

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -40,9 +40,6 @@ function get_local_version() {
 function extract_dnsmasq_version() {
   # Return version of system-wide dnsmasq daemon
   dnsmasq -v | awk '/Dnsmasq version/{print $3}'
-  # echo "2.72"
-  # echo "2.72-3"
-  # echo "2.73"
 }
 
 # Compare versions
@@ -63,20 +60,16 @@ if [[ "$2" == "remote" ]]; then
   GITHUB_CORE_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/pi-hole/releases/latest' 2> /dev/null)")"
   GITHUB_WEB_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null)")"
   GITHUB_FTL_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null)")"
-  # GITHUB_FTL_VERSION="v3.8"
-  # GITHUB_FTL_VERSION="v4.0"
-  # GITHUB_FTL_VERSION="v4.1"
 
   # We save the upstream version if either
   #  - the dnsmasq version is at least 2.73, or
   #  - the upstream version of FTL is at least v4.0
-  dnsmasqversion=$(version_cmp 2.73 $(extract_dnsmasq_version))
-  FTLupstreamversion=$(version_cmp v4.0 ${GITHUB_FTL_VERSION})
+  dnsmasqversion="$(version_cmp 2.73 $(extract_dnsmasq_version))"
+  FTLupstreamversion="$(version_cmp v4.0 ${GITHUB_FTL_VERSION})"
   if [[ $dnsmasqversion == 1 && $FTLupstreamversion == 1 ]]; then
     GITHUB_CORE_VERSION="$(get_local_version /etc/.pihole)"
     GITHUB_WEB_VERSION="$(get_local_version /var/www/html/admin)"
     GITHUB_FTL_VERSION="$(pihole-FTL version)"
-    echo "don't save tags"
   fi
 
   echo -n "${GITHUB_CORE_VERSION} ${GITHUB_WEB_VERSION} ${GITHUB_FTL_VERSION}" > "/etc/pihole/GitHubVersions"

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -389,6 +389,43 @@ def test_IPv6_ULA_GUA_test(Pihole):
     expected_stdout = 'Found IPv6 ULA address, using it for blocking IPv6 ads'
     assert expected_stdout in detectPlatform.stdout
 
+# Test special update checker logic for too old versions of dnsmasq
+def test_dnsmasq_2_72_3_FTL_3_0(Pihole):
+    ''' confirms online tags are not stored for a too old version of dnsmasq with FTL v3.x '''
+    # mock uname to return aarch64 platform
+    mock_command('dnsmasq', {'-v':('Dnsmasq version 2.72-3  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
+    updateCheck = Pihole.run('''
+    ./opt/pihole/updatecheck.sh X test 3.0
+    ''')
+    expected_stdout = 'No update'
+    assert expected_stdout in updateCheck.stdout
+    error = 'Update'
+    assert error not in updateCheck.stdout
+
+def test_dnsmasq_2_72_3_FTL_4_0(Pihole):
+    ''' confirms online tags are stored for a too old version of dnsmasq with FTL v4.x '''
+    # mock uname to return aarch64 platform
+    mock_command('dnsmasq', {'-v':('Dnsmasq version 2.72-3  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
+    updateCheck = Pihole.run('''
+    ./opt/pihole/updatecheck.sh X test 4.0
+    ''')
+    expected_stdout = 'Update'
+    assert expected_stdout in updateCheck.stdout
+    error = 'Np update'
+    assert error not in updateCheck.stdout
+
+def test_dnsmasq_2_73_FTL_3_0(Pihole):
+    ''' confirms online tags are stored for a fairly recent version of dnsmasq with FTL v3.x '''
+    # mock uname to return aarch64 platform
+    mock_command('dnsmasq', {'-v':('Dnsmasq version 2.73  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
+    updateCheck = Pihole.run('''
+    ./opt/pihole/updatecheck.sh X test 3.0
+    ''')
+    expected_stdout = 'Update'
+    assert expected_stdout in updateCheck.stdout
+    error = 'Np update'
+    assert error not in updateCheck.stdout
+
 # Helper functions
 def mock_command(script, args, container):
     ''' Allows for setup of commands we don't really want to have to run for real in unit tests '''

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -395,7 +395,7 @@ def test_dnsmasq_2_72_3_FTL_3_0(Pihole):
     # mock uname to return aarch64 platform
     mock_command('dnsmasq', {'-v':('Dnsmasq version 2.72-3  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
     updateCheck = Pihole.run('''
-    ./opt/pihole/updatecheck.sh X test 3.0
+    ./opt/pihole/updatecheck.sh X test v3.0
     ''')
     expected_stdout = 'No update'
     assert expected_stdout in updateCheck.stdout
@@ -407,11 +407,11 @@ def test_dnsmasq_2_72_3_FTL_4_0(Pihole):
     # mock uname to return aarch64 platform
     mock_command('dnsmasq', {'-v':('Dnsmasq version 2.72-3  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
     updateCheck = Pihole.run('''
-    ./opt/pihole/updatecheck.sh X test 4.0
+    ./opt/pihole/updatecheck.sh X test v4.0
     ''')
     expected_stdout = 'Update'
     assert expected_stdout in updateCheck.stdout
-    error = 'Np update'
+    error = 'No update'
     assert error not in updateCheck.stdout
 
 def test_dnsmasq_2_73_FTL_3_0(Pihole):
@@ -419,11 +419,11 @@ def test_dnsmasq_2_73_FTL_3_0(Pihole):
     # mock uname to return aarch64 platform
     mock_command('dnsmasq', {'-v':('Dnsmasq version 2.73  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
     updateCheck = Pihole.run('''
-    ./opt/pihole/updatecheck.sh X test 3.0
+    ./opt/pihole/updatecheck.sh X test v3.0
     ''')
     expected_stdout = 'Update'
     assert expected_stdout in updateCheck.stdout
-    error = 'Np update'
+    error = 'No update'
     assert error not in updateCheck.stdout
 
 # Helper functions

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -392,10 +392,10 @@ def test_IPv6_ULA_GUA_test(Pihole):
 # Test special update checker logic for too old versions of dnsmasq
 def test_dnsmasq_2_72_3_FTL_3_0(Pihole):
     ''' confirms online tags are not stored for a too old version of dnsmasq with FTL v3.x '''
-    # mock uname to return aarch64 platform
-    mock_command('dnsmasq', {'-v':('Dnsmasq version 2.72-3  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
+    mock_command('dnsmasq', {'-v':('\"Dnsmasq version 2.72-3  Copyright (c) 2000-2017 Simon Kelley\"', '0')}, Pihole)
+    mock_command('pihole-FTL', {'version': ('\"v3.0\"', '0')}, Pihole)
     updateCheck = Pihole.run('''
-    ./opt/pihole/updatecheck.sh X test v3.0
+    ./opt/pihole/updatecheck.sh updatechecker test
     ''')
     expected_stdout = 'No update'
     assert expected_stdout in updateCheck.stdout
@@ -404,10 +404,10 @@ def test_dnsmasq_2_72_3_FTL_3_0(Pihole):
 
 def test_dnsmasq_2_72_3_FTL_4_0(Pihole):
     ''' confirms online tags are stored for a too old version of dnsmasq with FTL v4.x '''
-    # mock uname to return aarch64 platform
-    mock_command('dnsmasq', {'-v':('Dnsmasq version 2.72-3  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
+    mock_command('dnsmasq', {'-v':('\"Dnsmasq version 2.72-3  Copyright (c) 2000-2017 Simon Kelley\"', '0')}, Pihole)
+    mock_command('pihole-FTL', {'version': ('\"v4.0\"', '0')}, Pihole)
     updateCheck = Pihole.run('''
-    ./opt/pihole/updatecheck.sh X test v4.0
+    ./opt/pihole/updatecheck.sh updatechecker test
     ''')
     expected_stdout = 'Update'
     assert expected_stdout in updateCheck.stdout
@@ -416,10 +416,10 @@ def test_dnsmasq_2_72_3_FTL_4_0(Pihole):
 
 def test_dnsmasq_2_73_FTL_3_0(Pihole):
     ''' confirms online tags are stored for a fairly recent version of dnsmasq with FTL v3.x '''
-    # mock uname to return aarch64 platform
-    mock_command('dnsmasq', {'-v':('Dnsmasq version 2.73  Copyright (c) 2000-2017 Simon Kelley', '0')}, Pihole)
+    mock_command('dnsmasq', {'-v':('\"Dnsmasq version 2.73  Copyright (c) 2000-2017 Simon Kelley\"', '0')}, Pihole)
+    mock_command('pihole-FTL', {'version': ('\"v3.0\"', '0')}, Pihole)
     updateCheck = Pihole.run('''
-    ./opt/pihole/updatecheck.sh X test v3.0
+    ./opt/pihole/updatecheck.sh updatechecker test
     ''')
     expected_stdout = 'Update'
     assert expected_stdout in updateCheck.stdout


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Add an exception in the update checker script to discard a possibly available update when the `dnsmasq` version is too low for extra logging and FTL's version is smaller than v4.0

**How does this PR accomplish the above?:**

We save the upstream version *only* if either
- the `dnsmasq` version is at least `2.73`, or
- the upstream version of `FTL` is at least `v4.0`

If both tests fail (`dnsmasq` is too old **and** `FTL` is not yet at `v4.0`), then we save the current tags as the most recent ones. By this, it will never be shown that an update would be available.