### PR TITLE
RFC: breadcrumb on the source list

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -149,10 +149,13 @@ gravity_GetBlocklistUrls() {
 
   # Parse source domains from $sources
   mapfile -t sourceDomains <<< "$(
-    # Logic: Split by folder/port
-    awk -F '[/:]' '{
+    awk '{
       # Remove URL protocol & optional username:password@
       gsub(/(.*:\/\/|.*:.*@)/, "", $0)
+
+      # remove non-alphanums but keep the path as a future breadcrumb
+      gsub(/[^[:alnum:]]/, "_", $0)
+
       if(length($1)>0){print $1}
       else {print "local"}
     }' <<< "$(printf '%s\n' "${sources[@]}")" 2> /dev/null


### PR DESCRIPTION
ignoring the template for a halfway good reason-

This is a quick change to the code **not to be accepted** but to gather comments. If the general idea is sound I'll make modifications to be backwards-compatible and to run through full testing.

Often when I'm trying to figure out why `somesite.com` is blocked I'll see results that are less than optimal. Suppose you have 100 adblock lists and they are all from `raw.githubusercontent.com`. The only way the items are distinguished is by the order they appear in the file, and if you are using the UI they aren't numbered- so if `somesite.com` appears in the 80th list, good luck counting to 80. (obviously, you can use an editor like vim to jump to a line number).

By changing the awk pattern around, we can dump the entire path as our filename. This makes it easy to see that my match comes from `raw.githubusercontent.com/some/bad/file.txt`. I'm probably being excessively conservative when scrubbing the filename- I'm removing `/` but also removing `.`. If this idea is legit we can talk about a better naming scheme.

I'm removing the `-F [:/]` section of awk, as I want to keep the whole URL.

Thoughts? I figured it was easier to commit code than to just open a vague issue.