### PR TITLE
flip uninstall compatability check

### DIFF
--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -53,16 +53,7 @@ if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
 fi
 
 # Compatability
-if [ -x "$(command -v rpm)" ]; then
-	# Fedora Family
-	PKG_REMOVE="${PKG_MANAGER} remove -y"
-	package_check() {
-		rpm -qa | grep ^$1- > /dev/null
-	}
-	package_cleanup() {
-		${SUDO} ${PKG_MANAGER} -y autoremove
-	}
-elif [ -x "$(command -v apt-get)" ]; then
+if [ -x "$(command -v apt-get)" ]; then
 	# Debian Family
 	PKG_REMOVE="${PKG_MANAGER} -y remove --purge"
 	package_check() {
@@ -71,6 +62,15 @@ elif [ -x "$(command -v apt-get)" ]; then
 	package_cleanup() {
 		${SUDO} ${PKG_MANAGER} -y autoremove
 		${SUDO} ${PKG_MANAGER} -y autoclean
+	}
+elif [ -x "$(command -v rpm)" ]; then
+	# Fedora Family
+	PKG_REMOVE="${PKG_MANAGER} remove -y"
+	package_check() {
+		rpm -qa | grep ^$1- > /dev/null
+	}
+	package_cleanup() {
+		${SUDO} ${PKG_MANAGER} -y autoremove
 	}
 else
   echo -e "  ${CROSS} OS distribution not supported"

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -60,17 +60,17 @@ if [ -x "$(command -v apt-get)" ]; then
 		dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -c "ok installed"
 	}
 	package_cleanup() {
-		${SUDO} ${PKG_MANAGER} -y autoremove
-		${SUDO} ${PKG_MANAGER} -y autoclean
+		"${SUDO} ${PKG_MANAGER}" -y autoremove
+		"${SUDO} ${PKG_MANAGER}" -y autoclean
 	}
 elif [ -x "$(command -v rpm)" ]; then
 	# Fedora Family
 	PKG_REMOVE="${PKG_MANAGER} remove -y"
 	package_check() {
-		rpm -qa | grep ^$1- > /dev/null
+		rpm -qa | grep "^$1-" > /dev/null
 	}
 	package_cleanup() {
-		${SUDO} ${PKG_MANAGER} -y autoremove
+		"${SUDO} ${PKG_MANAGER}" -y autoremove
 	}
 else
   echo -e "  ${CROSS} OS distribution not supported"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. 
---
**What does this PR aim to accomplish?:**
Consistency with the following installer commit: https://github.com/pi-hole/pi-hole/commit/04c60e8a1c2aa2f6c06e6277018cea2b7db07eaf

**How does this PR accomplish the above?:**
Flip the check for `rpm` and `apt-get` as the install-base is primarily Debian.  
(Protects against the rare chance that a Debian user has `rpm` installed)

**What documentation changes (if any) are needed to support this PR?:**
This tweak should not require additional documentation.

