### PR TITLE
Change the enable/disable method

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -13,9 +13,6 @@ basename=pihole
 piholeDir=/etc/"${basename}"
 whitelist="${piholeDir}"/whitelist.txt
 blacklist="${piholeDir}"/blacklist.txt
-if [[ "${BLOCKING_ENABLED}" == false ]]; then
-  blacklist="${blacklist}.bck"
-fi
 
 readonly regexlist="/etc/pihole/regex.list"
 reload=false

--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -13,6 +13,10 @@ basename=pihole
 piholeDir=/etc/"${basename}"
 whitelist="${piholeDir}"/whitelist.txt
 blacklist="${piholeDir}"/blacklist.txt
+if [[ "${BLOCKING_ENABLED}" == false ]]; then
+  blacklist="${blacklist}.bck"
+fi
+
 readonly regexlist="/etc/pihole/regex.list"
 reload=false
 addmode=true

--- a/gravity.sh
+++ b/gravity.sh
@@ -73,6 +73,19 @@ if [[ -r "${piholeDir}/pihole.conf" ]]; then
   echo -e "  ${COL_LIGHT_RED}Ignoring overrides specified within pihole.conf! ${COL_NC}"
 fi
 
+# Determine if Pi-hole blocking is disabled
+# If this is the case, we want to update
+#  gravity.list.bck and black.list.bck instead of
+#  gravity.list and black.list
+detect_pihole_blocking_status() {
+  if [[ -e "${adList}.bck" ]]; then
+    adList="${adList}.bck"
+  fi
+  if [[ -e "${blackList}.bck" ]]; then
+    blackList="${blackList}.bck"
+  fi
+}
+
 # Determine if DNS resolution is available before proceeding
 gravity_CheckDNSResolutionAvailable() {
   local lookupDomain="pi.hole"
@@ -620,6 +633,8 @@ if [[ "${forceDelete:-}" == true ]]; then
   rm /etc/pihole/list.* 2> /dev/null || true
   echo -e "${OVER}  ${TICK} ${str}"
 fi
+
+detect_pihole_blocking_status
 
 # Determine which functions to run
 if [[ "${skipDownload}" == false ]]; then

--- a/gravity.sh
+++ b/gravity.sh
@@ -78,11 +78,12 @@ fi
 #  gravity.list.bck and black.list.bck instead of
 #  gravity.list and black.list
 detect_pihole_blocking_status() {
-  if [[ -e "${adList}.bck" ]]; then
+  if [[ "${BLOCKING}" == false ]]; then
+    echo -e "  ${INFO} Pi-hole blocking is disabled"
     adList="${adList}.bck"
-  fi
-  if [[ -e "${blackList}.bck" ]]; then
     blackList="${blackList}.bck"
+  else
+    echo -e "  ${INFO} Pi-hole blocking is enabled"
   fi
 }
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -78,7 +78,7 @@ fi
 #  gravity.list.bck and black.list.bck instead of
 #  gravity.list and black.list
 detect_pihole_blocking_status() {
-  if [[ "${BLOCKING}" == false ]]; then
+  if [[ "${BLOCKING_ENABLED}" == false ]]; then
     echo -e "  ${INFO} Pi-hole blocking is disabled"
     adList="${adList}.bck"
     blackList="${blackList}.bck"

--- a/pihole
+++ b/pihole
@@ -10,7 +10,8 @@
 # Please see LICENSE file for your rights under this license.
 
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
-readonly wildcardlist="/etc/dnsmasq.d/03-pihole-wildcard.conf"
+readonly gravitylist="/etc/pihole/gravity.list"
+readonly blacklist="/etc/pihole/black.list"
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
 
@@ -146,10 +147,13 @@ Time:
 
   elif [[ "${1}" == "0" ]]; then
     # Disable Pi-hole
-    sed -i 's/^addn-hosts=\/etc\/pihole\/gravity.list/#addn-hosts=\/etc\/pihole\/gravity.list/' /etc/dnsmasq.d/01-pihole.conf
-    sed -i 's/^addn-hosts=\/etc\/pihole\/black.list/#addn-hosts=\/etc\/pihole\/black.list/' /etc/dnsmasq.d/01-pihole.conf
-    if [[ -e "$wildcardlist" ]]; then
-      mv "$wildcardlist" "/etc/pihole/wildcard.list"
+    if [[ -e "${gravitylist}" ]]; then
+      mv "${gravitylist}" "${gravitylist}.bck"
+      echo "" > "${gravitylist}"
+    fi
+    if [[ -e "${blacklist}" ]]; then
+      mv "${blacklist}" "${blacklist}.bck"
+      echo "" > "${blacklist}"
     fi
     if [[ $# > 1 ]]; then
       local error=false
@@ -193,9 +197,11 @@ Time:
     echo -e "  ${INFO} Enabling blocking"
     local str="Pi-hole Enabled"
 
-    sed -i 's/^#addn-hosts/addn-hosts/' /etc/dnsmasq.d/01-pihole.conf
-    if [[ -e "/etc/pihole/wildcard.list" ]]; then
-      mv "/etc/pihole/wildcard.list" "$wildcardlist"
+    if [[ -e "${gravitylist}.bck" ]]; then
+      mv "${gravitylist}.bck" "${gravitylist}"
+    fi
+    if [[ -e "${blacklist}" ]]; then
+      mv "${blacklist}.bck" "${blacklist}"
     fi
   fi
 

--- a/pihole
+++ b/pihole
@@ -283,7 +283,7 @@ statusFunc() {
     # No configs were found
     case "${1}" in
       "web") echo 99;;
-      *) echo -e "  ${INFO} No hosts file linked to dnsmasq, adding it in enabled state";;
+      *) echo -e "  ${INFO} Pi-hole blocking will be enabled";;
     esac
     # Enable blocking
     pihole enable

--- a/pihole
+++ b/pihole
@@ -191,6 +191,8 @@ Time:
       fi
 
       local str="Pi-hole Disabled"
+      sed -i "/BLOCKING=/d" "${setupVars}"
+      echo "BLOCKING=true" >> "${setupVars}"
     fi
   else
     # Enable Pi-hole
@@ -203,6 +205,8 @@ Time:
     if [[ -e "${blacklist}" ]]; then
       mv "${blacklist}.bck" "${blacklist}"
     fi
+    sed -i "/BLOCKING=/d" "${setupVars}"
+    echo "BLOCKING=false" >> "${setupVars}"
   fi
 
   restartDNS reload

--- a/pihole
+++ b/pihole
@@ -203,7 +203,7 @@ Time:
     if [[ -e "${gravitylist}.bck" ]]; then
       mv "${gravitylist}.bck" "${gravitylist}"
     fi
-    if [[ -e "${blacklist}" ]]; then
+    if [[ -e "${blacklist}.bck" ]]; then
       mv "${blacklist}.bck" "${blacklist}"
     fi
     sed -i "/BLOCKING_ENABLED=/d" "${setupVars}"
@@ -253,8 +253,6 @@ Options:
 }
 
 statusFunc() {
-  local addnConfigs
-
   # Determine if service is running on port 53 (Cr: https://superuser.com/a/806331)
   if (echo > /dev/tcp/127.0.0.1/53) >/dev/null 2>&1; then
     if [[ "${1}" != "web" ]]; then
@@ -269,9 +267,6 @@ statusFunc() {
   fi
 
   # Determine if Pi-hole's blocking is enabled
-
-  addnConfigs=$?
-
   if grep -q "BLOCKING_ENABLED=false" /etc/pihole/setupVars.conf; then
     # A config is commented out
     case "${1}" in

--- a/pihole
+++ b/pihole
@@ -192,8 +192,8 @@ Time:
       fi
 
       local str="Pi-hole Disabled"
-      sed -i "/BLOCKING=/d" "${setupVars}"
-      echo "BLOCKING=false" >> "${setupVars}"
+      sed -i "/BLOCKING_ENABLED=/d" "${setupVars}"
+      echo "BLOCKING_ENABLED=false" >> "${setupVars}"
     fi
   else
     # Enable Pi-hole
@@ -206,8 +206,8 @@ Time:
     if [[ -e "${blacklist}" ]]; then
       mv "${blacklist}.bck" "${blacklist}"
     fi
-    sed -i "/BLOCKING=/d" "${setupVars}"
-    echo "BLOCKING=true" >> "${setupVars}"
+    sed -i "/BLOCKING_ENABLED=/d" "${setupVars}"
+    echo "BLOCKING_ENABLED=true" >> "${setupVars}"
   fi
 
   restartDNS reload
@@ -272,13 +272,13 @@ statusFunc() {
 
   addnConfigs=$?
 
-  if grep -q "BLOCKING=false" /etc/pihole/setupVars.conf; then
+  if grep -q "BLOCKING_ENABLED=false" /etc/pihole/setupVars.conf; then
     # A config is commented out
     case "${1}" in
       "web") echo 0;;
       *) echo -e "  ${CROSS} Pi-hole blocking is Disabled";;
     esac
-  elif grep -q "BLOCKING=true" /etc/pihole/setupVars.conf;  then
+  elif grep -q "BLOCKING_ENABLED=true" /etc/pihole/setupVars.conf;  then
     # Configs are set
     case "${1}" in
       "web") echo 1;;

--- a/pihole
+++ b/pihole
@@ -12,6 +12,7 @@
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 readonly gravitylist="/etc/pihole/gravity.list"
 readonly blacklist="/etc/pihole/black.list"
+readonly setupVars="/etc/pihole/setupVars.conf"
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
 
@@ -192,7 +193,7 @@ Time:
 
       local str="Pi-hole Disabled"
       sed -i "/BLOCKING=/d" "${setupVars}"
-      echo "BLOCKING=true" >> "${setupVars}"
+      echo "BLOCKING=false" >> "${setupVars}"
     fi
   else
     # Enable Pi-hole
@@ -206,7 +207,7 @@ Time:
       mv "${blacklist}.bck" "${blacklist}"
     fi
     sed -i "/BLOCKING=/d" "${setupVars}"
-    echo "BLOCKING=false" >> "${setupVars}"
+    echo "BLOCKING=true" >> "${setupVars}"
   fi
 
   restartDNS reload

--- a/pihole
+++ b/pihole
@@ -268,16 +268,17 @@ statusFunc() {
     return 0
   fi
 
-  # Determine if Pi-hole's addn-hosts configs are commented out
-  addnConfigs=$(grep -i "addn-hosts=/" /etc/dnsmasq.d/01-pihole.conf)
+  # Determine if Pi-hole's blocking is enabled
 
-  if [[ "${addnConfigs}" =~ "#" ]]; then
+  addnConfigs=$?
+
+  if grep -q "BLOCKING=false" /etc/pihole/setupVars.conf; then
     # A config is commented out
     case "${1}" in
       "web") echo 0;;
       *) echo -e "  ${CROSS} Pi-hole blocking is Disabled";;
     esac
