### PR TITLE
Bugfix - Check version of installed php

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -176,8 +176,8 @@ if command -v apt-get &> /dev/null; then
     fi
   else
     # Supported php is installed, its common, cgi & sqlite counterparts are deps
-    phpInsMajor="$(echo $phpInsVer | cut -d\. -f1)"
-    phpInsMinor="$(echo $phpInsVer | cut -d\. -f2)"
+    phpInsMajor="$(echo "$phpInsVersion" | cut -d\. -f1)"
+    phpInsMinor="$(echo "$phpInsVersion" | cut -d\. -f2)"
     phpVer="php$phpInsMajor.phpInsMinor"
   fi
   # We also need the correct version for `php-sqlite` (which differs across distros)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -166,13 +166,13 @@ if command -v apt-get &> /dev/null; then
     echo -e "  ${INFO} Existing PHP installation detected : PHP version $phpInsVersion"
     phpInsMajor="$(echo "$phpInsVersion" | cut -d\. -f1)"
     phpInsMinor="$(echo "$phpInsVersion" | cut -d\. -f2)"
-    # Is installed php version supported? (php 5.4 is EOL)
-    if [ "$(echo "$phpInsMajor.$phpInsMinor < 5.5" | bc )" == 0 ]; then
-      phpInsSupported=true
+    # Is installed php version newer than php5?
+    if [ "$(echo "$phpInsMajor.$phpInsMinor < 7.0" | bc )" == 0 ]; then
+      phpInsNewer=true
     fi
   fi
   # Check if installed php is unsupported version (5.4 is EOL)
-  if [[ "$phpInsSupported" != true ]]; then
+  if [[ "$phpInsNewer" != true ]]; then
     # Prefer the php metapackage if it's there
     if ${PKG_MANAGER} install --dry-run php > /dev/null 2>&1; then
       phpVer="php"
@@ -181,7 +181,7 @@ if command -v apt-get &> /dev/null; then
       phpVer="php5"
     fi
   else
-    # Supported php is installed, its common, cgi & sqlite counterparts are deps
+    # Newer php is installed, its common, cgi & sqlite counterparts are deps
     phpVer="php$phpInsMajor.$phpInsMinor"
   fi
   # We also need the correct version for `php-sqlite` (which differs across distros)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -180,8 +180,6 @@ if command -v apt-get &> /dev/null; then
     phpInsMinor="$(echo $phpInsVer | cut -d\. -f2)"
     phpVer="php$phpInsMajor.phpInsMinor"
   fi
-  
-  fi
   # We also need the correct version for `php-sqlite` (which differs across distros)
   if ${PKG_MANAGER} install --dry-run ${phpVer}-sqlite3 > /dev/null 2>&1; then
     phpSqlite="sqlite3"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -166,12 +166,12 @@ if command -v apt-get &> /dev/null; then
     echo -e "  ${INFO} Existing PHP installation detected : PHP version $phpInsVersion"
     phpInsMajor="$(echo "$phpInsVersion" | cut -d\. -f1)"
     phpInsMinor="$(echo "$phpInsVersion" | cut -d\. -f2)"
-    # Is installed php version newer than php5?
+    # Is installed php version 7.0 or greater
     if [ "$(echo "$phpInsMajor.$phpInsMinor < 7.0" | bc )" == 0 ]; then
       phpInsNewer=true
     fi
   fi
-  # Check if installed php is unsupported version (5.4 is EOL)
+  # Check if installed php is v 7.0, or newer to determine packages to install
   if [[ "$phpInsNewer" != true ]]; then
     # Prefer the php metapackage if it's there
     if ${PKG_MANAGER} install --dry-run php > /dev/null 2>&1; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -166,7 +166,7 @@ if command -v apt-get &> /dev/null; then
     echo -e "  ${INFO} Existing PHP installation detected : PHP version $phpInsVersion"
   fi
   # Check if installed php is supported version (5.4 is EOL)
-  if [[ $phpInsVersion < "5.5" ]]; then
+  if [[ "$phpInsVersion" < "5.5" ]]; then
     # Prefer the php metapackage if it's there
     if ${PKG_MANAGER} install --dry-run php > /dev/null 2>&1; then
       phpVer="php"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -178,7 +178,7 @@ if command -v apt-get &> /dev/null; then
     # Supported php is installed, its common, cgi & sqlite counterparts are deps
     phpInsMajor="$(echo "$phpInsVersion" | cut -d\. -f1)"
     phpInsMinor="$(echo "$phpInsVersion" | cut -d\. -f2)"
-    phpVer="php$phpInsMajor.phpInsMinor"
+    phpVer="php$phpInsMajor.$phpInsMinor"
   fi
   # We also need the correct version for `php-sqlite` (which differs across distros)
   if ${PKG_MANAGER} install --dry-run ${phpVer}-sqlite3 > /dev/null 2>&1; then


### PR DESCRIPTION
Signed-off-by: Rob Gill <rrobgill@protonmail.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Not install an old version of PHP if the system already has a newer version installed. 

#2117 identifies this issue.

Condition is somewhat uncommon as it appears to only happen if updated PHP has been installed, not from default repos. New repo offers packages eg ```php7.0*``` , but system contains no (or outdated) metapackage ```php```.

**How does this PR accomplish the above?:**

During installation, checks current version of php. If a presently supported version (5.5 or greater) is found, then it is used as the basis for installing the php related web dependencies (x-common, x-cli, x-sqlite). 

This is achieved by setting existing variable ```phpVer``` based upon currently installed php version. Only code relating to setting ```phpVer``` is changed, there is no change to installation code.

**What documentation changes (if any) are needed to support this PR?:**

None.

---


