### PR TITLE
Add back --wild list.sh help and use -- for long params like --regex

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -32,8 +32,11 @@ helpFunc() {
   if [[ "${listMain}" == "${whitelist}" ]]; then
     param="w"
     type="white"
+  elif [[ "${listMain}" == "${regexlist}" && "${wildcard}" == true ]]; then
+    param="-wild"
+    type="wildcard black"
   elif [[ "${listMain}" == "${regexlist}" ]]; then
-    param="wild"
+    param="-regex"
     type="regex black"
   else
     param="b"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix concerns brought up about the wildcard and regex list help menus: https://github.com/pi-hole/pi-hole/pull/2236#issuecomment-405094105
Add back help menu for wildcard blacklisting, even though it really is just regex blacklisting.

**How does this PR accomplish the above?:**
Add back help menu for wildcard blacklisting and use double dashes for regex and wildcard parameters.

**What documentation changes (if any) are needed to support this PR?:**
None