### PR TITLE
remove duplicate declaration in ftlinstall()

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2028,7 +2028,6 @@ FTLinstall() {
 
   local ftlBranch
   local url
-  local ftlBranch
 
   if [[ -f "/etc/pihole/ftlbranch" ]];then
     ftlBranch=$(</etc/pihole/ftlbranch)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Remove duplicate declaration 'local ftlBranch'

https://github.com/pi-hole/pi-hole/blob/6689e00e6a7a7ce8342e73432dd422dc68d0f5b5/automated%20install/basic-install.sh#L2029-L2031

**How does this PR accomplish the above?:**
Deleting the duplicate instance.

**What documentation changes (if any) are needed to support this PR?:**
None.


---