### PR TITLE
Fix to enable pihole-FTL service before starting it

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2483,9 +2483,12 @@ main() {
     echo -e "  ${INFO} Restarting services..."
     # Start services
 
-    # Enable FTL
-    start_service pihole-FTL
+    # Enable FTL 
+    # Ensure the service is enabled before trying to start it
+    # Fixes a problem reported on Ubuntu 18.04 where trying to start
+    # the service before enabling causes installer to exit
     enable_service pihole-FTL
+    start_service pihole-FTL
 
     # Download and compile the aggregated block list
     runGravity


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X]  I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

This PR fixes a situation happening on ubuntu 18.04.
When installer is starting the pihole-FTL service, in some cases the installer exits, without providing any info, because `systemctl` is not able to found the service unit file.

**How does this PR accomplish the above?:**

We swapped order of starting and enabling operations related only to pihole-FTL service.
With this patch, we first enable the service, so `systemctl` can be informed about this new service available, then we start it.

**What documentation changes (if any) are needed to support this PR?:**

We think this do not needs any doc change. We are confident enough that this PR is not a breaking change.

In addition to automatic tests, author of PR has tested the installer both in manual and in unattended mode, but only against ubuntu.