-  elif [[ -n "${addnConfigs}" ]]; then
+  elif grep -q "BLOCKING=true" /etc/pihole/setupVars.conf;  then
     # Configs are set
     case "${1}" in
       "web") echo 1;;
@@ -289,9 +290,8 @@ statusFunc() {
       "web") echo 99;;
       *) echo -e "  ${INFO} No hosts file linked to dnsmasq, adding it in enabled state";;
     esac
-    # Add addn-host= to dnsmasq
-    echo "addn-hosts=/etc/pihole/gravity.list" >> /etc/dnsmasq.d/01-pihole.conf
-    restartDNS
+    # Enable blocking
+    pihole enable
   fi
 }
 

--- a/pihole
+++ b/pihole
@@ -199,7 +199,7 @@ Time:
     fi
   fi
 
-  restartDNS
+  restartDNS reload
 
   echo -e "${OVER}  ${TICK} ${str}"
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish and how does it accomplish it?:**

Change the method we use to disable/enable blocking. So far, we commented the config lines
```
addn-hosts=/etc/pihole/gravity.list
addn-hosts=/etc/pihole/black.list
```
and then restarting `pihole-FTL`. This is very inefficient and slow, as, on shutdown of `pihole-FTL`, we update the database and then on restart, import all queries again from the database.

This PR changes this. Instead of changing the configuration to not load the files, we replace them by empty files which are then reread on `reload`ing `pihole-FTL`. The old files are kept as backup and restored on `pihole enable`. This is a much cleaner variant of handling the blocking status and also *much* faster than always restarting the daemon. It solves a number of delay issues recently reported with the Enable/Disable functionality of Pi-hole.

Pi-hole `gravity` is modified to update the backup files when blocking is disabled.

The current blocking status is tracked by setting the new variable `BLOCKED_ENABLED` in `setupVars.conf`.