### PR TITLE
Added setcap ability check 

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -142,13 +142,11 @@ show_ascii_berry() {
 setcap_check(){
   # print info regarding probing file capabilities
   echo -e "  ${INFO} Testing for setting file capability in /usr/bin/"
-  # check for setcap error
   # create test file
   ${SUDO} touch /usr/bin/pihole.setcap.test
   # set the file with the correct capabilities and awk possible failure
   setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1 {print $1}')"
-  # check status of test file
-  # if returned response is empty, the command succeded.
+  # check status of test file if returned response is empty, the command succeded.
   if [ -z "$setcap_status" ]; then
     echo -e "  ${TICK} Setting capabilities in /usr/bin/ is supported by your system."
     # removing test file

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -149,7 +149,7 @@ setcap_check(){
   if [ -z "$setcap_status" ]; then
     echo -e "  ${TICK} Setting capabilities in /usr/bin/ is supported by your system."
     # removing test file
-    ${SUDO} rm -rf /usr/bin/pihole.setcap.test
+    ${SUDO} rm -f /usr/bin/pihole.setcap.test
   # if command has returned Failed, display error message and exit
   elif [ "$setcap_status" = "Failed" ]; then
     echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
@@ -157,7 +157,7 @@ setcap_check(){
       in order to get help related to this issue."
     echo -e "  ${INFO} Installation aborted."
     # removing test file
-    ${SUDO} rm -rf /usr/bin/pihole.setcap.test
+    ${SUDO} rm -f /usr/bin/pihole.setcap.test
     # exit the installer
     exit 0
   fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -139,18 +139,18 @@ show_ascii_berry() {
 
 # Compatibility
 setcap_check(){
-  # print info regarding probing file capabilities
+  # Print info regarding probing file capabilities
   echo -e "  ${INFO} Testing for setting file capability in /usr/bin/"
-  # create test file
+  # Create test file
   ${SUDO} touch /usr/bin/pihole.setcap.test
-  # set the file with the correct capabilities and awk possible failure
+  # Set the file with the correct capabilities and awk possible failure
   setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1')"
-  # check status of test file if returned response is empty, the command succeded.
+  # Check status of test file if returned response is empty, the command succeded.
   if [ -z "$setcap_status" ]; then
     echo -e "  ${TICK} Setting capabilities in /usr/bin/ is supported by your system."
-    # removing test file
+    # Removing test file
     ${SUDO} rm -f /usr/bin/pihole.setcap.test
-  # if command has returned Failed, display error message and exit
+  # If command has returned Failed, display error message and exit
   elif [[ $setcap_status = *"Failed"* ]]; then
     echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
@@ -159,11 +159,12 @@ setcap_check(){
       $setcap_status
       ${COL_NC} failed"
     echo -e "  ${INFO} Installation aborted."
-    # removing test file
+    # Removing test file
     ${SUDO} rm -f /usr/bin/pihole.setcap.test
-    # exit the installer
+    # Exit the installer
     exit 0
   else
+    # For any other setcap error, display info and error message, then exit.
     echo -e "  ${CROSS} ${COL_LIGHT_RED}An error occured while trying to set capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
       in order to get help related to this issue, and reference the following message:
@@ -171,7 +172,7 @@ setcap_check(){
       $setcap_status
       ${COL_NC} error"
     echo -e "  ${INFO} Installation aborted."
-    # exit the installer
+    # Exit the installer
     exit 0
   fi
 }

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -160,6 +160,13 @@ setcap_check(){
     ${SUDO} rm -f /usr/bin/pihole.setcap.test
     # exit the installer
     exit 0
+  else
+    echo -e "  ${CROSS} ${COL_LIGHT_RED}An error occured while trying to set capabilities in /usr/bin/${COL_NC}
+      Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
+      in order to get help related to this issue."
+    echo -e "  ${INFO} Installation aborted."
+    # exit the installer
+    exit 0
   fi
 }
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -214,9 +214,9 @@ if command -v apt-get &> /dev/null; then
   fi
   # Since our install script is so large, we need several other programs to successfully get a machine provisioned
   # These programs are stored in an array so they can be looped through later
-  INSTALLER_DEPS=(apt-utils dialog debconf dhcpcd5 git ${iproute_pkg} whiptail)
+  INSTALLER_DEPS=(apt-utils dialog debconf dhcpcd5 libcap2-bin git ${iproute_pkg} whiptail)
   # Pi-hole itself has several dependencies that also need to be installed
-  PIHOLE_DEPS=(bc cron curl dnsutils iputils-ping lsof netcat psmisc sudo unzip wget idn2 sqlite3 libcap2-bin dns-root-data resolvconf)
+  PIHOLE_DEPS=(bc cron curl dnsutils iputils-ping lsof netcat psmisc sudo unzip wget idn2 sqlite3 dns-root-data resolvconf)
   # The Web dashboard has some that also need to be installed
   # It's useful to separate the two since our repos are also setup as "Core" code and "Web" code
   PIHOLE_WEB_DEPS=(lighttpd ${phpVer}-common ${phpVer}-cgi ${phpVer}-${phpSqlite})
@@ -2314,7 +2314,6 @@ main() {
     echo -e "  ${TICK} ${str}"
     # Show the Pi-hole logo so people know it's genuine since the logo and name are trademarked
     show_ascii_berry
-    setcap_check
     make_temporary_log
   # Otherwise,
   else
@@ -2375,6 +2374,9 @@ main() {
 
   # Install packages used by this installation script
   install_dependent_packages INSTALLER_DEPS[@]
+
+  # Check for setcap ability
+  setcap_check
 
    # Check if SELinux is Enforcing
   checkSelinux

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -138,30 +138,29 @@ show_ascii_berry() {
 }
 
 # Compatibility
-
 setcap_check(){
-# print info regarding probing file capabilities
-echo -e "  ${INFO} Testing for setting file capability in /usr/bin/"
-# create test file
-${SUDO} touch /usr/bin/pihole.setcap.test
-# set the file with the correct capabilities and awk possible failure
-setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1 {print $1}')"
-# check status of test file if returned response is empty, the command succeded.
-if [ -z "$setcap_status" ]; then
-  echo -e "  ${TICK} Setting capabilities in /usr/bin/ is supported by your system."
-  # removing test file
-  ${SUDO} rm -rf /usr/bin/pihole.setcap.test
-# if command has returned Failed, display error message and exit
-elif [ "$setcap_status" = "Failed" ]; then
-  echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
+  # print info regarding probing file capabilities
+  echo -e "  ${INFO} Testing for setting file capability in /usr/bin/"
+  # create test file
+  ${SUDO} touch /usr/bin/pihole.setcap.test
+  # set the file with the correct capabilities and awk possible failure
+  setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1 {print $1}')"
+  # check status of test file if returned response is empty, the command succeded.
+  if [ -z "$setcap_status" ]; then
+    echo -e "  ${TICK} Setting capabilities in /usr/bin/ is supported by your system."
+    # removing test file
+    ${SUDO} rm -rf /usr/bin/pihole.setcap.test
+  # if command has returned Failed, display error message and exit
+  elif [ "$setcap_status" = "Failed" ]; then
+    echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
       in order to get help related to this issue."
-  echo -e "  ${INFO} Installation aborted."
-  # removing test file
-  ${SUDO} rm -rf /usr/bin/pihole.setcap.test
-  # exit the installer
-  exit 0
-fi
+    echo -e "  ${INFO} Installation aborted."
+    # removing test file
+    ${SUDO} rm -rf /usr/bin/pihole.setcap.test
+    # exit the installer
+    exit 0
+  fi
 }
 
 distro_check() {

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -154,7 +154,7 @@ setcap_check(){
   elif [[ $setcap_status = *"Failed"* ]]; then
     echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
-      in order to get help related to this issue and reference the following message:
+      in order to get help related to this issue, and reference the following message:
       ${COL_LIGHT_RED}
       $setcap_status
       ${COL_NC} failed"
@@ -166,7 +166,7 @@ setcap_check(){
   else
     echo -e "  ${CROSS} ${COL_LIGHT_RED}An error occured while trying to set capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
-      in order to get help related to this issue and reference the following message:
+      in order to get help related to this issue, and reference the following message:
       ${COL_LIGHT_RED}
       $setcap_status
       ${COL_NC} error"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -155,9 +155,10 @@ setcap_check(){
     ${SUDO} rm -rf /usr/bin/pihole.setcap.test
   # if command has returned Failed, display error message and exit
   elif [ "$setcap_status" = "Failed" ]; then
-    echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system doesn't support setting capabilities in /usr/bin/${COL_NC}
+    echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
       in order to get help related to this issue."
+    echo -e "  ${INFO} Installation aborted."
     # removing test file
     ${SUDO} rm -rf /usr/bin/pihole.setcap.test
   # exit the installer

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -144,7 +144,7 @@ setcap_check(){
   echo -e "  ${INFO} Testing for setting file capability in /usr/bin/"
   # check for setcap error
   # create test file
-  ${SUDO} touch /usr/bin/pihole.setcap.tes
+  ${SUDO} touch /usr/bin/pihole.setcap.test
   # set the file with the correct capabilities and awk possible failure
   setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1 {print $1}')"
   # check status of test file

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -258,7 +258,7 @@ elif command -v rpm &> /dev/null; then
   UPDATE_PKG_CACHE=":"
   PKG_INSTALL=(${PKG_MANAGER} install -y)
   PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
-  INSTALLER_DEPS=(dialog git iproute net-tools newt procps-ng which)
+  INSTALLER_DEPS=(dialog git iproute net-tools newt procps-ng which libcap)
   PIHOLE_DEPS=(bc bind-utils cronie curl findutils nmap-ncat sudo unzip wget libidn2 psmisc)
   PIHOLE_WEB_DEPS=(lighttpd lighttpd-fastcgi php-common php-cli php-pdo)
   LIGHTTPD_USER="lighttpd"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -157,7 +157,7 @@ setcap_check(){
       in order to get help related to this issue, and reference the following message:
       ${COL_LIGHT_RED}
       $setcap_status
-      ${COL_NC} failed"
+      ${COL_NC}"
     echo -e "  ${INFO} Installation aborted."
     # Removing test file
     ${SUDO} rm -f /usr/bin/pihole.setcap.test
@@ -170,7 +170,7 @@ setcap_check(){
       in order to get help related to this issue, and reference the following message:
       ${COL_LIGHT_RED}
       $setcap_status
-      ${COL_NC} error"
+      ${COL_NC}"
     echo -e "  ${INFO} Installation aborted."
     # Exit the installer
     exit 0

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -140,28 +140,28 @@ show_ascii_berry() {
 # Compatibility
 
 setcap_check(){
-  # print info regarding probing file capabilities
-  echo -e "  ${INFO} Testing for setting file capability in /usr/bin/"
-  # create test file
-  ${SUDO} touch /usr/bin/pihole.setcap.test
-  # set the file with the correct capabilities and awk possible failure
-  setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1 {print $1}')"
-  # check status of test file if returned response is empty, the command succeded.
-  if [ -z "$setcap_status" ]; then
-    echo -e "  ${TICK} Setting capabilities in /usr/bin/ is supported by your system."
-    # removing test file
-    ${SUDO} rm -rf /usr/bin/pihole.setcap.test
-  # if command has returned Failed, display error message and exit
-  elif [ "$setcap_status" = "Failed" ]; then
-    echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
+# print info regarding probing file capabilities
+echo -e "  ${INFO} Testing for setting file capability in /usr/bin/"
+# create test file
+${SUDO} touch /usr/bin/pihole.setcap.test
+# set the file with the correct capabilities and awk possible failure
+setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1 {print $1}')"
+# check status of test file if returned response is empty, the command succeded.
+if [ -z "$setcap_status" ]; then
+  echo -e "  ${TICK} Setting capabilities in /usr/bin/ is supported by your system."
+  # removing test file
+  ${SUDO} rm -rf /usr/bin/pihole.setcap.test
+# if command has returned Failed, display error message and exit
+elif [ "$setcap_status" = "Failed" ]; then
+  echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
       in order to get help related to this issue."
-    echo -e "  ${INFO} Installation aborted."
-    # removing test file
-    ${SUDO} rm -rf /usr/bin/pihole.setcap.test
+  echo -e "  ${INFO} Installation aborted."
+  # removing test file
+  ${SUDO} rm -rf /usr/bin/pihole.setcap.test
   # exit the installer
   exit 0
-  fi
+fi
 }
 
 distro_check() {

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -144,17 +144,20 @@ setcap_check(){
   # create test file
   ${SUDO} touch /usr/bin/pihole.setcap.test
   # set the file with the correct capabilities and awk possible failure
-  setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1 {print $1}')"
+  setcap_status="$(${SUDO} setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip /usr/bin/pihole.setcap.test 2>&1 | awk 'FNR == 1')"
   # check status of test file if returned response is empty, the command succeded.
   if [ -z "$setcap_status" ]; then
     echo -e "  ${TICK} Setting capabilities in /usr/bin/ is supported by your system."
     # removing test file
     ${SUDO} rm -f /usr/bin/pihole.setcap.test
   # if command has returned Failed, display error message and exit
-  elif [ "$setcap_status" = "Failed" ]; then
+  elif [[ $setcap_status = *"Failed"* ]]; then
     echo -e "  ${CROSS} ${COL_LIGHT_RED}Your system does not support setting capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
-      in order to get help related to this issue."
+      in order to get help related to this issue and reference the following message:
+      ${COL_LIGHT_RED}
+      $setcap_status
+      ${COL_NC} failed"
     echo -e "  ${INFO} Installation aborted."
     # removing test file
     ${SUDO} rm -f /usr/bin/pihole.setcap.test
@@ -163,7 +166,10 @@ setcap_check(){
   else
     echo -e "  ${CROSS} ${COL_LIGHT_RED}An error occured while trying to set capabilities in /usr/bin/${COL_NC}
       Please visit our discourse forum at ${COL_LIGHT_CYAN}https://discourse.pi-hole.net${COL_NC}
-      in order to get help related to this issue."
+      in order to get help related to this issue and reference the following message:
+      ${COL_LIGHT_RED}
+      $setcap_status
+      ${COL_NC} error"
     echo -e "  ${INFO} Installation aborted."
     # exit the installer
     exit 0


### PR DESCRIPTION
Signed-off-by: RamSet <RamSet@gmail.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x ] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Prevent errors executing pihole_FTL by pihole user.

**How does this PR accomplish the above?:**
Check for ability to setcap under /usr/bin/

![image](https://user-images.githubusercontent.com/20760161/41798920-bd4de15e-762c-11e8-8ee6-80cf248bb180.png)

![image](https://user-images.githubusercontent.com/20760161/41798868-8bc2276c-762c-11e8-8639-c125bed66518.png)

**What documentation changes (if any) are needed to support this PR?:**

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

