### PR TITLE
Fix error: /opt/pihole/gravity.sh: 385: Warning: command substitution: ignored null byte in input

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -382,9 +382,8 @@ gravity_ConsolidateDownloadedBlocklists() {
     if [[ -r "${i}" ]]; then
       # Remove windows CRs from file, convert list to lower case, and append into $matterAndLight
       tr -d '\r' < "${i}" | tr '[:upper:]' '[:lower:]' >> "${piholeDir}/${matterAndLight}"
-
       # Ensure that the first line of a new list is on a new line
-      lastLine=$(tail -1 "${piholeDir}/${matterAndLight}" | tr -d '\0')
+      IFS= read -r -d '' lastLine <"${piholeDir}/${matterAndLight}" || [[ $lastLine ]]
       if [[ "${#lastLine}" -gt 0 ]]; then
         echo "" >> "${piholeDir}/${matterAndLight}"
       fi

--- a/gravity.sh
+++ b/gravity.sh
@@ -384,7 +384,7 @@ gravity_ConsolidateDownloadedBlocklists() {
       tr -d '\r' < "${i}" | tr '[:upper:]' '[:lower:]' >> "${piholeDir}/${matterAndLight}"
 
       # Ensure that the first line of a new list is on a new line
-      lastLine=$(tail -1 "${piholeDir}/${matterAndLight}")
+      lastLine=$(tail -1 "${piholeDir}/${matterAndLight}" | tr -d '\0')
       if [[ "${#lastLine}" -gt 0 ]]; then
         echo "" >> "${piholeDir}/${matterAndLight}"
       fi
@@ -505,7 +505,7 @@ gravity_ParseBlacklistDomains() {
 
   # Empty $accretionDisc if it already exists, otherwise, create it
   : > "${piholeDir}/${accretionDisc}"
-  
+
   if [[ -f "${piholeDir}/${whitelistMatter}" ]]; then
     gravity_ParseDomainsIntoHosts "${piholeDir}/${whitelistMatter}" "${piholeDir}/${accretionDisc}"
   else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Remove this error some users see:

```
/opt/pihole/gravity.sh: 385: Warning: command substitution: ignored null byte in input
```

**How does this PR accomplish the above?:**
Removed null bytes with `tr -d` as mentioned [here](https://stackoverflow.com/questions/46163678/get-rid-of-warning-command-substitution-ignored-null-byte-in-input?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa).

**What documentation changes (if any) are needed to support this PR?:**
None


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
