### PR TITLE
Fix FTL install leaking error output

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2058,7 +2058,7 @@ FTLinstall() {
             # Install the FTL service
             echo -e "${OVER}  ${TICK} ${str}"
             # dnsmasq can now be stopped and disabled if it exists
-            if which dnsmasq > /dev/null; then
+            if which dnsmasq &> /dev/null; then
                 if check_service_active "dnsmasq";then
                     echo "  ${INFO} FTL can now resolve DNS Queries without dnsmasq running separately"
                     stop_service dnsmasq
@@ -2187,7 +2187,7 @@ FTLcheckUpdate() {
     local localSha1
 
     # if dnsmasq exists and is running at this point, force reinstall of FTL Binary
-    if which dnsmasq > /dev/null; then
+    if which dnsmasq &> /dev/null; then
         if check_service_active "dnsmasq";then
             return 0
         fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1370,11 +1370,11 @@ check_service_active() {
     # If systemctl exists,
     if command -v systemctl &> /dev/null; then
         # use that to check the status of the service
-        systemctl is-enabled "${1}" > /dev/null
+        systemctl is-enabled "${1}" &> /dev/null
     # Otherwise,
     else
         # fall back to service command
-        service "${1}" status > /dev/null
+        service "${1}" status &> /dev/null
     fi
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix leaked error messages during FTL install:
- Ubuntu 18.04
```
  [i] FTL Checks...
  [✓] Detected x86_64 architecture
  [i] Checking for existing FTL binary...
Failed to get unit file state for dnsmasq.service: No such file or directory
  [✓] Downloading and Installing FTL
Failed to get unit file state for dnsmasq.service: No such file or directory
```
- CentOS 7
```
  [i] FTL Checks...
  [✓] Detected x86_64 architecture
  [i] Checking for existing FTL binary...
which: no dnsmasq in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
  [✓] Downloading and Installing FTL
which: no dnsmasq in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
```

**How does this PR accomplish the above?:**
Change command output redirection from `>` to `&>` in `check_service_active`.

**What documentation changes (if any) are needed to support this PR?:**
None