### PR TITLE
Installer fixes for Fedora & CentOS

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -291,6 +291,13 @@ elif command -v rpm &> /dev/null; then
                 "${PKG_INSTALL[@]}" "yum-utils" &> /dev/null
                 yum-config-manager --enable ${REMI_REPO} &> /dev/null
                 echo -e "  ${TICK} Remi's RPM repository has been enabled for PHP7"
+                # trigger an install/update of PHP to ensure previous version of PHP is updated from REMI
+                if "${PKG_INSTALL[@]}" "php-cli" &> /dev/null; then
+                    echo -e "  ${TICK} PHP7 installed/updated via Remi's RPM repository"
+                else
+                    echo -e "  ${CROSS} There was a problem updating to PHP7 via Remi's RPM repository"
+                    exit 1
+                fi
             fi
         fi
     fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -244,7 +244,8 @@ elif command -v rpm &> /dev/null; then
     # If the host OS is Fedora,
     if grep -qi 'fedora' /etc/redhat-release; then
         # all required packages should be available by default with the latest fedora release
-        : # continue
+        # ensure 'php-json' is installed on Fedora (installed as dependency on CentOS7 + Remi repository)
+        PIHOLE_WEB_DEPS+=('php-json')
     # or if host OS is CentOS,
     elif grep -qi 'centos' /etc/redhat-release; then
         # Pi-Hole currently supports CentOS 7+ with PHP7+


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits.
---
**What does this PR aim to accomplish?:**
- Update PHP via Remi after enabling the repository otherwise PHP will not get updated via Remi until next system update.
- Add `php-json` as a web dependency on Fedora. This package is pulled as a dependency with CentOS + Remi. Note that `php-json` is not available on CentOS without Remi (default PHP) so the dependency should not be added to `PIHOLE_WEB_DEPS` directly. (also discovered here: https://github.com/pi-hole/pi-hole/issues/2002#issuecomment-388687187)

**How does this PR accomplish the above?:**
- install/update PHP after Remi repository is enabled
- add `php-json` to web dependencies when installed on Fedora 

**What documentation changes (if any) are needed to support this PR?:**
n/a
