### PR TITLE
Lighttpd service test

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2290,15 +2290,13 @@ main() {
   if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
     enable_service lighttpd
   fi
-
-  if [[ -x "$(command -v systemctl)" ]]; then
-    # Value will either be 1, if true, or 0
-    LIGHTTPD_ENABLED=$(systemctl is-enabled lighttpd | grep -c 'enabled' || true)
-  else
-    # Value will either be 1, if true, or 0
-    LIGHTTPD_ENABLED=$(service lighttpd status | awk '/Loaded:/ {print $0}' | grep -c 'enabled' || true)
+  # Determin if lighttpd is correctly enabled
+  if check_service_active "lighttpd"; then
+      LIGHTTPD_ENABLED=true;
+    else
+      LIGHTTPD_ENABLED=false;
   fi
-
+  
   # Install and log everything to a file
   installPihole | tee -a /proc/$$/fd/3
 
@@ -2327,7 +2325,7 @@ main() {
   # If the Web server was installed,
   if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
 
-    if [[ "${LIGHTTPD_ENABLED}" == "1" ]]; then
+    if [[ "${LIGHTTPD_ENABLED}" == true ]]; then
       start_service lighttpd
       enable_service lighttpd
     else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2290,11 +2290,11 @@ main() {
   if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
     enable_service lighttpd
   fi
-  # Determin if lighttpd is correctly enabled
+  # Determine if lighttpd is correctly enabled
   if check_service_active "lighttpd"; then
-      LIGHTTPD_ENABLED=true;
+      LIGHTTPD_ENABLED=true
     else
-      LIGHTTPD_ENABLED=false;
+      LIGHTTPD_ENABLED=false
   fi
   
   # Install and log everything to a file

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2296,7 +2296,7 @@ main() {
     else
       LIGHTTPD_ENABLED=false
   fi
-  
+
   # Install and log everything to a file
   installPihole | tee -a /proc/$$/fd/3
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Standardize handling of service detection within the install script.

**How does this PR accomplish the above?:**

This hands checking of lighttpd's status over to the existing check_service_active() function. 

Use of existing function:
Avoids duplication of service detection logic.
Uses return code to determine status, thereby avoids parsing text to determine status, and reliance on English language locale to determine activity, (which may also be broken on some systems #2204 )

All other checks of services within the install script are handled by this function.

**What documentation changes (if any) are needed to support this PR?:**

None.

---

I tested this on antiX - (a non-systemd Debian derivative), and the install worked correctly:

![2018-06-02_10 54 30](https://user-images.githubusercontent.com/35944068/40868924-e8f7d6ac-6655-11e8-971c-f7fed175b125.png)



