### PR TITLE
Add CloudFlare DNS servers

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -772,6 +772,7 @@ setDNS() {
       DNSWatch ""
       Quad9 ""
       FamilyShield ""
+      CloudFlare ""
       Custom "")
   # In a whiptail dialog, show the options
   DNSchoices=$(whiptail --separate-output --menu "Select Upstream DNS Provider. To use your own, select Custom." ${r} ${c} 7 \
@@ -822,6 +823,11 @@ setDNS() {
       echo "FamilyShield servers"
       PIHOLE_DNS_1="208.67.222.123"
       PIHOLE_DNS_2="208.67.220.123"
+      ;;
+    CloudFlare)
+      echo "CloudFlare servers"
+      PIHOLE_DNS_1="1.1.1.1"
+      PIHOLE_DNS_2="1.0.0.1"
       ;;
     Custom)
       # Until the DNS settings are selected,


### PR DESCRIPTION
Add CloudFlare DNS servers as an extra upstream DNS provider.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [ ] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*

This PR adds the possibility of CloudFlare DNS as an upstream DNS provider when setting up Pi-Hole.


**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

By simply adding the option within the `basic-install.sh` script.


**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*

None.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

