### PR TITLE
Don't attempt to download non-existent FTL Binary

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -133,8 +133,17 @@ main() {
     FTL_update=true
     echo -e "  ${INFO} FTL:\\t\\t${COL_YELLOW}update available${COL_NC}"
   else
+    case $? in
+    1)
+      echo -e "  ${INFO} FTL:\\t\\t${COL_LIGHT_GREEN}up to date${COL_NC}"
+      ;;
+    2)
+      echo -e "  ${INFO} FTL:\\t\\t${COL_LIGHT_RED}Branch is not available.${COL_NC}\\n\\t\\t\\tUse ${COL_LIGHT_GREEN}pihole checkout ftl [branchname]${COL_NC} to switch to a valid branch."
+      ;;
+    *)
+      echo -e "  ${INFO} FTL:\\t\\t${COL_LIGHT_RED}Something has gone wrong, contact support${COL_NC}"
+    esac
     FTL_update=false
-    echo -e "  ${INFO} FTL:\\t\\t${COL_LIGHT_GREEN}up to date${COL_NC}"
   fi
 
   if [[ "${core_update}" == false && "${web_update}" == false && "${FTL_update}" == false ]]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1762,6 +1762,86 @@ update_dialogs() {
     esac
 }
 
+check_download_exists() {
+  status=$(curl --head --silent "https://ftl.pi-hole.net/${1}" | head -n 1)
+  if grep -q "404" <<< "$status"; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+fully_fetch_repo() {
+  # Add upstream branches to shallow clone
+  local directory="${1}"
+
+  cd "${directory}" || return 1
+  if is_repo "${directory}"; then
+    git remote set-branches origin '*' || return 1
+    git fetch --quiet || return 1
+  else
+    return 1
+  fi
+  return 0
+}
+
+get_available_branches() {
+  # Return available branches
+  local directory
+  directory="${1}"
+  local output
+
+  cd "${directory}" || return 1
+  # Get reachable remote branches, but store STDERR as STDOUT variable
+  output=$( { git remote show origin | grep 'tracked' | sed 's/tracked//;s/ //g'; } 2>&1 )
+  echo "$output"
+  return
+}
+
+fetch_checkout_pull_branch() {
+  # Check out specified branch
+  local directory
+  directory="${1}"
+  local branch
+  branch="${2}"
+
+  # Set the reference for the requested branch, fetch, check it put and pull it
+  cd "${directory}" || return 1
+  git remote set-branches origin "${branch}" || return 1
+  git stash --all --quiet &> /dev/null || true
+  git clean --quiet --force -d || true
+  git fetch --quiet || return 1
+  checkout_pull_branch "${directory}" "${branch}" || return 1
+}
+
+checkout_pull_branch() {
+  # Check out specified branch
+  local directory
+  directory="${1}"
+  local branch
+  branch="${2}"
+  local oldbranch
+
+  cd "${directory}" || return 1
+
+  oldbranch="$(git symbolic-ref HEAD)"
+
+  str="Switching to branch: '${branch}' from '${oldbranch}'"
+  echo -ne "  ${INFO} $str"
+  git checkout "${branch}" --quiet || return 1
+  echo -e "${OVER}  ${TICK} $str"
+
+  git_pull=$(git pull || return 1)
+
+  if [[ "$git_pull" == *"up-to-date"* ]]; then
+    echo -e "  ${INFO} ${git_pull}"
+  else
+    echo -e "$git_pull\\n"
+  fi
+
+  return 0
+}
+
 clone_or_update_repos() {
   # If the user wants to reconfigure,
   if [[ "${reconfigure}" == true ]]; then
@@ -1977,6 +2057,15 @@ FTLcheckUpdate()
   fi
 
   if [[ ! "${ftlBranch}" == "master" ]]; then
+    #Check whether or not the binary for this FTL branch actually exists. If not, then there is no update!
+    local path
+    path="${ftlBranch}/${binary}"
+    # shellcheck disable=SC1090
+    if ! check_download_exists "$path"; then
+      echo -e "  ${INFO} Branch \"${ftlBranch}\" is not available.\\n  ${INFO} Use ${COL_LIGHT_GREEN}pihole checkout ftl [branchname]${COL_NC} to switch to a valid branch."
+      return 2
+    fi
+
     if [[ ${ftlLoc} ]]; then
       # We already have a pihole-FTL binary downloaded.
       # Alt branches don't have a tagged version against them, so just confirm the checksum of the local vs remote to decide whether we download or not


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
As reported [here on discourse](https://discourse.pi-hole.net/t/error-updating-latest-beta-ftldns-with-regex/), `pihole -up` or `pihole -r` will not gracefully continue if the download for that branch of `FTL` is no longer available. 

**How does this PR accomplish the above?:**
Add a simple check to see if the binary exists, if not, there is no update.

A future change may add some helpful output to this, however it is no necessary at this time.

**What documentation changes (if any) are needed to support this PR?:**