### PR TITLE
Use regex lists instead of wildcards for blocking

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -138,7 +138,7 @@ AddDomain() {
     bool=true
     domain="${1}"
 
-    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))$(echo domain | sed "s/\./\\\./g")$"
+    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))$(echo "${domain}" | sed "s/\./\\\./g")$"
 
     # Is the domain in the list?
     # Search only for exactly matching lines
@@ -186,7 +186,7 @@ RemoveDomain() {
     [[ -z "${type}" ]] && type="--wildcard-only"
     domain="${1}"
 
-    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))$(echo domain | sed "s/\./\\\./g")$"
+    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))$(echo "${domain}" | sed "s/\./\\\./g")$"
 
     bool=true
     # Is it in the list?

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -222,7 +222,7 @@ Displaylist() {
     verbose=false
     echo -e "Displaying $string:\n"
     count=1
-    while IFS= read -r RD; do
+    while IFS= read -r RD || [ -n "${RD}" ]; do
       echo "  ${count}: ${RD}"
       count=$((count+1))
     done < "${listMain}"

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -138,7 +138,7 @@ AddDomain() {
     bool=true
     domain="${1}"
 
-    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain}$"
+    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))$(echo domain | sed "s/\./\\\./g")$"
 
     # Is the domain in the list?
     # Search only for exactly matching lines
