### PR TITLE
Get user locale when debugging

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -494,8 +494,9 @@ parse_setup_vars() {
 }
 
 parse_locale() {
+  local pihole_locale
   echo_current_diagnostic "Locale"
-  local pihole_locale="$(locale)"
+  pihole_locale="$(locale)"
   parse_file "${pihole_locale}"
 }
 

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -493,6 +493,12 @@ parse_setup_vars() {
   fi
 }
 
+parse_locale() {
+  echo_current_diagnostic "Locale"
+  local pihole_locale="$(locale)"
+  parse_file "${pihole_locale}"
+}
+
 does_ip_match_setup_vars() {
   # Check for IPv4 or 6
   local protocol="${1}"
@@ -879,8 +885,11 @@ parse_file() {
   # Put the current Internal Field Separator into another variable so it can be restored later
   OLD_IFS="$IFS"
   # Get the lines that are in the file(s) and store them in an array for parsing later
-  IFS=$'\r\n' command eval 'file_info=( $(cat "${filename}") )'
-
+  if [[ -f "$filename" ]]; then
+    IFS=$'\r\n' command eval 'file_info=( $(cat "${filename}") )'
+  else
+    read -a file_info <<< $filename
+  fi
   # Set a named variable for better readability
   local file_lines
   # For each line in the file,
@@ -1165,6 +1174,7 @@ parse_setup_vars
 check_x_headers
 analyze_gravity_list
 show_content_of_pihole_files
+parse_locale
 analyze_pihole_log
 copy_to_debug_log
 upload_to_tricorder


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Include `locale` in the debug log.  We've seen several issues with the locale so this will speed up debugging.

**How does this PR accomplish the above?:**
Adds a function to parse through the `locale`'s command

**What documentation changes (if any) are needed to support this PR?:**
None.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

