### PR TITLE
Remove LOCAL_DNS_PORT support

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -149,9 +149,13 @@ ProcessDNSSettings() {
 		let COUNTER=COUNTER+1
 	done
 
-  if [ ! -z "${LOCAL_DNS_PORT}" ]; then
-    add_dnsmasq_setting "server" "127.0.0.1#${LOCAL_DNS_PORT}"
-  fi
+	# The option LOCAL_DNS_PORT is deprecated
+	# We apply it once more, and then convert it into the current format
+	if [ ! -z "${LOCAL_DNS_PORT}" ]; then
+		add_dnsmasq_setting "server" "127.0.0.1#${LOCAL_DNS_PORT}"
+		add_setting "PIHOLE_DNS_${COUNTER}" "127.0.0.1#${LOCAL_DNS_PORT}"
+		delete_setting "LOCAL_DNS_PORT"
+	fi
 
 	delete_dnsmasq_setting "domain-needed"
 
@@ -529,16 +533,6 @@ SetPrivacyLevel() {
 		changeFTLsetting "PRIVACYLEVEL" "${args[2]}"
 	fi
 }
-SetLocalDNSport() {
-  # Ensure port is a natural number { 0, 1, 2, 3, ... }
-  if [[ "${1}" == "0" ]]; then
-    delete_setting "LOCAL_DNS_PORT"
-    ProcessDNSSettings
-  elif [[ "${1}" =~ ^[0-9]+$ ]]; then
-    change_setting "LOCAL_DNS_PORT" "${1}"
-    ProcessDNSSettings
-  fi
-}
 
 main() {
 	args=("$@")
@@ -570,7 +564,6 @@ main() {
 		"adlist"              ) CustomizeAdLists;;
 		"audit"               ) audit;;
 		"-l" | "privacylevel" ) SetPrivacyLevel;;
-		"localdnsport"        ) SetLocalDNSport "$3";;
 		*                     ) helpFunc;;
 	esac
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Remove support for the `LOCAL_DNS_PORT` setting in `setupVars.conf`. It is not needed anymore as https://github.com/pi-hole/AdminLTE/pull/742 adds support for resolvers (also local ones) on arbitrary ports. Hence, it should be merged after the other PR, but they are not in conflict.

**How does this PR accomplish the above?:**

Add a part in the code that parses this setting and automatically converts it into the new format.

I tested this for a (small) variety of cases, e.g.

`setupVars.conf` before:
```
PIHOLE_DNS_1=8.8.8.8
PIHOLE_DNS_2=1.1.1.1
LOCAL_DNS_PORT=5353                  <------
```

`setupVars.conf` after running `pihole -a -i all` (or any other suitable command):
```
PIHOLE_DNS_1=8.8.8.8
PIHOLE_DNS_2=1.1.1.1
PIHOLE_DNS_3=127.0.0.1#5353          <------
```

This also works fine if there was no forward destination defined before (as should be the case for people following the Pi-hole +  `unbound` wiki):

`setupVars.conf` before:
```
LOCAL_DNS_PORT=5353
```

`setupVars.conf` after running `pihole -a -i all` (or any other suitable command):
```
PIHOLE_DNS_1=127.0.0.1#5353
```