### PR TITLE
Fix gravity_ParseFileIntoDomains Awk comment

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -277,9 +277,9 @@ gravity_ParseFileIntoDomains() {
     # Most of the lists downloaded are already in hosts file format but the spacing/formating is not contigious
     # This helps with that and makes it easier to read
     # It also helps with debugging so each stage of the script can be researched more in depth
-    #Awk -F splits on given IFS, we grab the right hand side (chops trailing #coments and /'s to grab the domain only.
-    #Last awk command takes non-commented lines and if they have 2 fields, take the left field (the domain) and leave
-    #+ the right (IP address), otherwise grab the single field.
+    # Awk -F splits on given IFS, we grab the right hand side (chops trailing #coments and /'s to grab the domain only.
+    # Last awk command takes non-commented lines and if they have 2 fields, take the right field (the domain) and leave
+    # the left (IP address), otherwise grab the single field.
 
     < ${source} awk -F '#' '{print $1}' | \
     awk -F '/' '{print $1}' | \


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fix the incorrect parsing comment.

**How does this PR accomplish the above?:**
Flip around the usage of "left" and "right" in the comment.

**What documentation changes (if any) are needed to support this PR?:**
None
