### PR TITLE
Remove error text from message when next whitelist request succeeds

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -329,6 +329,7 @@ setHeader();
           setTimeout(function(){window.location.reload(1);}, 10000);
           $("#bpOutput").removeClass("add");
           $("#bpOutput").addClass("success");
+          $("#bpOutput").html("");
         } else {
           $("#bpOutput").removeClass("add");
           $("#bpOutput").addClass("error");
@@ -338,6 +339,7 @@ setHeader();
       error: function(jqXHR, exception) {
         $("#bpOutput").removeClass("add");
         $("#bpOutput").addClass("exception");
+        $("#bpOutput").html("");
       }
     });
   }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fixes #2230.

**How does this PR accomplish the above?:**
Clean the `html` content of the success/error message in case of a successful response or an unhandled error, so the CSS `::before` and `::after` properties on `#bpOutput` ([here](https://github.com/pi-hole/pi-hole/blob/fbee18e24d56b418e3329a56ae4156dbe8fe5e1f/advanced/blockingpage.css)) are all that shows in those cases.

**What documentation changes (if any) are needed to support this PR?:**
None