### PR TITLE
Improve /etc/dnsmasq.conf handling

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2113,6 +2113,7 @@ FTLinstall() {
             # /etc/dnsmasq.conf contains only "conf-dir=/etc/dnsmasq.d"
             local conffile="/etc/dnsmasq.conf"
             if [[ -f "${conffile}" ]]; then
+                echo "  ${INFO} Backing up ${conffile} to ${conffile}.old"
                 mv "${conffile}" "${conffile}.old"
             fi
             # Create /etc/dnsmasq.conf

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1092,7 +1092,7 @@ chooseBlocklists() {
 }
 
 # Accept a string parameter, it must be one of the default lists
-# This function allow to not duplicate code in chooseBlocklists and 
+# This function allow to not duplicate code in chooseBlocklists and
 # in installDefaultBlocklists
 appendToListsFile() {
     case $1 in
@@ -1113,7 +1113,7 @@ installDefaultBlocklists() {
     # If this file exists, we avoid overriding it.
     if [[ -f "${adlistFile}" ]]; then
         return;
-    fi  
+    fi
     appendToListsFile StevenBlack
     appendToListsFile MalwareDom
     appendToListsFile Cameleon
@@ -2109,12 +2109,14 @@ FTLinstall() {
                 fi
             fi
 
-            #ensure /etc/dnsmasq.conf contains `conf-dir=/etc/dnsmasq.d`
-            confdir="conf-dir=/etc/dnsmasq.d"
-            conffile="/etc/dnsmasq.conf"
-            if ! grep -q "$confdir" "$conffile"; then
-                echo "$confdir" >> "$conffile"
+            # Backup existing /etc/dnsmasq.conf if present and ensure that
+            # /etc/dnsmasq.conf contains only "conf-dir=/etc/dnsmasq.d"
+            local conffile="/etc/dnsmasq.conf"
+            if [[ -f "${conffile}" ]]; then
+                mv "${conffile}" "${conffile}.old"
             fi
+            # Create /etc/dnsmasq.conf
+            echo "conf-dir=/etc/dnsmasq.d" > "${conffile}"
 
             return 0
         # Otherwise,
@@ -2483,7 +2485,7 @@ main() {
     echo -e "  ${INFO} Restarting services..."
     # Start services
 
-    # Enable FTL 
+    # Enable FTL
     # Ensure the service is enabled before trying to start it
     # Fixes a problem reported on Ubuntu 18.04 where trying to start
     # the service before enabling causes installer to exit


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Fix an issue with when an advanced `dnsmasq` configuration is already present on a system, a Pi-hole installation may cause an invalid configuration. This PR fixes https://github.com/pi-hole/FTL/issues/360.

Example: Assume a user has a full `dnsmasq` configuration in his `/etc/dnsmasq.conf`. On installation, our installer puts new files into `/etc/dnsmasq.d` and adds a line to `/etc/dnsmasq.conf` that all files in this new directory should be read in. If, however, the user already specified the cache size and we do it again in `01-pihole.conf`, this creates a situation in which `pihole-FTL` (resp. `dnsmasq`) cannot be started due to duplicated configuration.

**How to reproduce**: Put `cache-size=150` into your `/etc/dnsmasq.d` and install Pi-hole. The installation does not finish as the configuration we add prevents the DNS server from being able to start.

**How does this PR accomplish the above?:**

- Backup existing `/etc/dnsmasq.conf` if present (rename to `/etc/dnsmasq.conf.old`)
- Ensure that `/etc/dnsmasq.conf` contains **only** `conf-dir=/etc/dnsmasq.d`


**What documentation changes (if any) are needed to support this PR?:**

None