### PR TITLE
add label to x-header so you know which one is being evaluated

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -712,20 +712,20 @@ check_x_headers() {
   # If the X-header found by curl matches what is should be,
   if [[ $block_page == "$block_page_working" ]]; then
     # display a success message
-    log_write "$TICK ${COL_GREEN}${block_page}${COL_NC}"
+    log_write "$TICK Block page X-Header: ${COL_GREEN}${block_page}${COL_NC}"
   else
     # Otherwise, show an error
-    log_write "$CROSS ${COL_RED}X-Header does not match or could not be retrieved.${COL_NC}"
+    log_write "$CROSS Block page X-Header: ${COL_RED}X-Header does not match or could not be retrieved.${COL_NC}"
     log_write "${COL_RED}${full_curl_output_block_page}${COL_NC}"
   fi
 
   # Same logic applies to the dashbord as above, if the X-Header matches what a working system shoud have,
   if [[ $dashboard == "$dashboard_working" ]]; then
     # then we can show a success
-    log_write "$TICK ${COL_GREEN}${dashboard}${COL_NC}"
+    log_write "$TICK Web interface X-Header: ${COL_GREEN}${dashboard}${COL_NC}"
   else
     # Othewise, it's a failure since the X-Headers either don't exist or have been modified in some way
-    log_write "$CROSS ${COL_RED}X-Header does not match or could not be retrieved.${COL_NC}"
+    log_write "$CROSS Web interface X-Header: ${COL_RED}X-Header does not match or could not be retrieved.${COL_NC}"
     log_write "${COL_RED}${full_curl_output_dashboard}${COL_NC}"
   fi
 }


### PR DESCRIPTION
Signed-off-by: Jacob Salmela <jacob.salmela@pi-hole.net>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Add a label to the debug log when evaluating the X-Headers--helpful wen it fails so we can see which one is which.

**How does this PR accomplish the above?:**
Just adds a text label in front of the variables output.

**What documentation changes (if any) are needed to support this PR?:**
None.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

