### PR TITLE
Get head and tail of pihole-FTL.log during debug process

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -958,7 +958,7 @@ list_files_in_dir() {
             "${PIHOLE_WEB_SERVER_ERROR_LOG_FILE}") make_array_from_file "${dir_to_parse}/${each_file}" 25
             ;;
             # Same for the FTL log
-            "${PIHOLE_FTL_LOG}") make_array_from_file "${dir_to_parse}/${each_file}" 25
+            "${PIHOLE_FTL_LOG}") head_tail_log "${dir_to_parse}/${each_file}" 35
             ;;
             # parse the file into an array in case we ever need to analyze it line-by-line
             *) make_array_from_file "${dir_to_parse}/${each_file}";
@@ -989,6 +989,34 @@ show_content_of_pihole_files() {
   show_content_of_files_in_dir "${CRON_D_DIRECTORY}"
   show_content_of_files_in_dir "${WEB_SERVER_LOG_DIRECTORY}"
   show_content_of_files_in_dir "${LOG_DIRECTORY}"
+}
+
+head_tail_log() {
+  # The file being processed
+  local filename="${1}"
+  # The number of lines to use for head and tail
+  local qty="${2}"
+  local head_line
+  local tail_line
+  # Put the current Internal Field Separator into another variable so it can be restored later
+  OLD_IFS="$IFS"
+  # Get the lines that are in the file(s) and store them in an array for parsing later
+  IFS=$'\r\n'
+  local log_head=()
+  log_head=( $(head -n ${qty} ${filename}) )
+  log_write "   ${COL_CYAN}-----head of $(basename ${filename})------${COL_NC}"
+  for head_line in "${log_head[@]}"; do
+    log_write "   ${head_line}"
+  done
+  log_write ""
+  local log_tail=()
+  log_tail=( $(tail -n ${qty} ${filename}) )
+  log_write "   ${COL_CYAN}-----tail of $(basename ${filename})------${COL_NC}"
+  for tail_line in "${log_tail[@]}"; do
+    log_write "   ${tail_line}"
+  done
+  # Set the IFS back to what it was
+  IFS="$OLD_IFS"
 }
 
 analyze_gravity_list() {

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -592,7 +592,7 @@ ping_gateway() {
     # Try to quietly ping the gateway 3 times, with a timeout of 3 seconds, using numeric output only,
     # on the pihole interface, and tail the last three lines of the output
     # If pinging the gateway is not successful,
-    if ! ${cmd} -c 3 -W 2 -n ${gateway} -I ${PIHOLE_INTERFACE} >/dev/null; then
+    if ! ${cmd} -c 1 -W 2 -n ${gateway} -I ${PIHOLE_INTERFACE} >/dev/null; then
       # let the user know
       log_write "${CROSS} ${COL_RED}Gateway did not respond.${COL_NC} ($FAQ_GATEWAY)\n"
       # and return an error code
@@ -613,7 +613,7 @@ ping_internet() {
   ping_ipv4_or_ipv6 "${protocol}"
   log_write "* Checking Internet connectivity via IPv${protocol}..."
   # Try to ping the address 3 times
-  if ! ${cmd} -W 2 -c 3 -n ${public_address} -I ${PIHOLE_INTERFACE} >/dev/null; then
+  if ! ${cmd} -c 1 -W 2 -n ${public_address} -I ${PIHOLE_INTERFACE} >/dev/null; then
     # if it's unsuccessful, show an error
     log_write "${CROSS} ${COL_RED}Cannot reach the Internet.${COL_NC}\n"
     return 1


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [ ] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [ ] I give this submission freely and claim no ownership.
- [ ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Gets the `head` and `tail` of the `pihole-FTL.log` so we have more info to diagnose issues.


**How does this PR accomplish the above?:**
A new `head` and `tail` function is made and can be used on any file.  This is then applied to the `pihole-FTL.log` log file.

**What documentation changes (if any) are needed to support this PR?:**
None.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

