### PR TITLE
Tweak/remove dnsmasq refs

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1973,7 +1973,7 @@ FTLcheckUpdate()
 
    # if dnsmasq is running at this point, force reinstall of FTL Binary
   if check_service_active "dnsmasq";then
-    return 1
+    return 0
   fi
 
   if [[ ! "${ftlBranch}" == "master" ]]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1971,6 +1971,11 @@ FTLcheckUpdate()
   local remoteSha1
   local localSha1
 
+   # if dnsmasq is running at this point, force reinstall of FTL Binary
+  if check_service_active "dnsmasq";then
+    return 1
+  fi
+
   if [[ ! "${ftlBranch}" == "master" ]]; then
     if [[ ${ftlLoc} ]]; then
       # We already have a pihole-FTL binary downloaded.
@@ -2021,11 +2026,6 @@ FTLcheckUpdate()
 FTLdetect() {
   echo ""
   echo -e "  ${INFO} FTL Checks..."
-
-  # if dnsmasq is running at this point, force reinstall of FTL Binary
-  if check_service_active "dnsmasq";then
-    FTLinstall "${binary}" || return 1
-  fi
 
   if FTLcheckUpdate ; then
     FTLinstall "${binary}" || return 1


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fixes #2156

**How does this PR accomplish the above?:**
When running `pihole checkout dev` from `master`, the `FTL` binary is downloaded before the install script is run. Since we no longer force the resolver to stop during the install process, this causes issues with `dnsmasq` never being disabled.

This PR forces the installer to reinstall `FTL` if it detects that `dnsmasq` is running, and _then_ disables `dnsmasq` once `FTL` is installed.

No need to check for `--resolver` flag any more, as all future versions of `FTL` should be capable of resolving. (`--resolver` flag was a good stop-gap for when we were unsure if `FTLDNS` would be the next release or not)

**What documentation changes (if any) are needed to support this PR?:**