### PR TITLE
WIP: Revert "Potential fix for #1909" - Fix current whitelisting issues from the web interface in 3.3

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -330,7 +330,7 @@ gravity_ParseFileIntoDomains() {
       }' "${source}" > "${destination}.exceptionsFile.tmp"
 
       # Remove exceptions
-      comm -23 "${destination}" <(sort "${destination}.exceptionsFile.tmp") > "${source}"
+      grep -F -x -v -f "${destination}.exceptionsFile.tmp" "${destination}" > "${source}"
       mv "${source}" "${destination}"
     fi
 
@@ -431,7 +431,7 @@ gravity_Whitelist() {
   echo -ne "  ${INFO} ${str}..."
 
   # Print everything from preEventHorizon into whitelistMatter EXCEPT domains in $whitelistFile
-  comm -23 "${piholeDir}/${preEventHorizon}" <(sort "${whitelistFile}") > "${piholeDir}/${whitelistMatter}"
+  grep -F -x -v -f "${whitelistFile}" "${piholeDir}/${preEventHorizon}" > "${piholeDir}/${whitelistMatter}"
 
   echo -e "${OVER}  ${INFO} ${str}"
 }


### PR DESCRIPTION
From some extensive testing, this is the change that broke whitelisting from the web interface. It makes absolutely no sense, as running the command on the CLI works. 

The `comm` command itself actually runs when run from the web interface, however it does not run as expected. Something is off, and I can't work it out. Seems safest to revert this change and agree on something else to fix #1909. I recall the original proposal was to add `-a` to the `grep` command that `comm` replaced. There may have been a good reason _not_ to do that, however...