### PR TITLE
Man page for pilhole-FTL

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1194,7 +1194,7 @@ installConfigs() {
 }
 
 install_manpage() {
-  # Copy Pi-hole man page and call mandb to update man page database
+  # Copy Pi-hole man pages and call mandb to update man page database
   # Default location for man files for /usr/local/bin is /usr/local/share/man
   # on lightweight systems may not be present, so check before copying.
   echo -en "  ${INFO} Testing man page installation"
@@ -1204,23 +1204,30 @@ install_manpage() {
     return
   elif [[ ! -d "/usr/local/share/man" ]]; then
     # appropriate directory for Pi-hole's man page is not present
-    echo -e "${OVER}  ${INFO} man page not installed"
+    echo -e "${OVER}  ${INFO} man pages not installed"
     return
-  elif [[ ! -d "/usr/local/share/man/man8" ]]; then
+  fi
+  if [[ ! -d "/usr/local/share/man/man8" ]]; then
     # if not present, create man8 directory
     mkdir /usr/local/share/man/man8
   fi
-  # Testing complete, copy the file & update the man db
-  cp ${PI_HOLE_LOCAL_REPO}/pihole.8 /usr/local/share/man/man8/pihole.8
+  if [[ ! -d "/usr/local/share/man/man5" ]]; then
+    # if not present, create man8 directory
+    mkdir /usr/local/share/man/man5
+  fi
+  # Testing complete, copy the files & update the man db
+  cp ${PI_HOLE_LOCAL_REPO}/manpages/pihole.8 /usr/local/share/man/man8/pihole.8
+  cp ${PI_HOLE_LOCAL_REPO}/manpages/pihole-FTL.8 /usr/local/share/man/man8/pihole-FTL.8
+  cp ${PI_HOLE_LOCAL_REPO}/manpages/pihole-FTL.conf.5 /usr/local/share/man/man5/pihole-FTL.conf.5
   if mandb -q &>/dev/null; then
     # Updated successfully
-    echo -e "${OVER}  ${TICK} man page installed and database updated"
+    echo -e "${OVER}  ${TICK} man pages installed and database updated"
     return
   else
     # Something is wrong with the system's man installation, clean up 
-    # our file, (leave everything how we found it).
-    rm /usr/local/share/man/man8/pihole.8
-    echo -e "${OVER}  ${CROSS} man page db not updated, man page not installed"
+    # our files, (leave everything how we found it).
+    rm /usr/local/share/man/man8/pihole.8 /usr/local/share/man/man8/pihole-FTL.8 /usr/local/share/man/man5/pihole-FTL.conf.5
+    echo -e "${OVER}  ${CROSS} man page db not updated, man pages not installed"
   fi
 }
 

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -173,7 +173,7 @@ removeNoPurge() {
 
     # If the pihole manpage exists, then delete and rebuild man-db
     if [[ -f /usr/local/share/man/man8/pihole.8 ]]; then
-        ${SUDO} rm -f /usr/local/share/man/man8/pihole.8
+        ${SUDO} rm -f /usr/local/share/man/man8/pihole.8 /usr/local/share/man/man8/pihole-FTL.8 /usr/local/share/man/man5/pihole-FTL.conf.5
         ${SUDO} mandb -q &>/dev/null
         echo -e "  ${TICK} Removed pihole man page"
     fi

--- a/manpages/pihole-FTL.8
+++ b/manpages/pihole-FTL.8
@@ -92,7 +92,7 @@ Command line arguments
 
 \fB--\fR  (options)
 .br
-    Pass options to internal resolver
+    Pass options to internal dnsmasq resolver
 .br
 .SH "EXAMPLE"
 Command line arguments can be arbitrarily combined, e.g:

--- a/manpages/pihole-FTL.8
+++ b/manpages/pihole-FTL.8
@@ -18,7 +18,11 @@ pihole-FTL - Pi-hole : The Faster-Than-Light (FTL) Engine
 .br
 \fBpihole-FTL -f\fR
 .br
+\fBpihole-FTL -h\fR
+.br
 \fBpihole-FTL dnsmasq-test\fR
+.br
+\fBpihole-FTL --\fR (\fBoptions\fR)
 .br
 
 .SH "DESCRIPTION"
@@ -28,7 +32,7 @@ Pi-hole : The Faster-Than-Light (FTL) Engine is a lightweight, purpose-built dae
 Usage
 .br
 
-\fB\fBservi\fRce pihole-FTL start\fR
+\fBservice pihole-FTL start\fR
 .br
     Start the pihole-FTL daemon
 .br
@@ -80,6 +84,16 @@ Command line arguments
 .br
     Don't start FTL, show help
 .br
+
+\fBdnsmasq-test\fR
+.br
+    Test resolver config file syntax
+.br
+
+\fB--\fR  (options)
+.br
+    Pass options to internal resolver
+.br
 .SH "EXAMPLE"
 Command line arguments can be arbitrarily combined, e.g:
 .br
@@ -91,4 +105,8 @@ Start ftl in foreground with more verbose logging, process everything and shutdo
 .br
 .SH "SEE ALSO"
 \fBpihole\fR(8), \fBpihole-FTL.conf\fR(5)
+.br
+.SH "COLOPHON"
+
+Get sucked into the latest news and community activity by entering Pi-hole's orbit. Information about Pi-hole, and the latest version of the software can be found at https://pi-hole.net
 .br

--- a/manpages/pihole-FTL.8
+++ b/manpages/pihole-FTL.8
@@ -1,0 +1,94 @@
+.TH "Pihole-FTL" "8" "pihole-FTL" "Pi-hole" "June 2018"
+.SH "NAME"
+pihole-FTL - Pi-hole : The Faster-Than-Light (FTL) Engine
+.br
+.SH "SYNOPSIS"
+\fBservice pihole-FTL \fR(\fBstart\fR|\fBstop\fR|\fBrestart\fR)
+.br
+
+\fBpihole-FTL debug\fR
+.br
+\fBpihole-FTL test\fR
+.br
+\fBpihole-FTL -v\fR
+.br
+\fBpihole-FTL -t\fR
+.br
+\fBpihole-FTL -b\fR
+.br
+\fBpihole-FTL -f\fR
+.br
+\fBpihole-FTL dnsmasq-test\fR
+.br
+
+.SH "DESCRIPTION"
+Pi-hole : The Faster-Than-Light (FTL) Engine is a lightweight, purpose-built daemon used to provide statistics needed for the Pi-hole Web Interface, and its API can be easily integrated into your own projects. Although it is an optional component of the Pi-hole ecosystem, it will be installed by default to provide statistics. As the name implies, FTL does its work \fIvery\fR \fIquickly\fR!
+.br
+
+Usage
+.br
+
+\fB\fBservi\fRce pihole-FTL start\fR
+.br
+    Start the pihole-FTL daemon
+.br
+
+\fBservice pihole-FTL stop\fR
+.br
+    Stop the pihole-FTL daemon
+.br
+
+\fBservice pihole-FTL restart\fR
+.br
+    If the pihole-FTP daemon is running, stop and then start, otherwise start.
+.br
+
+Command line arguments
+.br
+
+\fBdebug\fR
+.br
+    Don't go into daemon mode (stay in foreground) + more verbose logging
+.br
+
+\fBtest\fR
+.br
+    Start FTL and process everything, but shut down immediately afterwards
+.br
+
+\fB-v, version\fR
+.br
+    Don't start FTL, show only version
+.br
+
+\fB-t, tag\fR
+.br
+    Don't start FTL, show only git tag
+.br
+
+\fB-b, branch\fR
+.br
+    Don't start FTL, show only git branch FTL was compiled from
+.br
+
+\fB-f, no-daemon\fR
+.br
+    Don't go into background (daemon mode)
+.br
+
+\fB-h, help\fR
+.br
+    Don't start FTL, show help
+.br
+.SH "EXAMPLE"
+Command line arguments can be arbitrarily combined, e.g:
+.br
+
+\fBpihole-FTL debug test\fR
+.br
+
+Start ftl in foreground with more verbose logging, process everything and shutdown immediately
+.br
+.SH "SEE ALSO"
+\fBpihole\fR(8), \fBpihole-FTL.conf\fR(5)
+.br

--- a/manpages/pihole-FTL.conf.5
+++ b/manpages/pihole-FTL.conf.5
@@ -68,6 +68,14 @@ pihole-FTL.conf - FTL's config file
 .br
     Which privacy level is used?
 .br
+    0 - show everything
+.br
+    1 - hide domains
+.br
+    2 - hide domains and clients
+.br
+    3 - paranoia mode (hide everything)
+.br
 
 \fBIGNORE_LOCALHOST=no|yes\fR
 .br

--- a/manpages/pihole-FTL.conf.5
+++ b/manpages/pihole-FTL.conf.5
@@ -1,0 +1,74 @@
+.TH "pihole-FTL.conf" "5" "pihole-FTL.conf" "pihole-FTL.conf" "June 2018"
+.SH "NAME"
+
+pihole-FTL.conf - FTL's config file
+.br
+.SH "DESCRIPTION"
+
+/etc/pihole/pihole-FTL.conf will be read by \fBpihole-FTL(8)\fR on startup.
+.br
+
+SOCKET_LISTENING=localonly|all
+.br
+    Listen only for local socket connections or permit all connections
+.br
+
+QUERY_DISPLAY=yes|no
+.br
+    Display all queries? Set to no to hide query display
+.br
+
+AAAA_QUERY_ANALYSIS=yes|no
+.br
+    Allow FTL to analyze AAAA queries from pihole.log?
+.br
+
+MAXDBDAYS=365
+.br
+    How long should queries be stored in the database?
+.br
+    Setting this to 0 disables the database altogether
+.br
+
+RESOLVE_IPV6=yes|no
+.br
+    Should FTL try to resolve IPv6 addresses to host names?
+.br
+
+RESOLVE_IPV4=yes|no
+.br
+    Should FTL try to resolve IPv4 addresses to host names?
+.br
+
+DBINTERVAL=1.0
+.br
+    How often do we store queries in FTL's database [minutes]?
+.br
+
+DBFILE=/etc/pihole/pihole-FTL.db
+.br
+    Specify path and filename of FTL's SQLite long-term database.
+.br
+    Setting this to DBFILE= disables the database altogether
+.br
+
+MAXLOGAGE=24.0
+.br
+    Up to how many hours of queries should be imported from the database and logs?
+.br
+    Maximum is 744 (31 days)
+.br
+
+For each setting, the option shown first is the default.
+.br
+.SH "SEE ALSO"
+
+\fBpihole\fR(8), \fBpihole-FTL\fR(8)
+.br
+.SH "COLOPHON"
+
+Pi-hole : The Faster-Than-Light (FTL) Engine is a lightweight, purpose-built daemon used to provide statistics needed for the Pi-hole Web Interface, and its API can be easily integrated into your own projects. Although it is an optional component of the Pi-hole ecosystem, it will be installed by default to provide statistics. As the name implies, FTL does its work \fIvery quickly\fR!
+.br
+
+Get sucked into the latest news and community activity by entering Pi-hole's orbit. Information about Pi-hole, and the latest version of the software can be found at https://pi-hole.net
+.br

--- a/manpages/pihole-FTL.conf.5
+++ b/manpages/pihole-FTL.conf.5
@@ -8,55 +8,75 @@ pihole-FTL.conf - FTL's config file
 /etc/pihole/pihole-FTL.conf will be read by \fBpihole-FTL(8)\fR on startup.
 .br
 
-SOCKET_LISTENING=localonly|all
+\fBSOCKET_LISTENING=localonly|all\fR
 .br
     Listen only for local socket connections or permit all connections
 .br
 
-QUERY_DISPLAY=yes|no
+\fBQUERY_DISPLAY=yes|no\fR
 .br
     Display all queries? Set to no to hide query display
 .br
 
-AAAA_QUERY_ANALYSIS=yes|no
+\fBAAAA_QUERY_ANALYSIS=yes|no\fR
 .br
     Allow FTL to analyze AAAA queries from pihole.log?
 .br
 
-MAXDBDAYS=365
-.br
-    How long should queries be stored in the database?
-.br
-    Setting this to 0 disables the database altogether
-.br
-
-RESOLVE_IPV6=yes|no
+\fBRESOLVE_IPV6=yes|no\fR
 .br
     Should FTL try to resolve IPv6 addresses to host names?
 .br
 
-RESOLVE_IPV4=yes|no
+\fBRESOLVE_IPV4=yes|no\fR
 .br
     Should FTL try to resolve IPv4 addresses to host names?
 .br
 
-DBINTERVAL=1.0
+\fBMAXDBDAYS=365\fR
+.br
+    How long should queries be stored in the database?
+.br
+    Setting this to 0 disables the database
+.br
+
+\fBDBINTERVAL=1.0\fR
 .br
     How often do we store queries in FTL's database [minutes]?
 .br
 
-DBFILE=/etc/pihole/pihole-FTL.db
+\fBDBFILE=/etc/pihole/pihole-FTL.db\fR
 .br
     Specify path and filename of FTL's SQLite long-term database.
 .br
     Setting this to DBFILE= disables the database altogether
 .br
 
-MAXLOGAGE=24.0
+\fBMAXLOGAGE=24.0\fR
 .br
     Up to how many hours of queries should be imported from the database and logs?
 .br
     Maximum is 744 (31 days)
+.br
+
+\fBFTLPORT=4711\fR
+.br
+    On which port should FTL be listening?
+.br
+
+\fBPRIVACYLEVEL=0|1|2|3\fR
+.br
+    Which privacy level is used?
+.br
+
+\fBIGNORE_LOCALHOST=no|yes\fR
+.br
+    Should FTL ignore queries coming from the local machine?
+.br
+
+\fBBLOCKINGMODE=IP|IP-AAAA-NODATA|NXDOMAIN|NULL\fR
+.br
+    How should FTL reply to blocked queries?
 .br
 
 For each setting, the option shown first is the default.

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -181,7 +181,7 @@ Available commands and options:
       off noflush       Disable the Pi-hole log at /var/log/pihole.log
 .br
 
-\fB-up, updat\fBe\fR\fR\fBPihole\fR [--check-only]
+\fB-up, updatePihole\fR [--check-only]
 .br
     Update Pi-hole subsystems
 .br
@@ -277,7 +277,7 @@ Some usage examples
 .br
     \fBpihole -b -d noads.example.com\fR  Remove "noads.example.com" from blacklist 
 .br
-    \fB\fBpihole -wild example\fR.com\fR        Add "example" as wildcard - would block ads.example.com, www.example.com etc.
+    \fBpihole -wild example.com\fR        Add "example.com" as wildcard - would block ads.example.com, www.example.com etc.
 .br
 
     Changing the Web Interface password

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -21,13 +21,13 @@ Pi-hole : A black-hole for internet advertisements
 .br
 \fBpihole -c\fR [-j|-r|-e]
 .br
-\fBpihole\fR \fB-d\fR [-a] 
+\fBpihole\fR \fB-d\fR [-a]
 .br
 \fBpihole -f
 .br
 pihole -r
 .br
-pihole -t 
+pihole -t
 .br
 pihole -g\fR
 .br
@@ -84,9 +84,9 @@ Available commands and options:
       --nuke            Removes all entries in a list
 .br
 
-\fB-d, debug\fR [-a]	
+\fB-d, debug\fR [-a]
 .br
-    Start a debugging session 
+    Start a debugging session
 .br
 
       -a                Enable automated debugging
@@ -96,8 +96,7 @@ Available commands and options:
 .br
     Flush the Pi-hole log
 .br
-		
-.br
+
 \fB-r, reconfigure\fR
 .br
     Reconfigure or Repair Pi-hole subsystems
@@ -129,11 +128,10 @@ Available commands and options:
 .br
       -l, privacylevel  <level> Set privacy level (0 = lowest, 3 = highest)
 .br
-		
-.br
+
 \fB-c, chronometer\fR	[options]
 .br
-    Calculates stats and displays to an LCD 
+    Calculates stats and displays to an LCD
 .br
 
     (Chronometer Options):
@@ -145,12 +143,12 @@ Available commands and options:
       -e, --exit        Output stats and exit witout refreshing
 .br
 
-\fB-g, updateGravity\fR	
+\fB-g, updateGravity\fR
 .br
     Update the list of ad-serving domains
 .br
 
-\fB-q, query\fR [option]	
+\fB-q, query\fR [option]
 .br
     Query the adlists for a specified domain
 .br
@@ -164,7 +162,7 @@ Available commands and options:
       -all              Return all query matches within a block list
 .br
 
-\fB-h, --help, help\fR	
+\fB-h, --help, help\fR
 .br
     Show a help dialog
 .br
@@ -178,21 +176,20 @@ Available commands and options:
 .br
       on                Enable the Pi-hole log at /var/log/pihole.log
 .br
-      off 		        Disable and flush the Pi-hole log at /var/log/pihole.log
+      off               Disable and flush the Pi-hole log at /var/log/pihole.log
 .br
       off noflush       Disable the Pi-hole log at /var/log/pihole.log
 .br
-	
+
+\fB-up, updat\fBe\fR\fR\fBPihole\fR [--check-only]
 .br
-\fB-up, updat\fBe\fR\fR\fBPihole\fR [--check-only]	
-.br
-    Update Pi-hole subsystems 
+    Update Pi-hole subsystems
 .br
 
       --check-only      Exit script before update is performed.
 .br
 
-\fB-v, version\fR [repo] [options]	
+\fB-v, version\fR [repo] [options]
 .br
     Show installed versions of Pi-hole, Web Interface &amp; FTL
 .br
@@ -234,8 +231,7 @@ Available commands and options:
 .br
     Disable Pi-hole subsystems, optionally for a set duration
 .br
-		
-.br
+
     (time options):	
 .br
       #s                Disable Pi-hole functionality for # second(s)
@@ -248,7 +244,7 @@ Available commands and options:
     Restart Pi-hole subsystems
 .br
 
-\fBcheckout\fR [repo] [branch]	
+\fBcheckout\fR [repo] [branch]
 .br
     Switch Pi-hole subsystems to a different Github branch
 .br
@@ -281,50 +277,43 @@ Some usage examples
 .br
     \fBpihole -b -d noads.example.com\fR  Remove "noads.example.com" from blacklist 
 .br
-    \fBpihole -wild example.com\fR            Add "example.com" as wildcard - would block ads.example.com, www.example.com etc.
+    \fB\fBpihole -wild example\fR.com\fR        Add "example" as wildcard - would block ads.example.com, www.example.com etc.
 .br
 
-    Changing the web ui password
+    Changing the Web Interface password
 .br
-	
-.br
+
     \fBpihole -a -p ExamplePassword\fR    Change the password to "ExamplePassword"
 .br
 
     Updating lists from internet sources
 .br
-	
-.br
+
     \fBpihole -g\fR                       Update the list of ad-serving domains
 .br
 
     Displaying version information
 .br
-	
-.br
+
     \fBpihole -v -a -c\fR                 Display the current version of AdminLTE
 .br
-	
-.br
+
     Temporarily disabling Pi-hole
 .br
-	
-.br
+
     \fBpihole disable 5m\fR               Disable Pi-hole functionality for five minutes
 .br
-	
-.br
+
     Switching Pi-hole subsystem branches
 .br
-	
-.br
+
     \fBpihole checkout master\fR          Switch to master branch
 .br
     \fBpihole checkout core dev\fR        Switch to core development branch
 .br
 .SH "SEE ALSO"
 
-dnsmasq(8), lighttpd(8)
+\fBlighttpd\fR(8), \fBpihole-FTL\fR(8)
 .br
 .SH "COLOPHON"
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Add conventional linux man page documentation for pihole-FTL.

**How does this PR accomplish the above?:**

Adds 2 additional manpages, for pihole-FTL, and its config file, pihole-FTL.conf
Copies them to appropriate location during install, and deletes them during uninstall.

Man pages located in directory, to not clog up the root directory of the repo.

**What documentation changes (if any) are needed to support this PR?:**

None.

Future changes to the command-line or config file options of pihole-FTL would need to be reflected in the man page files.

---
