### PR TITLE
Revert "Fix error: /opt/pihole/gravity.sh: 385: Warning: command substitution: ignored null byte in input"

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -387,8 +387,9 @@ gravity_ConsolidateDownloadedBlocklists() {
     if [[ -r "${i}" ]]; then
       # Remove windows CRs from file, convert list to lower case, and append into $matterAndLight
       tr -d '\r' < "${i}" | tr '[:upper:]' '[:lower:]' >> "${piholeDir}/${matterAndLight}"
+
       # Ensure that the first line of a new list is on a new line
-      IFS= read -r -d '' lastLine <"${piholeDir}/${matterAndLight}" || [[ $lastLine ]]
+      lastLine=$(tail -1 "${piholeDir}/${matterAndLight}")
       if [[ "${#lastLine}" -gt 0 ]]; then
         echo "" >> "${piholeDir}/${matterAndLight}"
       fi


### PR DESCRIPTION
Reverts pi-hole/pi-hole#2069