### PR TITLE
Use adlist as default query

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -14,7 +14,7 @@ piholeDir="/etc/pihole"
 adListsList="$piholeDir/adlists.list"
 wildcardlist="/etc/dnsmasq.d/03-pihole-wildcard.conf"
 options="$*"
-adlist=""
+adlist="true"
 all=""
 exact=""
 blockpage=""
@@ -186,8 +186,8 @@ fi
 
 # Get adlist file content as array
 if [[ -n "${adlist}" ]] || [[ -n "${blockpage}" ]]; then
-  for adlistUrl in $(< "${adListsList}"); do
-    if [[ "${adlistUrl:0:4}" =~ (http|www.) ]]; then
+  IFS=$'\n'; for adlistUrl in $(< "${adListsList}"); do
+    if [[ "${adlistUrl:0:1}" != "#" ]]; then
       adlists+=("${adlistUrl}")
     fi
   done


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Ensures that a blacklist query returns which adlist URL the match is found in, instead of the less-than-relevant internal file name. Also brings `query.sh` in line with #2261


**How does this PR accomplish the above?:**
Changelog in commit


**What documentation changes (if any) are needed to support this PR?:**
None, I believe.