### PR TITLE
Add run_command function

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -198,10 +198,10 @@ run_command() {
   if [ "$rc" != 0 ]; then
     local _critical
     $nonZeroExit && _critical="critical "
-    echo -e "\n  ${COL_LIGHT_RED}Error: a ${_critical}command failed${COL_NC}"
-    echo -e "\n  The command was:"
+    echo -e "\\n  ${COL_LIGHT_RED}Error: a ${_critical}command failed${COL_NC}"
+    echo -e "\\n  The command was:"
     echo -e "    ${COL_BOLD}$1${COL_NC}"
-    echo -e "\n  Output from the command was:${COL_GRAY}"
+    echo -e "\\n  Output from the command was:${COL_GRAY}"
     sed 's/^/  | /' <&12
     echo -e "${COL_NC}"
     echo "  Call stack:"
@@ -1605,7 +1605,7 @@ install_dependent_packages() {
           sed 's/\o033[\[(]?\?[0-9;]*[A-Za-z]//g;/^|[[:space:]]*$/d' "$logfile"
           echo -e "$COL_NC"
         fi
-        echo -e "\n${COL_LIGHT_RED}Error: apt failed; cancelling install${COL_NC}"
+        echo -e "\\n${COL_LIGHT_RED}Error: apt failed; cancelling install${COL_NC}"
         exit 1
       fi
       rm -f $logfile

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1608,7 +1608,7 @@ install_dependent_packages() {
         echo -e "\\n${COL_LIGHT_RED}Error: apt failed; cancelling install${COL_NC}"
         exit 1
       fi
-      rm -f $logfile
+      rm -f "$logfile"
       return
     fi
       echo ""


### PR DESCRIPTION
Signed-off-by: Neepawa <github@groupbcl.ca>

**By submitting this pull request, I confirm the following** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?**

Fix issue #2252 by providing useful messages to the user if a command run as part of the `base-install.sh` script faile.

**How does this PR accomplish the above?**

The PR implements a new function called `run_command`, which runs a command passed to it and captures its output in a file. If the command fails, useful information is written on stdout:

	Error: a command failed

	The command was:
	  halt_and_catch_fire --flame_colour=blue --now

	Output from the command:
	| halt_and_catch_fire: missing /dev file of device to destroy

	Call stack:
	  The failed command was called in function 'foo' at line 1560
	  Called from function 'bar' at line 2095
	  Called from function 'main' at line 2681
	  Called from function 'main' at line 2787

Experienced users can use this information to jump-start troubleshooting on problems. Inexperienced users can copy and paste the information to a help forum.

By default, `run_command` returns control to the caller if an error occurs. Passing `--nzx` (**n**on-**z**ero e**x**it) to the function causes it to issue an `exit` instead, cancelling the install. This mimics the behaviour of `set -e` (now disabled as part of this PR.)

(Given that most calls to `run_command` pass `--nzx,` we may want to consider making `--nzx` the default behaviour and pass a parameter like `--no-cancel` for commands that can fail without cancelling the script.)

*Implementation notes*

* When choosing which commands to invoke using `run_command` I erred on the side of caution, going with the idea that even straightforward commands can fail for unexpected reasons. For example, typically there's no for reason a command like `mkdir -p /etc/pihole` should ever fail. But what if `/etc` is on a journalling file system and Linux just flagged it as read-only because the journal got corrupted?

* I've commented out the `set -e` line because it should no longer be required.

* Currently on the development branch, the `install_manpage` function is giving errors when trying to copy man pages from `/etc/.pihole` because the files don't exist. I consider these errors non-fatal but report them anyway. I also modified the logic slightly to bypass running `mandb` if any man file copy fails.

* When testing this feature on CentOS, I discovered the command `systemctl restart pihole-FTL` was failing because *systemd* was unaware the *pihole-FTL* control file had been added. This failure was previously not reported because all output was redirected to `/dev/null`, and was also ignored because the return code from `systemctl` wasn't being checked. I fixed the problem by issuing `systemctl daemon-reload` prior to running `systemctl restart`.

* In `install_dependent_packages` I added a `--logfile` parameter to `debconf-apt-progress` to capture the output from the `${PKG_INSTALL}` command. Without this all the output from `apt-get` was lost and couldn't be reported if an error occurred.

* At the `installPihole` step at line 2500, I added `set -o pipefail' to capture the return code from `installPihole` instead of `tee`. After checking the return code I turn off *pipefail* to prevent issues later on.

* The install script terminates if `installPihole` fails.

*Minor cosmetic changes*

* I corrected a couple of "its/it's" errors in the comments, and replaced a couple of instances of "setup" (a noun) with "set up" (the verb.) I resisted the urge to reduce very long comment lines to multiple shorter lines, given that's already being addressed in the "Cleanup of basic-install.sh" pull request.

* I corrected a problem with indentation in the `FTLinstall` function.

**What documentation changes (if any) are needed to support this PR?**

None.