### PR TITLE
Add err_trap function

### DIFF
--- a/advanced/bash-completion/pihole
+++ b/advanced/bash-completion/pihole
@@ -7,10 +7,10 @@ _pihole() {
 
 	case "${prev}" in
 		"pihole")
-			opts="admin blacklist checkout chronometer debug disable enable flush help logging query reconfigure restartdns status tail uninstall updateGravity updatePihole version wildcard whitelist"
+			opts="admin blacklist checkout chronometer debug disable enable flush help logging query reconfigure regex restartdns status tail uninstall updateGravity updatePihole version wildcard whitelist"
 			COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
 		;;
-		"whitelist"|"blacklist"|"wildcard")
+		"whitelist"|"blacklist"|"wildcard"|"regex")
 			opts_lists="\--delmode \--noreload \--quiet \--list \--nuke"
 			COMPREPLY=( $(compgen -W "${opts_lists}" -- ${cur}) )
 		;;

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1391,7 +1391,7 @@ install_manpage() {
     tag_output; cp -a $fromDir/pihole-FTL.8 $toManDir/man8/pihole-FTL.8 >&4 2>&1; rc2=$?
     tag_output; cp -a $fromDir/pihole-FTL.conf.5 $toManDir/man5/pihole-FTL.conf.5 >&4 2>&1; rc3=$?
     set -e
-    if [ $rc1 == 0 -a $rc1 == 0 -a $rc2 == 0 ]; then
+    if [ $rc1 == 0 ] && [ $rc2 == 0 ] && [ $rc3 == 0 ]; then
         tag_output; mandb -q >&4 2>&1
         # Updated successfully
         echo -e "${OVER}  ${TICK} man pages installed and database updated"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1617,14 +1617,14 @@ install_dependent_packages() {
             # Tell debconf-apt-progress to log output from apt-get to a file, otherwise
             # we lose apt-get's output and can't report it to the caller
             apt_get_logfile=$(mktemp /tmp/pihole__apt_get_logfile_XXXXXX)
-            debconf-apt-progress --logfile $apt_get_logfile -- "${PKG_INSTALL[@]}" "${installArray[@]}" || rc=1
+            debconf-apt-progress --logfile "$apt_get_logfile" -- "${PKG_INSTALL[@]}" "${installArray[@]}" || rc=1
             if [ $rc != 0 ]; then
-                tag_output; cat $apt_get_logfile >&4
+                tag_output; cat "$apt_get_logfile" >&4
                 err_trap "${PKG_INSTALL[*]} ${installArray[*]}"
-                tag_output; rm -f $apt_get_logfile >&4 2>&1
+                tag_output; rm -f "$apt_get_logfile" >&4 2>&1
                 exit 1
             fi
-            tag_output; rm -f $apt_get_logfile >&4 2>&1
+            tag_output; rm -f "$apt_get_logfile" >&4 2>&1
             return
         fi
         echo ""
@@ -2086,7 +2086,7 @@ fetch_checkout_pull_branch() {
     git clean --quiet --force -d || true
     cmd='git fetch'
     tag_output; eval "$cmd" >&4 2>&1 || err_trap "$cmd" || return 1
-    checkout_pull_branch
+    checkout_pull_branch "${directory}" "${branch}" || return 1
 }
 
 checkout_pull_branch() {
@@ -2576,8 +2576,9 @@ main() {
     copy_to_install_log
 
     # Inform the user if the installPihole step failed
-    if [ -f $INSTALL_PIHOLE_SEM_FILE ]; then
+    if [ -f "$INSTALL_PIHOLE_SEM_FILE" ]; then
       echo -e "  ${COL_LIGHT_RED}Pi-hole installation failed.${COL_NC}"
+      rm -f "$INSTALL_PIHOLE_SEM_FILE"
       exit 1
     fi
   

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -187,7 +187,6 @@ else
     COL_BOLD='\e[1m' # Bright
     COL_LIGHT_GREEN='\e[1;32m'
     COL_LIGHT_RED='\e[1;31m'
-    COL_LIGHT_BOLD='\e[1;31m'
     COL_GRAY='\e[1;90m'
     TICK="[${COL_LIGHT_GREEN}✓${COL_NC}]"
     CROSS="[${COL_LIGHT_RED}✗${COL_NC}]"


### PR DESCRIPTION
Signed-off-by: Neepawa <github@groupbcl.ca>

**By submitting this pull request, I confirm the following** 

- [X] I have read and understood the
  [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md),
  as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits.
  ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---

**What does this PR aim to accomplish?**

Fix issue #2252 by providing useful messages to the user if a command run as part of the `base-install.sh` script faile.

**How does this PR accomplish the above?**

The PR implements a new function called `err_trap`, which run whenever an error occurs in a stand-alone command (that is, a commmand that is not part of a pipeline.) Output is similar to the following:

	Error: a command failed

	The command was:
	  halt_and_catch_fire --flame_colour=blue --now

	Output from the command:
	| halt_and_catch_fire: missing /dev file of device to destroy

	Call stack:
	  The failed command was called in function 'foo' at line 1560
	  Called from function 'bar' at line 2095
	  Called from function 'install_main' at line 2681
	  Called from function 'main' at line 2787

Experienced users can use this information to jump-start troubleshooting on problems. Inexperienced users can copy and paste the information to a help forum.

*Implementation notes*

* In order for the command's output to be displayed to the user, it must be redirected to file descriptor 4:  
    &nbsp; `tag_output; command --parameters >&4 2>&1`

* File descriptor 4 is set up shortly after the installer starts.

* The `tag_ouput` call is needed to add `__TAG__` to file descriptor 4. This is required because writes to file descriptors are appending, and the `__TAG__` lines separate output between commands. Without it, when `err_trap` runs it would display the output of all prior commands in addition to the one it's reporting on.

* I added code to terminate the script if `installPihole` fails.

*Minor cosmetic changes*

* I corrected a couple of "its/it's" errors in the comments, and replaced a couple of instances of "setup" (a noun) with "set up" (the verb.) I resisted the urge to reduce very long comment lines to multiple shorter lines, given that's already being addressed in the "Cleanup of basic-install.sh" pull request.

**What documentation changes (if any) are needed to support this PR?**

None.
