### PR TITLE
Fix block page crash on PHP 5.4

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -103,7 +103,7 @@ $bpAskAdmin = !empty($svEmail) ? '<a href="mailto:'.$svEmail.'?subject=Site Bloc
 
 // Determine if at least one block list has been generated
 $blocklistglob = glob("/etc/pihole/list.0.*.domains");
-if($blocklistglob === array()) {
+if ($blocklistglob === array()) {
     die("[ERROR] There are no domain lists generated lists within <code>/etc/pihole/</code>! Please update gravity by running <code>pihole -g</code>, or repair Pi-hole using <code>pihole -r</code>.");
 }
 

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -103,8 +103,9 @@ $bpAskAdmin = !empty($svEmail) ? '<a href="mailto:'.$svEmail.'?subject=Site Bloc
 
 // Determine if at least one block list has been generated
 $blocklistglob = glob("/etc/pihole/list.0.*.domains");
-if ($blocklistglob = "")
+if ($blocklistglob = "") {
     die("[ERROR] There are no domain lists generated lists within <code>/etc/pihole/</code>! Please update gravity by running <code>pihole -g</code>, or repair Pi-hole using <code>pihole -r</code>.");
+}
 
 // Set location of adlists file
 if (is_file("/etc/pihole/adlists.list")) {

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -103,7 +103,7 @@ $bpAskAdmin = !empty($svEmail) ? '<a href="mailto:'.$svEmail.'?subject=Site Bloc
 
 // Determine if at least one block list has been generated
 $blocklistglob = glob("/etc/pihole/list.0.*.domains");
-if ($blocklistglob = "") {
+if($blocklistglob === array()) {
     die("[ERROR] There are no domain lists generated lists within <code>/etc/pihole/</code>! Please update gravity by running <code>pihole -g</code>, or repair Pi-hole using <code>pihole -r</code>.");
 }
 

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -102,7 +102,8 @@ if ($serverName === "pi.hole") {
 $bpAskAdmin = !empty($svEmail) ? '<a href="mailto:'.$svEmail.'?subject=Site Blocked: '.$serverName.'"></a>' : "<span/>";
 
 // Determine if at least one block list has been generated
-if (empty(glob("/etc/pihole/list.0.*.domains")))
+$blocklistglob = glob("/etc/pihole/list.0.*.domains");
+if ($blocklistglob = "")
     die("[ERROR] There are no domain lists generated lists within <code>/etc/pihole/</code>! Please update gravity by running <code>pihole -g</code>, or repair Pi-hole using <code>pihole -r</code>.");
 
 // Set location of adlists file


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Prevent the pi-hole block page from returning 500 / server error on systems (such as Centos 7) which ship with old versions of PHP (5.4)

#1955 and [AdminLTE#746](https://github.com/pi-hole/AdminLTE/issues/746)

**How does this PR accomplish the above?:**
Avoid empty(glob()) which does not work under PHP < 5.5.

*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

Avoiding calling empty() on a function allows this to work under PHP5. 
Making the check for blocklist generation in this way instead is compatible with both PHP5 and PHP7.

**What documentation changes (if any) are needed to support this PR?:**
None. 






Signed-off-by: Rob Gill <rrobgill@protonmail.com>