### PR TITLE
Fix gravity's regex counting logic

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -464,7 +464,7 @@ gravity_ShowBlockCount() {
   fi
 
   if [[ -f "${regexFile}" ]]; then
-    num=$(grep -c "^(?!#)" "${regexFile}")
+    num=$(grep -c "^[^#]" "${regexFile}")
     echo -e "  ${INFO} Number of regex filters: ${num}"
   fi
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [ ] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [ ] I give this submission freely and claim no ownership.
- [ ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Fix gravity's regex counting logic


**How does this PR accomplish the above?:**

The previously chosen command was fine, however, it unintentionally triggered some bash internals, effectively leading to a failure. We now use an alternative formulation for achieving the exact same thing which is not affected by this issue.