@@ -186,7 +186,7 @@ RemoveDomain() {
     [[ -z "${type}" ]] && type="--wildcard-only"
     domain="${1}"
 
-    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain}$"
+    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))$(echo domain | sed "s/\./\\\./g")$"
 
     bool=true
     # Is it in the list?

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -33,7 +33,7 @@ helpFunc() {
     type="white"
   elif [[ "${listMain}" == "${regexlist}" ]]; then
     param="wild"
-    type="wildcard black"
+    type="regex black"
   else
     param="b"
     type="black"

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -136,6 +136,7 @@ AddDomain() {
   elif [[ "${list}" == "${regexlist}" ]]; then
     [[ -z "${type}" ]] && type="--wildcard-only"
     bool=true
+    domain="${1}"
 
     [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain}$"
 
@@ -145,13 +146,13 @@ AddDomain() {
 
     if [[ "${bool}" == false ]]; then
       if [[ "${verbose}" == true ]]; then
-      echo -e "  ${INFO} Adding ${1} to regex list..."
+      echo -e "  ${INFO} Adding ${domain} to regex list..."
       fi
       reload="restart"
-      echo "$1" >> "${regexlist}"
+      echo "$domain" >> "${regexlist}"
     else
       if [[ "${verbose}" == true ]]; then
-        echo -e "  ${INFO} ${1} already exists in regex list, no need to add!"
+        echo -e "  ${INFO} ${domain} already exists in regex list, no need to add!"
       fi
     fi
   fi
@@ -183,6 +184,8 @@ RemoveDomain() {
     fi
   elif [[ "${list}" == "${regexlist}" ]]; then
     [[ -z "${type}" ]] && type="--wildcard-only"
+    domain="${1}"
+
     [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain}$"
 
     bool=true
@@ -190,14 +193,14 @@ RemoveDomain() {
     grep -Fx "${domain}" "${regexlist}" > /dev/null 2>&1 || bool=false
     if [[ "${bool}" == true ]]; then
       # Remove it from the other one
-      echo -e "  ${INFO} Removing $1 from regex list..."
+      echo -e "  ${INFO} Removing $domain from regex list..."
       local lineNumber
-      lineNumber=$(grep -Fnx "$1" "${list}" | cut -f1 -d:)
+      lineNumber=$(grep -Fnx "$domain" "${list}" | cut -f1 -d:)
       sed -i "${lineNumber}d" "${list}"
       reload=true
     else
       if [[ "${verbose}" == true ]]; then
-        echo -e "  ${INFO} ${1} does not exist in regex list, no need to remove!"
+        echo -e "  ${INFO} ${domain} does not exist in regex list, no need to remove!"
       fi
     fi
   fi

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -69,7 +69,7 @@ HandleOther() {
   # Check validity of domain (don't check for regex entries)
   if [[ "${#domain}" -le 253 ]]; then
     if [[ "${listMain}" == "${regexlist}" ]]; then
-      validDomain=""
+      validDomain="${domain}"
     else
       validDomain=$(grep -P "^((-|_)*[a-z\d]((-|_)*[a-z\d])*(-|_)*)(\.(-|_)*([a-z\d]((-|_)*[a-z\d])*))*$" <<< "${domain}") # Valid chars check
       validDomain=$(grep -P "^[^\.]{1,63}(\.[^\.]{1,63})*$" <<< "${validDomain}") # Length of each label
@@ -185,8 +185,9 @@ RemoveDomain() {
     if [[ "${bool}" == true ]]; then
       # Remove it from the other one
       echo -e "  ${INFO} Removing $1 from regex list..."
-      # /I flag: search case-insensitive
-      sed -i "/${domain}/Id" "${list}"
+      local lineNumber
+      lineNumber=$(grep -Fnx "$1" "${list}" | cut -f1 -d:)
+      sed -i "${lineNumber}d" "${list}"
       reload=true
     else
       if [[ "${verbose}" == true ]]; then

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -133,7 +133,7 @@ AddDomain() {
     bool=true
     # Is the domain in the list?
     # Search only for exactly matching lines
-    grep -E "^${domain}$" "${regexlist}" > /dev/null 2>&1 || bool=false
+    grep -Fx "${domain}" "${regexlist}" > /dev/null 2>&1 || bool=false
 
     if [[ "${bool}" == false ]]; then
       if [[ "${verbose}" == true ]]; then
@@ -177,7 +177,7 @@ RemoveDomain() {
     [[ -z "${type}" ]] && type="--wildcard-only"
     bool=true
     # Is it in the list?
-    grep -E "^${domain}$" "${regexlist}" > /dev/null 2>&1 || bool=false
+    grep -Fx "${domain}" "${regexlist}" > /dev/null 2>&1 || bool=false
     if [[ "${bool}" == true ]]; then
       # Remove it from the other one
       echo -e "  ${INFO} Removing $1 from regex list..."

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -245,8 +245,8 @@ for var in "$@"; do
   case "${var}" in
     "-w" | "whitelist"   ) listMain="${whitelist}"; listAlt="${blacklist}";;
     "-b" | "blacklist"   ) listMain="${blacklist}"; listAlt="${whitelist}";;
-    "-wild" | "wildcard" ) listMain="${regexlist}"; wildcard=true;;
-    "-regex" | "regex"   ) listMain="${regexlist}";;
+    "--wild" | "wildcard" ) listMain="${regexlist}"; wildcard=true;;
+    "--regex" | "regex"   ) listMain="${regexlist}";;
     "-nr"| "--noreload"  ) reload=false;;
     "-d" | "--delmode"   ) addmode=false;;
     "-q" | "--quiet"     ) verbose=false;;

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -138,7 +138,7 @@ AddDomain() {
     bool=true
     domain="${1}"
 
-    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))$(echo "${domain}" | sed "s/\./\\\./g")$"
+    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain//\\./\\\.}$"
 
     # Is the domain in the list?
     # Search only for exactly matching lines
