### PR TITLE
Don't run the installer when doing ftl checkout, instead just run the…

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -166,6 +166,9 @@ checkout() {
     if check_download_exists "$path"; then
         echo "  ${TICK} Branch ${2} exists"
         echo "${2}" > /etc/pihole/ftlbranch
+        FTLinstall "${binary}"
+        start_service pihole-FTL
+        enable_service pihole-FTL
     else
         echo "  ${CROSS} Requested branch \"${2}\" is not available"
         ftlbranches=( $(git ls-remote https://github.com/pi-hole/ftl | grep 'heads' | sed 's/refs\/heads\///;s/ //g' | awk '{print $2}') )
@@ -180,7 +183,7 @@ checkout() {
   fi
 
   # Force updating everything
-  if [[  ! "${1}" == "web"  ]]; then
+  if [[  ! "${1}" == "web" && ! "${1}" == "ftl" ]]; then
     echo -e "  ${INFO} Running installer to upgrade your installation"
     if "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh" --unattended; then
       exit 0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

To prevent the full install script from being run when performing `pihole checkout ftl ...`, and only run the relevant FTL install functions

**How does this PR accomplish the above?:**

By doing what it aims to accomplish. (See diff!)

**What documentation changes (if any) are needed to support this PR?:**

None