### PR TITLE
Use simpler regex format for wildcards

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -141,7 +141,7 @@ AddDomain() {
         bool=true
         domain="${1}"
 
-        [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain//\./\\.}$"
+        [[ "${wildcard}" == true ]] && domain="\\.?${domain//\./\\.}$"
 
         # Is the domain in the list?
         # Search only for exactly matching lines
@@ -189,7 +189,7 @@ RemoveDomain() {
         [[ -z "${type}" ]] && type="--wildcard-only"
         domain="${1}"
 
-        [[ "${wildcard}" == true ]] && domain="((^)|(\\.))${domain//\./\\.}$"
+        [[ "${wildcard}" == true ]] && domain="\\.?${domain//\./\\.}$"
 
         bool=true
         # Is it in the list?

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -141,7 +141,7 @@ AddDomain() {
         bool=true
         domain="${1}"
 
-        [[ "${wildcard}" == true ]] && domain="\\.?${domain//\./\\.}$"
+        [[ "${wildcard}" == true ]] && domain="(^|\\.)${domain//\./\\.}$"
 
         # Is the domain in the list?
         # Search only for exactly matching lines
@@ -189,7 +189,7 @@ RemoveDomain() {
         [[ -z "${type}" ]] && type="--wildcard-only"
         domain="${1}"
 
-        [[ "${wildcard}" == true ]] && domain="\\.?${domain//\./\\.}$"
+        [[ "${wildcard}" == true ]] && domain="(^|\\.)${domain//\./\\.}$"
 
         bool=true
         # Is it in the list?

--- a/advanced/Scripts/wildcard_regex_converter.sh
+++ b/advanced/Scripts/wildcard_regex_converter.sh
@@ -24,5 +24,5 @@ convert_wildcard_to_regex() {
     # Remove repeated domains (may have been inserted two times due to A and AAAA blocking)
     uniquedomains="$(uniq <<< "${domains}")"
     # Automatically generate regex filters and remove old wildcards file
-    awk '{print "\\.?"$0"$"}' <<< "${uniquedomains}" >> "${regexFile:?}" && rm "${wildcardFile}"
+    awk '{print "(^|\\.)"$0"$"}' <<< "${uniquedomains}" >> "${regexFile:?}" && rm "${wildcardFile}"
 }

--- a/advanced/Scripts/wildcard_regex_converter.sh
+++ b/advanced/Scripts/wildcard_regex_converter.sh
@@ -24,5 +24,5 @@ convert_wildcard_to_regex() {
     # Remove repeated domains (may have been inserted two times due to A and AAAA blocking)
     uniquedomains="$(uniq <<< "${domains}")"
     # Automatically generate regex filters and remove old wildcards file
-    awk '{print "((^)|(\\.))"$0"$"}' <<< "${uniquedomains}" >> "${regexFile:?}" && rm "${wildcardFile}"
+    awk '{print "\\.?"$0"$"}' <<< "${uniquedomains}" >> "${regexFile:?}" && rm "${wildcardFile}"
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Use a simpler wildcard regex format.

**How does this PR accomplish the above?:**
Use `(^|\.)domain\.com$` instead of `((^)|(\.))domain\.com$`

**What documentation changes (if any) are needed to support this PR?:**
None