@@ -186,7 +186,7 @@ RemoveDomain() {
     [[ -z "${type}" ]] && type="--wildcard-only"
     domain="${1}"
 
-    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))$(echo "${domain}" | sed "s/\./\\\./g")$"
+    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain//\\./\\\.}$"
 
     bool=true
     # Is it in the list?

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -138,7 +138,7 @@ AddDomain() {
     bool=true
     domain="${1}"
 
-    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain//\\./\\\.}$"
+    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain//\./\\.}$"
 
     # Is the domain in the list?
     # Search only for exactly matching lines
@@ -186,7 +186,7 @@ RemoveDomain() {
     [[ -z "${type}" ]] && type="--wildcard-only"
     domain="${1}"
 
-    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain//\\./\\\.}$"
+    [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain//\./\\.}$"
 
     bool=true
     # Is it in the list?

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -71,8 +71,8 @@ HandleOther() {
     if [[ "${listMain}" == "${regexlist}" ]]; then
       validDomain="${domain}"
     else
-      validDomain=$(grep -P "^((-|_)*[a-z\d]((-|_)*[a-z\d])*(-|_)*)(\.(-|_)*([a-z\d]((-|_)*[a-z\d])*))*$" <<< "${domain}") # Valid chars check
-      validDomain=$(grep -P "^[^\.]{1,63}(\.[^\.]{1,63})*$" <<< "${validDomain}") # Length of each label
+      validDomain=$(grep -P "^((-|_)*[a-z\\d]((-|_)*[a-z\\d])*(-|_)*)(\\.(-|_)*([a-z\\d]((-|_)*[a-z\\d])*))*$" <<< "${domain}") # Valid chars check
+      validDomain=$(grep -P "^[^\\.]{1,63}(\\.[^\\.]{1,63})*$" <<< "${validDomain}") # Length of each label
     fi
   fi
 

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -66,10 +66,14 @@ HandleOther() {
   # Convert to lowercase
   domain="${1,,}"
 
-  # Check validity of domain
+  # Check validity of domain (don't check for regex entries)
   if [[ "${#domain}" -le 253 ]]; then
-    validDomain=$(grep -P "^((-|_)*[a-z\d]((-|_)*[a-z\d])*(-|_)*)(\.(-|_)*([a-z\d]((-|_)*[a-z\d])*))*$" <<< "${domain}") # Valid chars check
-    validDomain=$(grep -P "^[^\.]{1,63}(\.[^\.]{1,63})*$" <<< "${validDomain}") # Length of each label
+    if [[ "${listMain}" == "${regexlist}" ]]; then
+      validDomain=""
+    else
+      validDomain=$(grep -P "^((-|_)*[a-z\d]((-|_)*[a-z\d])*(-|_)*)(\.(-|_)*([a-z\d]((-|_)*[a-z\d])*))*$" <<< "${domain}") # Valid chars check
+      validDomain=$(grep -P "^[^\.]{1,63}(\.[^\.]{1,63})*$" <<< "${validDomain}") # Length of each label
+    fi
   fi
 
   if [[ -n "${validDomain}" ]]; then

--- a/advanced/Scripts/wildcard_regex_converter.sh
+++ b/advanced/Scripts/wildcard_regex_converter.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+wildcardFile="/etc/dnsmasq.d/03-pihole-wildcard.conf"
+
+convert_wildcard_to_regex() {
+  if [ ! -f "${wildcardFile}" ]; then
+    return
+  fi
+  local addrlines domains uniquedomains
+  # Obtain wildcard domains from old file
+  addrlines="$(grep -oE "/.*/" ${wildcardFile})"
+  # Strip "/" from domain names
+  domains="$(sed 's/\///g;' <<< "${addrlines}")"
+  # Remove repeated domains (may have been inserted two times due to A and AAAA blocking)
+  uniquedomains="$(uniq <<< "${domains}")"
+  # Automatically generate regex filters and remove old wildcards file
+  awk '{print "(^)|(\\.)"$0"$"}' <<< "${uniquedomains}" >> "${regexFile}" && rm "${wildcardFile}"
+}

--- a/advanced/Scripts/wildcard_regex_converter.sh
+++ b/advanced/Scripts/wildcard_regex_converter.sh
@@ -19,10 +19,10 @@ convert_wildcard_to_regex() {
   local addrlines domains uniquedomains
   # Obtain wildcard domains from old file
   addrlines="$(grep -oE "/.*/" ${wildcardFile})"
-  # Strip "/" from domain names
-  domains="$(sed 's/\///g;' <<< "${addrlines}")"
+  # Strip "/" from domain names and convert "." to regex-compatible "\."
+  domains="$(sed 's/\///g;s/\./\\./g' <<< "${addrlines}")"
   # Remove repeated domains (may have been inserted two times due to A and AAAA blocking)
   uniquedomains="$(uniq <<< "${domains}")"
   # Automatically generate regex filters and remove old wildcards file
-  awk '{print "(^)|(\\.)"$0"$"}' <<< "${uniquedomains}" >> "${regexFile:?}" && rm "${wildcardFile}"
+  awk '{print "((^)|(\\.))"$0"$"}' <<< "${uniquedomains}" >> "${regexFile:?}" && rm "${wildcardFile}"
 }

--- a/advanced/Scripts/wildcard_regex_converter.sh
+++ b/advanced/Scripts/wildcard_regex_converter.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+# Network-wide ad blocking via your own hardware.
+#
+# Provides an automated migration subroutine to convert Pi-hole v3.x wildcard domains to Pi-hole v4.x regex filters
+#
+# This file is copyright under the latest version of the EUPL.
+# Please see LICENSE file for your rights under this license.
+
+# regexFile set in gravity.sh
 
 wildcardFile="/etc/dnsmasq.d/03-pihole-wildcard.conf"
 

--- a/advanced/Scripts/wildcard_regex_converter.sh
+++ b/advanced/Scripts/wildcard_regex_converter.sh
@@ -24,5 +24,5 @@ convert_wildcard_to_regex() {
   # Remove repeated domains (may have been inserted two times due to A and AAAA blocking)
   uniquedomains="$(uniq <<< "${domains}")"
   # Automatically generate regex filters and remove old wildcards file
-  awk '{print "(^)|(\\.)"$0"$"}' <<< "${uniquedomains}" >> "${regexFile}" && rm "${wildcardFile}"
+  awk '{print "(^)|(\\.)"$0"$"}' <<< "${uniquedomains}" >> "${regexFile:?}" && rm "${wildcardFile}"
 }

--- a/gravity.sh
+++ b/gravity.sh
@@ -644,6 +644,11 @@ if [[ "${skipDownload}" == false ]] || [[ "${listType}" == "whitelist" ]]; then
   gravity_Whitelist
 fi
 
+# Set proper permissions on the regex file
+touch "${regexFile}"
+chown pihole:www-data "${regexFile}"
+chmod 664 "${regexFile}"
+
 convert_wildcard_to_regex
 gravity_ShowBlockCount
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -465,7 +465,7 @@ gravity_ShowBlockCount() {
   fi
 
   if [[ -f "${regexFile}" ]]; then
-    num=$(grep -c "^" "${regexFile}")
+    num=$(grep -c "^(?!#)" "${regexFile}")
     echo -e "  ${INFO} Number of regex filters: ${num}"
   fi
 }

--- a/gravity.sh
+++ b/gravity.sh
@@ -15,6 +15,8 @@ export LC_ALL=C
 
 coltable="/opt/pihole/COL_TABLE"
 source "${coltable}"
+regexconverter="/opt/pihole/wildcard_regex_converter.sh"
+source "${regexconverter}"
 
 basename="pihole"
 PIHOLE_COMMAND="/usr/local/bin/${basename}"
@@ -26,7 +28,7 @@ adListDefault="${piholeDir}/adlists.default"
 
 whitelistFile="${piholeDir}/whitelist.txt"
 blacklistFile="${piholeDir}/blacklist.txt"
-wildcardFile="/etc/dnsmasq.d/03-pihole-wildcard.conf"
+regexFile="${piholeDir}/regex.list"
 
 adList="${piholeDir}/gravity.list"
 blackList="${piholeDir}/black.list"
@@ -453,7 +455,7 @@ gravity_Whitelist() {
   echo -e "${OVER}  ${INFO} ${str}"
 }
 
-# Output count of blacklisted domains and wildcards
+# Output count of blacklisted domains and regex filters
 gravity_ShowBlockCount() {
   local num
 
@@ -462,13 +464,9 @@ gravity_ShowBlockCount() {
     echo -e "  ${INFO} Number of blacklisted domains: ${num}"
   fi
 
-  if [[ -f "${wildcardFile}" ]]; then
-    num=$(grep -c "^" "${wildcardFile}")
-    # If IPv4 and IPv6 is used, divide total wildcard count by 2
-    if [[ -n "${IPV4_ADDRESS}" ]] && [[ -n "${IPV6_ADDRESS}" ]];then
-      num=$(( num/2 ))
-    fi
-    echo -e "  ${INFO} Number of wildcard blocked domains: ${num}"
+  if [[ -f "${regexFile}" ]]; then
+    num=$(grep -c "^" "${regexFile}")
+    echo -e "  ${INFO} Number of regex filters: ${num}"
   fi
 }
 
@@ -646,6 +644,7 @@ if [[ "${skipDownload}" == false ]] || [[ "${listType}" == "whitelist" ]]; then
   gravity_Whitelist
 fi
 
+convert_wildcard_to_regex
 gravity_ShowBlockCount
 
 # Perform when downloading blocklists, or modifying the white/blacklist (not wildcards)

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -5,7 +5,7 @@ Pi-hole : A black-hole for internet advertisements
 .br
 .SH "SYNOPSIS"
 
-\fBpihole\fR (\fB-w\fR|\fB-b\fR|\fB-wild\fR) [options] domain(s)
+\fBpihole\fR (\fB-w\fR|\fB-b\fR|\fB-wild\fR|\fB-regex\fR) [options] domain(s)
 .br
 \fBpihole -a\fR \fB-p\fR password
 .br
@@ -68,7 +68,12 @@ Available commands and options:
 
 \fB-wild, wildcard\fR [options] [<domain1> <domain2 ...>]
 .br
-    Add or removes specified regex pattern to the regex blacklist
+    Add or removes specified domain to the wildcard blacklist
+.br
+
+\fB-regex, regex\fR [options] [<regex1> <regex2 ...>]
+.br
+    Add or removes specified regex filter to the regex blacklist
 .br
 
     (Whitelist/Blacklist manipulation options):
@@ -273,11 +278,15 @@ Some usage examples
     Whitelist/blacklist manipulation
 .br
 
-    \fBpihole -w iloveads.example.com\fR  Add "iloveads.example.com" to whitelist
+    \fBpihole -w iloveads.example.com\fR       Add "iloveads.example.com" to whitelist
 .br
-    \fBpihole -b -d noads.example.com\fR  Remove "noads.example.com" from blacklist
+    \fBpihole -b -d noads.example.com\fR       Remove "noads.example.com" from blacklist
 .br
-    \fBpihole -wild ^example.*$\fR        Add "^example.*$" as a regex pattern - would block all domains starting with "example"
+    \fBpihole -wild "^example.*$"\fR           Add "^example.*$" as a regex pattern - would
+    block all domains starting with "example"
+.br
+    \fBpihole -regex "ad.*\.example\.com$"\fR  Add "ad.*\.example\.com$" to the regex
+    blacklist - would block all subdomains of example.com which start with "ad"
 .br
 
     Changing the Web Interface password

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -68,7 +68,7 @@ Available commands and options:
 
 \fB-wild, wildcard\fR [options] [<domain1> <domain2 ...>]
 .br
-    Add or removes specified domain, and all subdomains to the blacklist
+    Add or removes specified regex pattern to the regex blacklist
 .br
 
     (Whitelist/Blacklist manipulation options):
@@ -167,9 +167,9 @@ Available commands and options:
     Show a help dialog
 .br
 
-\fB-l, logging\fR [on|off|off noflush]	
+\fB-l, logging\fR [on|off|off noflush]
 .br
-    Specify whether the Pi-hole log should be used 
+    Specify whether the Pi-hole log should be used
 .br
 
 	(Logging options):
@@ -193,7 +193,7 @@ Available commands and options:
 .br
     Show installed versions of Pi-hole, Web Interface &amp; FTL
 .br
- 
+
 .br
     (repo options):
 .br
@@ -232,7 +232,7 @@ Available commands and options:
     Disable Pi-hole subsystems, optionally for a set duration
 .br
 
-    (time options):	
+    (time options):
 .br
       #s                Disable Pi-hole functionality for # second(s)
 .br
@@ -275,9 +275,9 @@ Some usage examples
 
     \fBpihole -w iloveads.example.com\fR  Add "iloveads.example.com" to whitelist
 .br
-    \fBpihole -b -d noads.example.com\fR  Remove "noads.example.com" from blacklist 
+    \fBpihole -b -d noads.example.com\fR  Remove "noads.example.com" from blacklist
 .br
-    \fBpihole -wild example.com\fR        Add "example.com" as wildcard - would block ads.example.com, www.example.com etc.
+    \fBpihole -wild ^example.*$\fR        Add "^example.*$" as a regex pattern - would block all domains starting with "example"
 .br
 
     Changing the Web Interface password

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -5,7 +5,7 @@ Pi-hole : A black-hole for internet advertisements
 .br
 .SH "SYNOPSIS"
 
-\fBpihole\fR (\fB-w\fR|\fB-b\fR|\fB-wild\fR|\fB-regex\fR) [options] domain(s)
+\fBpihole\fR (\fB-w\fR|\fB-b\fR|\fB--wild\fR|\fB--regex\fR) [options] domain(s)
 .br
 \fBpihole -a\fR \fB-p\fR password
 .br
@@ -66,12 +66,12 @@ Available commands and options:
     Adds or removes specified domain or domains to the blacklist
 .br
 
-\fB-wild, wildcard\fR [options] [<domain1> <domain2 ...>]
+\fB--wild, wildcard\fR [options] [<domain1> <domain2 ...>]
 .br
     Add or removes specified domain to the wildcard blacklist
 .br
 
-\fB-regex, regex\fR [options] [<regex1> <regex2 ...>]
+\fB--regex, regex\fR [options] [<regex1> <regex2 ...>]
 .br
     Add or removes specified regex filter to the regex blacklist
 .br
@@ -282,10 +282,10 @@ Some usage examples
 .br
     \fBpihole -b -d noads.example.com\fR       Remove "noads.example.com" from blacklist
 .br
-    \fBpihole -wild example.com\fR             Add example.com as a wildcard - would
+    \fBpihole --wild example.com\fR             Add example.com as a wildcard - would
     block all subdomains of example.com, including example.com itself.
 .br
-    \fBpihole -regex "ad.*\.example\.com$"\fR  Add "ad.*\.example\.com$" to the regex
+    \fBpihole --regex "ad.*\.example\.com$"\fR  Add "ad.*\.example\.com$" to the regex
     blacklist - would block all subdomains of example.com which start with "ad"
 .br
 

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -282,8 +282,8 @@ Some usage examples
 .br
     \fBpihole -b -d noads.example.com\fR       Remove "noads.example.com" from blacklist
 .br
-    \fBpihole -wild "^example.*$"\fR           Add "^example.*$" as a regex pattern - would
-    block all domains starting with "example"
+    \fBpihole -wild example.com\fR             Add example.com as a wildcard - would
+    block all subdomains of example.com, including example.com itself.
 .br
     \fBpihole -regex "ad.*\.example\.com$"\fR  Add "ad.*\.example\.com$" to the regex
     blacklist - would block all subdomains of example.com which start with "ad"

--- a/pihole
+++ b/pihole
@@ -393,8 +393,8 @@ Add '-h' after specific commands for more information on usage
 Whitelist/Blacklist Options:
   -w, whitelist       Whitelist domain(s)
   -b, blacklist       Blacklist domain(s)
-  -wild, wildcard     Wildcard blacklist domain(s)
-  -regex, regex       Regex blacklist domains(s)
+  --wild, wildcard     Wildcard blacklist domain(s)
+  --regex, regex       Regex blacklist domains(s)
                         Add '-h' for more info on whitelist/blacklist usage
 
 Debugging Options:
@@ -438,8 +438,8 @@ fi
 case "${1}" in
   "-w" | "whitelist"            ) listFunc "$@";;
   "-b" | "blacklist"            ) listFunc "$@";;
-  "-wild" | "wildcard"          ) listFunc "$@";;
-  "-regex" | "regex"            ) listFunc "$@";;
+  "--wild" | "wildcard"          ) listFunc "$@";;
+  "--regex" | "regex"            ) listFunc "$@";;
   "-d" | "debug"                ) debugFunc "$@";;
   "-f" | "flush"                ) flushFunc "$@";;
   "-up" | "updatePihole"        ) updatePiholeFunc "$@";;

