### PR TITLE
Use domain list format for black.list and gravity.list

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -515,11 +515,9 @@ gravity_ParseBlacklistDomains() {
 
   if [[ -f "${piholeDir}/${whitelistMatter}" ]]; then
     mv "${piholeDir}/${whitelistMatter}" "${piholeDir}/${accretionDisc}"
-    grep -c "^" "${piholeDir}/${whitelistMatter}" > "${piholeDir}/numBlocked" 2> /dev/null
   else
     # There was no whitelist file, so use preEventHorizon instead of whitelistMatter.
     mv "${piholeDir}/${preEventHorizon}" "${piholeDir}/${accretionDisc}"
-    grep -c "^" "${piholeDir}/${preEventHorizon}" > "${piholeDir}/numBlocked" 2> /dev/null
   fi
 
   # Move the file over as /etc/pihole/gravity.list so dnsmasq can use it

--- a/gravity.sh
+++ b/gravity.sh
@@ -535,11 +535,10 @@ gravity_ParseUserDomains() {
   if [[ ! -f "${blacklistFile}" ]]; then
     return 0
   fi
-
-  mv "${blacklistFile}" "${blackList}.tmp"
+  
   # Copy the file over as /etc/pihole/black.list so dnsmasq can use it
-  mv "${blackList}.tmp" "${blackList}" 2> /dev/null || \
-    echo -e "\\n  ${CROSS} Unable to move ${blackList##*/}.tmp to ${piholeDir}"
+  cp "${blacklistFile}" "${blackList}" 2> /dev/null || \
+    echo -e "\\n  ${CROSS} Unable to move ${blacklistFile##*/} to ${piholeDir}"
 }
 
 # Trap Ctrl-C

--- a/gravity.sh
+++ b/gravity.sh
@@ -512,13 +512,13 @@ gravity_ParseBlacklistDomains() {
 
   # Empty $accretionDisc if it already exists, otherwise, create it
   : > "${piholeDir}/${accretionDisc}"
-  
+
   if [[ -f "${piholeDir}/${whitelistMatter}" ]]; then
-    gravity_ParseDomainsIntoHosts "${piholeDir}/${whitelistMatter}" "${piholeDir}/${accretionDisc}"
+    mv "${piholeDir}/${whitelistMatter}" "${piholeDir}/${accretionDisc}"
     grep -c "^" "${piholeDir}/${whitelistMatter}" > "${piholeDir}/numBlocked" 2> /dev/null
   else
     # There was no whitelist file, so use preEventHorizon instead of whitelistMatter.
-    gravity_ParseDomainsIntoHosts "${piholeDir}/${preEventHorizon}" "${piholeDir}/${accretionDisc}"
+    mv "${piholeDir}/${preEventHorizon}" "${piholeDir}/${accretionDisc}"
     grep -c "^" "${piholeDir}/${preEventHorizon}" > "${piholeDir}/numBlocked" 2> /dev/null
   fi
 
@@ -538,7 +538,7 @@ gravity_ParseUserDomains() {
     return 0
   fi
 
-  gravity_ParseDomainsIntoHosts "${blacklistFile}" "${blackList}.tmp"
+  mv "${blacklistFile}" "${blackList}.tmp"
   # Copy the file over as /etc/pihole/black.list so dnsmasq can use it
   mv "${blackList}.tmp" "${blackList}" 2> /dev/null || \
     echo -e "\\n  ${CROSS} Unable to move ${blackList##*/}.tmp to ${piholeDir}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Remove unnecessary overhead in our lists caused by having to write them in HOSTS format. Often, the IP addresses (esp. the IPv6 address) is longer than the blocked domain itself. In addition, the HOSTS format will be much longer, as it contains each entry two times for IPv4 + IPv6 blocking.

**How does this PR accomplish the above?:**

Generate gravity.list and black.list in simple domain lists format for FTLDNS. Leave local.list in HOSTS format.

Compare HOSTS format:
```
192.168.2.11 baddomain1.com
fda2:2001:5647:0:ba27:ebff:fe37:4205 baddomain1.com
192.168.2.11 baddomain2.com
fda2:2001:5647:0:ba27:ebff:fe37:4205 baddomain2.com
```
and simple list format:
```
baddomain1.com
baddomain2.com
```

**What documentation changes (if any) are needed to support this PR?:**

Unclear, a blog post informing users might be nice.