### PR TITLE
Allow for empty/non existent adlist file

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -44,6 +44,8 @@ skipDownload="false"
 
 resolver="pihole-FTL"
 
+haveSourceUrls=true
+
 # Source setupVars from install script
 setupVars="${piholeDir}/setupVars.conf"
 if [[ -f "${setupVars}" ]];then
@@ -129,17 +131,11 @@ gravity_CheckDNSResolutionAvailable() {
 gravity_GetBlocklistUrls() {
   echo -e "  ${INFO} ${COL_BOLD}Neutrino emissions detected${COL_NC}..."
 
-  # Determine if adlists file needs handling
-  if [[ ! -f "${adListFile}" ]]; then
-    echo -e "  ${CROSS} No adlists file found. Nothing to do!"
-  elif [[ -f "${adListDefault}" ]] && [[ -f "${adListFile}" ]]; then
+  if [[ -f "${adListDefault}" ]] && [[ -f "${adListFile}" ]]; then
     # Remove superceded $adListDefault file
     rm "${adListDefault}" 2> /dev/null || \
       echo -e "  ${CROSS} Unable to remove ${adListDefault}"
   fi
-
-  local str="Pulling blocklist source list into range"
-  echo -ne "  ${INFO} ${str}..."
 
   # Retrieve source URLs from $adListFile
   # Logic: Remove comments and empty lines
@@ -156,11 +152,15 @@ gravity_GetBlocklistUrls() {
     }' <<< "$(printf '%s\n' "${sources[@]}")" 2> /dev/null
   )"
 
+  local str="Pulling blocklist source list into range"
+
   if [[ -n "${sources[*]}" ]] && [[ -n "${sourceDomains[*]}" ]]; then
     echo -e "${OVER}  ${TICK} ${str}"
   else
     echo -e "${OVER}  ${CROSS} ${str}"
-    gravity_Cleanup "error"
+    echo -e "  ${INFO} No source list found, or it is empty"
+    echo ""
+    haveSourceUrls=false
   fi
 }
 
@@ -374,7 +374,9 @@ gravity_ConsolidateDownloadedBlocklists() {
   local str lastLine
 
   str="Consolidating blocklists"
-  echo -ne "  ${INFO} ${str}..."
+  if [[ "${haveSourceUrls}" == true ]]; then
+    echo -ne "  ${INFO} ${str}..."
+  fi
 
   # Empty $matterAndLight if it already exists, otherwise, create it
   : > "${piholeDir}/${matterAndLight}"
@@ -393,8 +395,9 @@ gravity_ConsolidateDownloadedBlocklists() {
       fi
     fi
   done
-
-  echo -e "${OVER}  ${TICK} ${str}"
+  if [[ "${haveSourceUrls}" == true ]]; then
+    echo -e "${OVER}  ${TICK} ${str}"
+  fi
 }
 
 # Parse consolidated list into (filtered, unique) domains-only format
@@ -402,24 +405,33 @@ gravity_SortAndFilterConsolidatedList() {
   local str num
 
   str="Extracting domains from blocklists"
-  echo -ne "  ${INFO} ${str}..."
+  if [[ "${haveSourceUrls}" == true ]]; then
+    echo -ne "  ${INFO} ${str}..."
+  fi
 
   # Parse into hosts file
   gravity_ParseFileIntoDomains "${piholeDir}/${matterAndLight}" "${piholeDir}/${parsedMatter}"
 
   # Format $parsedMatter line total as currency
   num=$(printf "%'.0f" "$(wc -l < "${piholeDir}/${parsedMatter}")")
-  echo -e "${OVER}  ${TICK} ${str}
-  ${INFO} Number of domains being pulled in by gravity: ${COL_BLUE}${num}${COL_NC}"
+  if [[ "${haveSourceUrls}" == true ]]; then
+    echo -e "${OVER}  ${TICK} ${str}"
+  fi
+  echo -e "  ${INFO} Number of domains being pulled in by gravity: ${COL_BLUE}${num}${COL_NC}"
 
   str="Removing duplicate domains"
-  echo -ne "  ${INFO} ${str}..."
-  sort -u "${piholeDir}/${parsedMatter}" > "${piholeDir}/${preEventHorizon}"
-  echo -e "${OVER}  ${TICK} ${str}"
+  if [[ "${haveSourceUrls}" == true ]]; then
+    echo -ne "  ${INFO} ${str}..."
+  fi
 
-  # Format $preEventHorizon line total as currency
-  num=$(printf "%'.0f" "$(wc -l < "${piholeDir}/${preEventHorizon}")")
-  echo -e "  ${INFO} Number of unique domains trapped in the Event Horizon: ${COL_BLUE}${num}${COL_NC}"
+  sort -u "${piholeDir}/${parsedMatter}" > "${piholeDir}/${preEventHorizon}"
+
+  if [[ "${haveSourceUrls}" == true ]]; then
+    echo -e "${OVER}  ${TICK} ${str}"
+    # Format $preEventHorizon line total as currency
+    num=$(printf "%'.0f" "$(wc -l < "${piholeDir}/${preEventHorizon}")")
+    echo -e "  ${INFO} Number of unique domains trapped in the Event Horizon: ${COL_BLUE}${num}${COL_NC}"
+  fi
 }
 
 # Whitelist user-defined domains
@@ -531,7 +543,6 @@ gravity_ParseUserDomains() {
   if [[ ! -f "${blacklistFile}" ]]; then
     return 0
   fi
-  
   # Copy the file over as /etc/pihole/black.list so dnsmasq can use it
   cp "${blacklistFile}" "${blackList}" 2> /dev/null || \
     echo -e "\\n  ${CROSS} Unable to move ${blacklistFile##*/} to ${piholeDir}"
@@ -618,7 +629,9 @@ if [[ "${skipDownload}" == false ]]; then
   # Gravity needs to download blocklists
   gravity_CheckDNSResolutionAvailable
   gravity_GetBlocklistUrls
-  gravity_SetDownloadOptions
+  if [[ "${haveSourceUrls}" == true ]]; then
+    gravity_SetDownloadOptions
+  fi
   gravity_ConsolidateDownloadedBlocklists
   gravity_SortAndFilterConsolidatedList
 else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Discovered [in this reddit thread](https://www.reddit.com/r/pihole/comments/8elrq9/blocking_via_regex_now_available_in_ftldns/dy876rz/?context=3&utm_content=context&utm_medium=message&utm_source=reddit&utm_name=frontpage)

Fixes a bug whereby `gravity.list` retains whatever it had in it before if `adlists.list` is empty or missing. We can assume that the user meant to delete or empty this file, and therefore `gravity.list` should be empty.
