### PR TITLE
Stats can still be generated without logging, no need for this sentence

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -977,7 +977,7 @@ setLogging() {
   local LogChoices
 
   # Ask if the user wants to log queries
-  LogToggleCommand=(whiptail --separate-output --radiolist "Do you want to log queries?\\n (Disabling will render graphs on the Admin page useless):" ${r} ${c} 6)
+  LogToggleCommand=(whiptail --separate-output --radiolist "Do you want to log queries?" ${r} ${c} 6)
   # The default selection is on
   LogChooseOptions=("On (Recommended)" "" on
       Off "" off)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -977,7 +977,7 @@ setLogging() {
   local LogChoices
 
   # Ask if the user wants to log queries
-  LogToggleCommand=(whiptail --separate-output --radiolist "Do you want to log queries?" ${r} ${c} 6)
+  LogToggleCommand=(whiptail --separate-output --radiolist "Do you want to log queries?" "${r}" "${c}" 6)
   # The default selection is on
   LogChooseOptions=("On (Recommended)" "" on
       Off "" off)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
As stats can now be generated without logging, this sentence is no longer valid.


**How does this PR accomplish the above?:**

**What documentation changes (if any) are needed to support this PR?:**