### PR TITLE
Fix sed: can't read /etc/pihole/pihole-FTL.conf: No such file or directory

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -17,7 +17,9 @@ source ${colfile}
 # a) the setting is not present in the config file, or
 # b) the setting is commented out (e.g. "#DBFILE=...")
 FTLconf="/etc/pihole/pihole-FTL.conf"
-[ -e "$FTLconf" ] && DBFILE="$(sed -n -e 's/^\s*DBFILE\s*=\s*//p' ${FTLconf})"
+if [ -e "$FTLconf" ]; then
+  DBFILE="$(sed -n -e 's/^\s*DBFILE\s*=\s*//p' ${FTLconf})"
+fi
 # Test for empty string. Use standard path in this case.
 if [ -z "$DBFILE" ]; then
   DBFILE="/etc/pihole/pihole-FTL.db"

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -17,7 +17,7 @@ source ${colfile}
 # a) the setting is not present in the config file, or
 # b) the setting is commented out (e.g. "#DBFILE=...")
 FTLconf="/etc/pihole/pihole-FTL.conf"
-[ -e "$FTLconf" ] && DBFILE="$(sed -n -e 's/^\s*DBFILE\s*=\s*//p' $FTLconf)"
+[ -e "$FTLconf" ] && DBFILE="$(sed -n -e 's/^\s*DBFILE\s*=\s*//p' ${FTLconf})"
 # Test for empty string. Use standard path in this case.
 if [ -z "$DBFILE" ]; then
   DBFILE="/etc/pihole/pihole-FTL.db"

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -16,7 +16,7 @@ source ${colfile}
 # Constructed to return nothing when
 # a) the setting is not present in the config file, or
 # b) the setting is commented out (e.g. "#DBFILE=...")
-DBFILE="$(sed -n -e 's/^\s^.DBFILE\s*=\s*//p' /etc/pihole/pihole-FTL.conf)"
+DBFILE="$(sed -n -e 's/^\s*DBFILE\s*=\s*//p' /etc/pihole/pihole-FTL.conf)"
 # Test for empty string. Use standard path in this case.
 if [ -z "$DBFILE" ]; then
   DBFILE="/etc/pihole/pihole-FTL.db"

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -16,7 +16,8 @@ source ${colfile}
 # Constructed to return nothing when
 # a) the setting is not present in the config file, or
 # b) the setting is commented out (e.g. "#DBFILE=...")
-DBFILE="$(sed -n -e 's/^\s*DBFILE\s*=\s*//p' /etc/pihole/pihole-FTL.conf)"
+FTLconf="/etc/pihole/pihole-FTL.conf"
+[ -e "$FTLconf" ] && DBFILE="$(sed -n -e 's/^\s*DBFILE\s*=\s*//p' $FTLconf)"
 # Test for empty string. Use standard path in this case.
 if [ -z "$DBFILE" ]; then
   DBFILE="/etc/pihole/pihole-FTL.db"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Each night since the upgrade to version v3.3.1 the script ``piholeLogFlush.sh`` generates the following error sent by cron in an email:
```
Subject: Cron <root@PiHole>    PATH="$PATH:/usr/local/bin/" pihole flush once quiet

sed: can't read /etc/pihole/pihole-FTL.conf: No such file or directory
```

**How does this PR accomplish the above?:**
The script now checks that the file ``/etc/pihole/pihole-FTL.conf`` exists before trying to read it.

I also changed the regular expression used to parse the file ``/etc/pihole/pihole-FTL.conf``. It was not working (for me).

**What documentation changes (if any) are needed to support this PR?:**
 No documentation change is needed.