### PR TITLE
Update debug script for simple list format

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -780,7 +780,8 @@ dig_at() {
   # Find a random blocked url that has not been whitelisted.
   # This helps emulate queries to different domains that a user might query
   # It will also give extra assurance that Pi-hole is correctly resolving and blocking domains
-  local random_url=$(shuf -n 1 "${PIHOLE_BLOCKLIST_FILE}")
+  local random_url
+  random_url=$(shuf -n 1 "${PIHOLE_BLOCKLIST_FILE}")
 
   # First, do a dig on localhost to see if Pi-hole can use itself to block a domain
   if local_dig=$(dig +tries=1 +time=2 -"${protocol}" "${random_url}" @${local_address} +short "${record_type}"); then

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -780,7 +780,7 @@ dig_at() {
   # Find a random blocked url that has not been whitelisted.
   # This helps emulate queries to different domains that a user might query
   # It will also give extra assurance that Pi-hole is correctly resolving and blocking domains
-  local random_url=$(shuf -n 1 "${PIHOLE_BLOCKLIST_FILE}" | awk -F ' ' '{ print $2 }')
+  local random_url=$(shuf -n 1 "${PIHOLE_BLOCKLIST_FILE}")
 
   # First, do a dig on localhost to see if Pi-hole can use itself to block a domain
   if local_dig=$(dig +tries=1 +time=2 -"${protocol}" "${random_url}" @${local_address} +short "${record_type}"); then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fixes trying to test the resolver with an empty string as the domain:
```
*** [ DIAGNOSING ]: Name resolution (IPv4) using a random blocked domain and a known ad-serving domain
[✗] Failed to resolve  via localhost (127.0.0.1)
[✗] Failed to resolve  via Pi-hole (192.168.0.2)
[✓] doubleclick.com is 123.123.123.123 via a remote, public DNS server (8.8.8.8)
```

**How does this PR accomplish the above?:**
Gravity is now just a list of domains, not IP addresses and domains separated by a space, so instead of parsing the random line the script finds, the debug script just uses the line as the domain.

**What documentation changes (if any) are needed to support this PR?:**
None