### PR TITLE
Remove PowerPC from FTL binaries

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2151,11 +2151,6 @@ get_binary_name() {
             # set the binary to be used
             binary="pihole-FTL-arm-linux-gnueabi"
         fi
-    elif [[ "${machine}" == "ppc" ]]; then
-        # PowerPC
-        echo -e "${OVER}  ${TICK} Detected PowerPC architecture"
-        # set the binary to be used
-        binary="pihole-FTL-powerpc-linux-gnu"
     elif [[ "${machine}" == "x86_64" ]]; then
         # This gives the architecture of packages dpkg installs (for example, "i386")
         local dpkgarch


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Remove PowerPC from the list of available architectures. It is no longer built, and may cause 404 errors if it attempts to download the binary.

**How does this PR accomplish the above?:**
Remove the check for PowerPC from the FTL binary architecture function.

**What documentation changes (if any) are needed to support this PR?:**
None