### PR TITLE
Fix Whitelisting from web issue brought in with 3.3

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -330,7 +330,7 @@ gravity_ParseFileIntoDomains() {
       }' "${source}" > "${destination}.exceptionsFile.tmp"
 
       # Remove exceptions
-      comm -23 "${destination}" <(sort "${destination}.exceptionsFile.tmp") > "${source}"
+      comm -23 <(sort "${destination}") <(sort "${destination}.exceptionsFile.tmp") > "${source}"
       mv "${source}" "${destination}"
     fi
 
@@ -431,7 +431,7 @@ gravity_Whitelist() {
   echo -ne "  ${INFO} ${str}..."
 
   # Print everything from preEventHorizon into whitelistMatter EXCEPT domains in $whitelistFile
-  comm -23 "${piholeDir}/${preEventHorizon}" <(sort "${whitelistFile}") > "${piholeDir}/${whitelistMatter}"
+  comm -23 <(sort"${piholeDir}/${preEventHorizon}") <(sort "${whitelistFile}") > "${piholeDir}/${whitelistMatter}"
 
   echo -e "${OVER}  ${INFO} ${str}"
 }

--- a/gravity.sh
+++ b/gravity.sh
@@ -431,7 +431,7 @@ gravity_Whitelist() {
   echo -ne "  ${INFO} ${str}..."
 
   # Print everything from preEventHorizon into whitelistMatter EXCEPT domains in $whitelistFile
-  comm -23 <(sort"${piholeDir}/${preEventHorizon}") <(sort "${whitelistFile}") > "${piholeDir}/${whitelistMatter}"
+  comm -23 <(sort "${piholeDir}/${preEventHorizon}") <(sort "${whitelistFile}") > "${piholeDir}/${whitelistMatter}"
 
   echo -e "${OVER}  ${INFO} ${str}"
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
To fix the whitelisting issue we are currently seeing when whitelisting from the web interface


**How does this PR accomplish the above?:**
This is a weird one, and it doesn't make a lot of sense logically. Perhaps someone with a better knowledge of PHP's `exec` command can shed some light on it...

Some notes:
- `comm` expects both files to be sorted (we acheive this on the whitelist file by calling `<(sort "${whitelistFile}")
-`list.preEventHorizon` is pre-sorted during it's generation. (using `sort -u`)
- When `pihole -w` is called from the CLI, everything goes to plan and the `comm` command is happy with the sort order of the two files.
- When `pihole -w` is called from the web interface, the `comm` command throws an error of `comm: file 1 is not in sorted order`.

The last point does not make any sense at all. When called from the web `list.preEventHorizon` is *identical* to `list.preEventHorizon` when called from the CLI. YET, when it is called from the web, it does not believe it to be sorted! (Attached is a zip file with lists from web and cli both pre and post sorting)

Now, I'm clutching at straws here, but maybe PHP's `exec` command has different rules for sorting than plain `bash`? I have no idea. 

[investigation.zip](https://github.com/pi-hole/pi-hole/files/1742309/investigation.zip)

All that aside, this change fixes the issue by ensuring that the `comm` deems both files to be sorted as it expects, regardless of whether it was called from the CLI or the web.

Really, if anyone can shed any light on the reason behind the different sort considerations, we would be truly appreciative of the insight!

**What documentation changes (if any) are needed to support this PR?:**
None

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

