### PR TITLE
Disable SystemD's DNS Stub Resolver On Install

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1279,7 +1279,7 @@ disable_resolved_stublistener() {
       # Make a backup of the original /etc/systemd/resolved.conf
       # (This will need to be restored on uninstallation)
       sed -r -i.orig 's/#?DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
-      systemctl restart systemd-resolved
+      systemctl reload-or-restart systemd-resolved
     fi
   fi
 }

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2315,7 +2315,7 @@ main() {
     if (systemctl is-enabled systemd-resolved | grep -c 'enabled' || true); then
       # if resolveconf is running unbind it from port 53
       # Note that this breaks dns functionality on host until dnsmasq/ftl are up and running
-      echo -e "Unbinding resolved from port 53"
+      echo -e "Disabling systemd-resolved DNSStubListener"
       # Make a backup of the original /etc/systemd/resolveconf.d
       # (This will need to be restored on uninstallation)
       sed -i.orig 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1269,16 +1269,16 @@ check_service_active() {
 # Resolved needs to remain in place for installer to download needed files
 # so this change needs to be made after installation is complete, but before resarting dnsmasq/ftl
 disable_resolved_stublistener() {
-  # Check if Systemd-resolved's DNSSTub listener is enabled and active on port 53
+  # Check if Systemd-resolved's DNSStubListener is enabled and active on port 53
   if check_service_active "systemd-resolved"; then
     # Check if DNSStubListener is enabled
-    if ( grep '#DNSStubListener=yes' /etc/systemd/resolved.conf &> /dev/null ); then
+    if ( grep -E '#?DNSStubListener=yes' /etc/systemd/resolved.conf &> /dev/null ); then
       # Disable the DNSStubListener to unbind it from port 53
       # Note that this breaks dns functionality on host until dnsmasq/ftl are up and running
       echo -e "Disabling systemd-resolved DNSStubListener"
       # Make a backup of the original /etc/systemd/resolved.conf
       # (This will need to be restored on uninstallation)
-      sed -i.orig 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
+      sed -r -i.orig 's/#?DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
       systemctl restart systemd-resolved
     fi
   fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1266,8 +1266,6 @@ check_service_active() {
 }
 
 # Systemd-resolved's DNSStubListener and dnsmasq can't share port 53. 
-# Resolved needs to remain in place for installer to download needed files,
-# so this change needs to be made after installation is complete, but before resarting dnsmasq/ftl
 disable_resolved_stublistener() {
   echo -en "  ${INFO} Testing if systemd-resolved is enabled"
   # Check if Systemd-resolved's DNSStubListener is enabled and active on port 53
@@ -2316,8 +2314,11 @@ main() {
     fi
   fi
 
-  echo -e "  ${INFO} Restarting services..."
-  # Start services
+  # Check for and disable systemd-resolved-DNSStubListener before reloading resolved
+  # DNSStubListener needs to remain in place for installer to download needed files,
+  # so this change needs to be made after installation is complete,
+  # but before starting or resarting the dnsmasq or ftl services
+  disable_resolved_stublistener
 
   # If the Web server was installed,
   if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
@@ -2330,8 +2331,8 @@ main() {
     fi
   fi
 
-  # Check for and if necessary disable systemd-resolved-DNSStubListener
-  disable_resolved_stublistener
+  echo -e "  ${INFO} Restarting services..."
+  # Start services
 
   # Enable FTL
   start_service pihole-FTL

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1265,6 +1265,25 @@ check_service_active() {
   fi
 }
 
+# Systemd-resolved's DNSStubListener and dnsmasq can't share port 53. 
+# Resolved needs to remain in place for installer to download needed files
+# so this change needs to be made after installation is complete, but before resarting dnsmasq/ftl
+disable_resolved_stublistener() {
+  # Check if Systemd-resolved's DNSSTub listener is enabled and active on port 53
+  if check_service_active "systemd-resolved"; then
+    # Check if DNSStubListener is enabled
+    if ( grep '#DNSStubListener=yes' /etc/systemd/resolved.conf &> /dev/null ); then
+      # Disable the DNSStubListener to unbind it from port 53
+      # Note that this breaks dns functionality on host until dnsmasq/ftl are up and running
+      echo -e "Disabling systemd-resolved DNSStubListener"
+      # Make a backup of the original /etc/systemd/resolved.conf
+      # (This will need to be restored on uninstallation)
+      sed -i.orig 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
+      systemctl restart systemd-resolved
+    fi
+  fi
+}
+
 update_package_cache() {
   # Running apt-get update/upgrade with minimal output can cause some issues with
   # requiring user input (e.g password for phpmyadmin see #218)
@@ -2304,24 +2323,8 @@ main() {
     fi
   fi
 
-  # resolved and dnsmasq can't share port 53. 
-  # resolved needs to remain in place for installer to download needed files
-  # so this change needs to be made after installation is complete, but before resarting dnsmasq/ftl
-
-  # Check if running ubuntu 18.04 bionic beaver, which ships with resolved active on port 53
-  # (This check may need to be broadened for other systems running resolved?)
-  if ( lsb_release -a | grep 'Ubuntu 18.04' &> /dev/null ); then
-    # Running ubuntu 18.04, so check if resolved is running,
-    if (systemctl is-enabled systemd-resolved | grep -c 'enabled' || true); then
-      # if resolveconf is running unbind it from port 53
-      # Note that this breaks dns functionality on host until dnsmasq/ftl are up and running
-      echo -e "Disabling systemd-resolved DNSStubListener"
-      # Make a backup of the original /etc/systemd/resolveconf.d
-      # (This will need to be restored on uninstallation)
-      sed -i.orig 's/#DNSStubListener=yes/DNSStubListener=no/g' /etc/systemd/resolved.conf
-      systemctl restart systemd-resolved
-    fi
-  fi
+  # Check for and if necessary disable systemd-resolved-DNSStubListener
+  disable_resolved_stublistener
 
   # Enable FTL
   start_service pihole-FTL

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -167,9 +167,8 @@ removeNoPurge() {
 
   # Restore resolved 
   if [[ -e /etc/systemd/resolved.conf.orig ]]; then
-    systemctl disable systemd-resolved
     ${SUDO} cp /etc/systemd/resolved.conf.orig /etc/systemd/resolved.conf
-    systemctl enable systemd-resolved
+    systemctl reload-or-restart systemd-resolved
   fi
 
   # Remove FTL

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -165,6 +165,13 @@ removeNoPurge() {
 	${SUDO} rm -f /etc/sudoers.d/pihole &> /dev/null
   echo -e "  ${TICK} Removed config files"
 
+  # Restore resolved 
+  if [[ -e /etc/systemd/resolved.conf.orig ]]; then
+    systemctl disable systemd-resolved
+    cp /etc/systemd/resolved.conf.orig /etc/systemd/resolved.conf
+    systemctl enable systemd-resolved
+  fi
+
   # Remove FTL
   if command -v pihole-FTL &> /dev/null; then
     echo -ne "  ${INFO} Removing pihole-FTL..."

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -168,7 +168,7 @@ removeNoPurge() {
   # Restore resolved 
   if [[ -e /etc/systemd/resolved.conf.orig ]]; then
     systemctl disable systemd-resolved
-    cp /etc/systemd/resolved.conf.orig /etc/systemd/resolved.conf
+    ${SUDO} cp /etc/systemd/resolved.conf.orig /etc/systemd/resolved.conf
     systemctl enable systemd-resolved
   fi
 


### PR DESCRIPTION
This deals with #2179

**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

**What does this PR aim to accomplish?:**
Allow pi-hole to work under Ubuntu Bionic 18.04

**How does this PR accomplish the above?:**
Stops systemd/resolved from binding to port 53.

**What documentation changes (if any) are needed to support this PR?:**
None


---
