### PR TITLE
Allow PHP to edit the regex file if web is installed

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1239,7 +1239,7 @@ installConfigs() {
     # Install an empty regex file
     if [[ ! -f "${regexFile}" ]]; then
         # Let PHP edit the regex file, if installed
-        install -o pihole -g "${LIGHTTPD_GROUP:-pihole}" -m 644 /dev/null "${regexFile}"
+        install -o pihole -g "${LIGHTTPD_GROUP:-pihole}" -m 664 /dev/null "${regexFile}"
     fi
 
     # If the user chose to install the dashboard,

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1237,7 +1237,9 @@ installConfigs() {
     version_check_dnsmasq
 
     # Install an empty regex file
-    touch "${regexFile}"
+    if [[ ! -f "${regexFile}" ]]; then
+        touch "${regexFile}"
+    fi
     chown pihole:pihole "${regexFile}"
     chmod 664 "${regexFile}"
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1238,10 +1238,9 @@ installConfigs() {
 
     # Install an empty regex file
     if [[ ! -f "${regexFile}" ]]; then
-        touch "${regexFile}"
+        # Let PHP edit the regex file, if installed
+        install -o pihole -g "${LIGHTTPD_GROUP:-pihole}" -m 644 /dev/null "${regexFile}"
     fi
-    chown pihole:pihole "${regexFile}"
-    chmod 664 "${regexFile}"
 
     # If the user chose to install the dashboard,
     if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
@@ -1269,9 +1268,6 @@ installConfigs() {
         chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /var/cache/lighttpd/compress
         mkdir -p /var/cache/lighttpd/uploads
         chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /var/cache/lighttpd/uploads
-
-        # Let PHP edit the regex file
-        chown pihole:${LIGHTTPD_GROUP} "${regexFile}"
     fi
 }
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -50,6 +50,7 @@ PI_HOLE_INSTALL_DIR="/opt/pihole"
 useUpdateVars=false
 
 adlistFile="/etc/pihole/adlists.list"
+regexFile="/etc/pihole/regex.list"
 # Pi-hole needs an IP address; to begin, these variables are empty since we don't know what the IP is until
 # this script can run
 IPV4_ADDRESS=""
@@ -1235,6 +1236,11 @@ installConfigs() {
     # Make sure Pi-hole's config files are in place
     version_check_dnsmasq
 
+    # Install an empty regex file
+    touch "${regexFile}"
+    chown pihole:pihole "${regexFile}"
+    chmod 664 "${regexFile}"
+
     # If the user chose to install the dashboard,
     if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
         # and if the Web server conf directory does not exist,
@@ -1261,6 +1267,9 @@ installConfigs() {
         chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /var/cache/lighttpd/compress
         mkdir -p /var/cache/lighttpd/uploads
         chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /var/cache/lighttpd/uploads
+
+        # Let PHP edit the regex file
+        chown pihole:${LIGHTTPD_GROUP} "${regexFile}"
     fi
 }
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -643,11 +643,6 @@ if [[ "${skipDownload}" == false ]] || [[ "${listType}" == "whitelist" ]]; then
   gravity_Whitelist
 fi
 
-# Set proper permissions on the regex file
-touch "${regexFile}"
-chown pihole:www-data "${regexFile}"
-chmod 664 "${regexFile}"
-
 convert_wildcard_to_regex
 gravity_ShowBlockCount
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix permissions error on the web interface when modifying the regex:
```
Failure! Something went wrong.
Unable to add regex "^example\.com$" to /etc/pihole/regex.list
Error message: file_put_contents(/etc/pihole/regex.list): failed to open stream: Permission denied
```

**How does this PR accomplish the above?:**
Use the correct lighttpd user group when setting regex file permissions. Not all distros use `www-data`.

**What documentation changes (if any) are needed to support this PR?:**
None