### PR TITLE
Fix wrong git command flag

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1918,7 +1918,7 @@ get_available_branches() {
 
     cd "${directory}" || return 1
     # Get reachable remote branches, but store STDERR as STDOUT variable
-    output=$( { git ls-remote --head --quiet | cut -d'/' -f3- -; } 2>&1 )
+    output=$( { git ls-remote --heads --quiet | cut -d'/' -f3- -; } 2>&1 )
     echo "$output"
     return
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fix this checkout error:
```
$ pihole checkout web FTLDNS
  Please note that changing branches severely alters your Pi-hole subsystems
  Features that work on the master branch, may not on a development branch
  This feature is NOT supported unless a Pi-hole developer explicitly asks!
  Have you read and understood this? [y/N] y

  [✗] Fetching branches from https://github.com/pi-hole/AdminLTE.git

usage: git ls-remote [--heads] [--tags] [-u <exec> | --upload-pack <exec>] [-q|--quiet] [--exit-code] [--get-url] [<repository> [<refs>...]]
```

**How does this PR accomplish the above?:**
Use the `--heads` flag for `git ls-remote` instead of `--head`. I could not find documentation on a `--head` flag, but it works as expected on my machine and there is a `--heads` flag does the same thing and is actually documented.

**What documentation changes (if any) are needed to support this PR?:**
None