### PR TITLE
debug script: fix empty ports on some systems

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -652,7 +652,7 @@ check_required_ports() {
   # Sort the addresses and remove duplicates
   while IFS= read -r line; do
       ports_in_use+=( "$line" )
-  done < <( lsof -i -P -n | awk -F' ' '/LISTEN/ {print $9, $1}' | sort -n | uniq | cut -d':' -f2 )
+  done < <( lsof -i -P -n | awk -F' ' '/LISTEN/ {print $1, $9}' | sort -n | tr -d '[*]\r' | uniq | awk '{print $2, $1}' )
 
   # Now that we have the values stored,
   for i in "${!ports_in_use[@]}"; do


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@pi-hole.net>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fixes empty information in the debug log, such as no port/service being populated:
```
[800] is in use by nginx
[] is in use by 
[2812] is in use by monit
```

New output is:

```
[:8443] is in use by openvpn
[127.0.0.1:4711] is in use by pihole-FT
[::1:4711] is in use by pihole-FT
[:53] is in use by pihole-FT
```

**How does this PR accomplish the above?:**
Some ports in `lsof` show up as `[::1]:4711` (note the brackets).  I modified the commands that parse it down and used `tr` to remove some special characters and then `awk` to print the appropriate values.


**What documentation changes (if any) are needed to support this PR?:**
Already included.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

