### PR TITLE
Fix service pihole-FTL status (sysV)

### DIFF
--- a/advanced/pihole-FTL.service
+++ b/advanced/pihole-FTL.service
@@ -69,13 +69,25 @@ stop() {
   echo
 }
 
+# Indicate the service status
+status() {
+  if is_running; then
+    echo "[ ok ] pihole-FTL is running"
+    exit 0
+  else
+    echo "[    ] pihole-FTL is not running"
+    exit 1
+  fi
+}  
+
+
 ### main logic ###
 case "$1" in
   stop)
         stop
         ;;
   status)
-        status pihole-FTL
+        status
         ;;
   start|restart|reload|condrestart)
         stop


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

**What does this PR aim to accomplish?:**

At the moment, on sysV (and other non-systemd) systems, the command service pihole-FTL status returns an error message:
```/etc/init.d/pihole-FTL: line 73: status: command not found```
(Noted on [discourse](https://discourse.pi-hole.net/t/pihole-not-correctly-installing-on-debian-9-4/10017/4), "fixed" in that case by user installing reinstalling systemd).

Confirmed by me on a antiX - a non-systemd Debian derivative.
![2018-06-02_15 22 26](https://user-images.githubusercontent.com/35944068/40871219-f6a3d196-667a-11e8-8c55-53eda3831253.png)

**How does this PR accomplish the above?:**

Adds missing function to pihole-FTL.service, to test if pihole-FTL process is running, and report status when requested (both by return code and text string).

![2018-06-02_15 17 12](https://user-images.githubusercontent.com/35944068/40871232-61b300f6-667b-11e8-93a5-6dcbfc1a6bea.png)

**What documentation changes (if any) are needed to support this PR?:**

None.


---