### PR TITLE
Create blacklist.txt if not existant

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -10,9 +10,9 @@
 
 # Globals
 basename=pihole
-piholeDir=/etc/${basename}
-whitelist=${piholeDir}/whitelist.txt
-blacklist=${piholeDir}/blacklist.txt
+piholeDir=/etc/"${basename}"
+whitelist="${piholeDir}"/whitelist.txt
+blacklist="${piholeDir}"/blacklist.txt
 readonly wildcardlist="/etc/dnsmasq.d/03-pihole-wildcard.conf"
 reload=false
 addmode=true
@@ -80,13 +80,13 @@ HandleOther() {
 
 PoplistFile() {
   # Check whitelist file exists, and if not, create it
-  if [[ ! -f ${whitelist} ]]; then
-    touch ${whitelist}
+  if [[ ! -f "${whitelist}" ]]; then
+    touch "${whitelist}"
   fi
 
   # Check blacklist file exists, and if not, create it
-  if [[ ! -f ${blacklist} ]]; then
-    touch ${blacklist}
+  if [[ ! -f "${blacklist}" ]]; then
+    touch "${blacklist}"
   fi
 
   for dom in "${domList[@]}"; do

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -84,6 +84,11 @@ PoplistFile() {
     touch ${whitelist}
   fi
 
+  # Check blacklist file exists, and if not, create it
+  if [[ ! -f ${blacklist} ]]; then
+    touch ${blacklist}
+  fi
+
   for dom in "${domList[@]}"; do
       # Logic: If addmode then add to desired list and remove from the other; if delmode then remove from desired list but do not add to the other
     if ${addmode}; then


### PR DESCRIPTION
Closes: https://github.com/pi-hole/pi-hole/issues/1888

**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
This PR fixed issue https://github.com/pi-hole/pi-hole/issues/1888:
The log contains a lot of:
```
Jan  3 11:42:35 PiHole lighttpd[553]: grep: blacklist.txt: No such file or directory
```

**How does this PR accomplish the above?:**
The installation script now creates an empty ``${piholeDir}/blacklist.txt`` file.

A similar code was used to create an empty ``${piholeDir}/whitelist.txt``. So I guess it was the good place to also create an empty ``${piholeDir}/blacklist.txt`` file.

**What documentation changes (if any) are needed to support this PR?:**
No documentation change is needed.