### PR TITLE
Fix incorrect variable string substitution

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -169,7 +169,7 @@ fi
 
 # Get adlist file content as array
 if [[ -n "${adlist}" ]] || [[ -n "${blockpage}" ]]; then
-  for adlistUrl in $(< "adListsList"); do
+  for adlistUrl in $(< "${adListsList}"); do
     if [[ "${adlistUrl:0:4}" =~ (http|www.) ]]; then
       adlists+=("${adlistUrl}")
     fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fix not being able to see adlist URLs using the query function:
```
/opt/pihole/query.sh: line 172: adListsList: No such file or directory
```
Closes #2255 

**How does this PR accomplish the above?:**
Fix an incorrect variable string substitution.

**What documentation changes (if any) are needed to support this PR?:**
None