### PR TITLE
Added `dhcpcd` to INSTALLER_DEPS for RedHat Family

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -206,7 +206,7 @@ elif command -v rpm &> /dev/null; then
   UPDATE_PKG_CACHE=":"
   PKG_INSTALL=(${PKG_MANAGER} install -y)
   PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
-  INSTALLER_DEPS=(dialog git iproute net-tools newt procps-ng)
+  INSTALLER_DEPS=(dialog git iproute net-tools newt procps-ng dhcpcd)
   PIHOLE_DEPS=(bc bind-utils cronie curl dnsmasq findutils nmap-ncat sudo unzip wget libidn2 psmisc)
   PIHOLE_WEB_DEPS=(lighttpd lighttpd-fastcgi php php-common php-cli php-pdo)
   # EPEL (https://fedoraproject.org/wiki/EPEL) is required for lighttpd on CentOS


### PR DESCRIPTION
Installation used to silently fail on Fedora 26 if the `dhcpcd` package was not found on the system.

Signed-off-by: Saswat Padhi <saswat.sourav@gmail.com>

**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fixes an installation issue on Fedora systems -- The installation used to silently fail if `dhcpcd` package was not found on the target system.
For Debian systems, the installation script installs `dhcpcd5` automatically, but this was missing for Red Hat Family OS.

**How does this PR accomplish the above?:**
This PR adds `dhcpcd` to the INSTALLER_DEPS to `dhcpcd` would be installed, if missing.

**What documentation changes (if any) are needed to support this PR?:**
_None_