### PR TITLE
Allow optional parsing of blocklists into NXDOMAIN style lists, rather than HOSTS

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -67,6 +67,7 @@ if [[ -f "${setupVars}" ]];then
   if [[ "${BLOCKSTYLE_NXDOMAIN}" == true ]]; then 
     truncate -s 0 "${blackList}"
     truncate -s 0 "${adList}"
+    dnsRestartType="restart"
   else
     rm "${adListNX}" 2> /dev/null
     rm "${blackListNX}" 2> /dev/null
@@ -624,8 +625,8 @@ for var in "$@"; do
     "-f" | "--force" ) forceDelete=true;;
     "-h" | "--help" ) helpFunc;;
     "-sd" | "--skip-download" ) skipDownload=true;;
-    "-b" | "--blacklist-only" ) listType="blacklist"; if [[ "${BLOCKSTYLE_NXDOMAIN}" == true ]]; then dnsRestartType="restart"; fi;;
-    "-w" | "--whitelist-only" ) listType="whitelist"; if [[ "${BLOCKSTYLE_NXDOMAIN}" == true ]]; then dnsRestartType="restart"; fi;;
+    "-b" | "--blacklist-only" ) listType="blacklist";;
+    "-w" | "--whitelist-only" ) listType="whitelist";;
     "-wild" | "--wildcard-only" ) listType="wildcard"; dnsRestartType="restart";;
   esac
 done

--- a/gravity.sh
+++ b/gravity.sh
@@ -624,8 +624,8 @@ for var in "$@"; do
     "-f" | "--force" ) forceDelete=true;;
     "-h" | "--help" ) helpFunc;;
     "-sd" | "--skip-download" ) skipDownload=true;;
-    "-b" | "--blacklist-only" ) listType="blacklist";;
-    "-w" | "--whitelist-only" ) listType="whitelist";;
+    "-b" | "--blacklist-only" ) listType="blacklist"; if [[ "${BLOCKSTYLE_NXDOMAIN}" == true ]]; then dnsRestartType="restart"; fi;;
+    "-w" | "--whitelist-only" ) listType="whitelist"; if [[ "${BLOCKSTYLE_NXDOMAIN}" == true ]]; then dnsRestartType="restart"; fi;;
     "-wild" | "--wildcard-only" ) listType="wildcard"; dnsRestartType="restart";;
   esac
 done

--- a/pihole
+++ b/pihole
@@ -11,6 +11,9 @@
 
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 readonly wildcardlist="/etc/dnsmasq.d/03-pihole-wildcard.conf"
+readonly adListNX="/etc/dnsmasq.d/00-pihole-gravity.conf"
+readonly userListNX="/etc/dnsmasq.d/00-pihole-userblacklist.conf"
+readonly whiteListNX="/etc/dnsmasq.d/99-pihole-whitelist.conf"
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
 
@@ -382,6 +385,15 @@ Time:
     if [[ -e "$wildcardlist" ]]; then
       mv "$wildcardlist" "/etc/pihole/wildcard.list"
     fi
+    if [[ -e "$adListNX" ]]; then
+      mv "$adListNX" "/etc/pihole/gravityNX.list"
+    fi
+    if [[ -e "$userListNX" ]]; then
+      mv "$userListNX" "/etc/pihole/blackNX.list"
+    fi
+    if [[ -e "$whiteListNX" ]]; then
+      mv "$whiteListNX" "/etc/pihole/whitelistNX.list"
+    fi
     if [[ $# > 1 ]]; then
       local error=false
       if [[ "${2}" == *"s" ]]; then
@@ -427,6 +439,15 @@ Time:
     sed -i 's/^#addn-hosts/addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
     if [[ -e "/etc/pihole/wildcard.list" ]]; then
       mv "/etc/pihole/wildcard.list" "$wildcardlist"
+    fi
+    if [[ -e "/etc/pihole/gravityNX.list" ]]; then
+      mv "/etc/pihole/gravityNX.list" "$adListNX"
+    fi
+    if [[ -e "/etc/pihole/blackNX.list" ]]; then
+      mv "/etc/pihole/blackNX.list" "$userListNX"
+    fi
+    if [[ -e "/etc/pihole/whitelistNX.list" ]]; then
+      mv "/etc/pihole/whitelistNX.list" "$whiteListNX"
     fi
   fi
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

As addressed in #2010, it would be nice to have the option to return `NXDOMAIN` instead of the address of the Pi-Hole host. With the PR, we can do just that. Obviously this renders the block page useless, but with the rise of HTTPS, that is becoming less and less relevant


**How does this PR accomplish the above?:**
`gravity.sh` now checks for a new value in `setupVars.conf` named `BLOCKSTYLE_NXDOMAIN` (boolean, name subject to change). If it is `true`, then `gravity` will empty out `gravity.list` and `black.list`, and then create three additional files:
- `/etc/dnsmasq.d/00-pihole-gravity.conf` - `server=/badDomain.com/`
- `/etc/dnsmasq.d/00-pihole-userBlacklist.conf` - `server=/badDomain.com/`
- `/etc/dnsmasq.d/99-pihole-whitelist.conf` - `server=/goodDomain.com/#`


**What documentation changes (if any) are needed to support this PR?:**
FTL will need a change to read number of blocked domains from this new source, as currently "number of blocked domains" shows as 0 (due to `gravity.list` being empty!)

![image](https://user-images.githubusercontent.com/1998970/36936281-3e75698e-1efb-11e8-9e8d-7abd9ff469ae.png)



---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

