### PR TITLE
Start pihole-FTL as root if capabilities are not supported by the system

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -34,9 +34,13 @@ start() {
     chown pihole:pihole /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port
     chown pihole:pihole /etc/pihole /etc/pihole/dhcp.leases /var/log/pihole.log
     chmod 0644 /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole.log
-    setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip "$(which pihole-FTL)"
     echo "nameserver 127.0.0.1" | /sbin/resolvconf -a lo.piholeFTL
-    su -s /bin/sh -c "/usr/bin/pihole-FTL" "$FTLUSER"
+    if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip "$(which pihole-FTL)"; then
+      su -s /bin/sh -c "/usr/bin/pihole-FTL" "$FTLUSER"
+    else
+      echo "Warning: Starting pihole-FTL as root because setting capabilities is not supported on this system"
+      pihole-FTL
+    fi
     echo
   fi
 }
@@ -78,7 +82,7 @@ status() {
     echo "[    ] pihole-FTL is not running"
     exit 1
   fi
-}  
+}
 
 
 ### main logic ###


### PR DESCRIPTION
Signed-off-by: DL6ER <dl6er@dl6er.de>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Fix issue that FTL cannot be started on kernels / file systems that do not support Linux capabilities.

**How does this PR accomplish the above?:**

We should check if the kernel / file system supports Linux capabilities before trying to start `pihole-FTL` as unprivileged user as binding to port 53 will inevitably fail if capabilities are not supported. Several users confirmed that running `pihole-FTL` as `root` works just fine in these edge cases and we should maybe fall back to starting `pihole-FTL` under `root` (as it is done for `dnsmasq`).

This PR add a check if the `setcap` command succeeded and only tries to start `pihole-FTL` as unprivileged user application if this is the case (should almost always be the case).


**What documentation changes (if any) are needed to support this PR?:**

None, but might be worth mentioning in the 4.1 release blog post so people know that they do not have to manually edit their service file any more.