--- a/pihole
+++ b/pihole
@@ -33,17 +33,7 @@ webpageFunc() {
   exit 0
 }
 
-whitelistFunc() {
- "${PI_HOLE_SCRIPT_DIR}"/list.sh "$@"
-  exit 0
-}
-
-blacklistFunc() {
-  "${PI_HOLE_SCRIPT_DIR}"/list.sh "$@"
-  exit 0
-}
-
-wildcardFunc() {
+listFunc() {
   "${PI_HOLE_SCRIPT_DIR}"/list.sh "$@"
   exit 0
 }
@@ -403,7 +393,8 @@ Add '-h' after specific commands for more information on usage
 Whitelist/Blacklist Options:
   -w, whitelist       Whitelist domain(s)
   -b, blacklist       Blacklist domain(s)
-  -wild, wildcard     Regex blacklist domain(s)
+  -wild, wildcard     Wildcard blacklist domain(s)
+  -regex, regex       Regex blacklist domains(s)
                         Add '-h' for more info on whitelist/blacklist usage
 
 Debugging Options:
@@ -445,9 +436,10 @@ fi
 
 # Handle redirecting to specific functions based on arguments
 case "${1}" in
-  "-w" | "whitelist"            ) whitelistFunc "$@";;
-  "-b" | "blacklist"            ) blacklistFunc "$@";;
-  "-wild" | "wildcard"          ) wildcardFunc "$@";;
+  "-w" | "whitelist"            ) listFunc "$@";;
+  "-b" | "blacklist"            ) listFunc "$@";;
+  "-wild" | "wildcard"          ) listFunc "$@";;
+  "-regex" | "regex"            ) listFunc "$@";;
   "-d" | "debug"                ) debugFunc "$@";;
   "-f" | "flush"                ) flushFunc "$@";;
   "-up" | "updatePihole"        ) updatePiholeFunc "$@";;

--- a/pihole
+++ b/pihole
@@ -599,7 +599,7 @@ Add '-h' after specific commands for more information on usage
 Whitelist/Blacklist Options:
   -w, whitelist       Whitelist domain(s)
   -b, blacklist       Blacklist domain(s)
-  -wild, wildcard     Blacklist domain(s), and all its subdomains
+  -wild, wildcard     Regex blacklist domain(s)
                         Add '-h' for more info on whitelist/blacklist usage
 
 Debugging Options:


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Change the CLI to support wildcard blocking through *FTL*DNS's regex filters. This is much more flexible than what we used before (defining zones in a `dnsmasq` config file) and replaces this method.

**How does this PR accomplish the above?:**

Use regex filters instead of building a `dnsmasq` config file.

**What documentation changes (if any) are needed to support this PR?:**

Help and man pages.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.