### PR TITLE
Fix static IP checking on Fedora

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -689,7 +689,7 @@ setStaticIPv4() {
     IFCFG_FILE=/etc/sysconfig/network-scripts/ifcfg-${PIHOLE_INTERFACE}
     IPADDR=$(echo "${IPV4_ADDRESS}" | cut -f1 -d/)
     # check if the desired IP is already set
-    if grep -q "${IPADDR}" "${IFCFG_FILE}"; then
+    if grep -Eq "${IPADDR}(\\b|\\/)" "${IFCFG_FILE}"; then
       echo -e "  ${INFO} Static IP already configured"
     # Otherwise,
     else


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
This bug was introduced by #1758 where the CIDR was removed from the static IP check.
i.e. Installer fails to reconfigure the IP when changing the static IP from `X.X.X.111` to `X.X.X.11`.

**How does this PR accomplish the above?:**
The CIDR was acting as a boundary so we need to test for a boundary or a slash character.

**What documentation changes (if any) are needed to support this PR?:**
Existing comment exists


EDIT: add failing example
