### PR TITLE
Don't use extra query logging

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -39,7 +39,7 @@ interface=@INT@
 
 cache-size=10000
 
-log-queries=extra
+log-queries
 log-facility=/var/log/pihole.log
 
 local-ttl=2


### PR DESCRIPTION
Signed-off-by: DL6ER <dl6er@dl6er.de>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Remove extra logging that was introduced in https://github.com/pi-hole/pi-hole/pull/1859 about 8 months ago as we do not use this file any more for statistics processing.


**How does this PR accomplish the above?:**

Revert #1859


**What documentation changes (if any) are needed to support this PR?:**

Unclear, probably none, however, the proper function of `pihole -t` should be verified (although it shouldn't depend on whether extra is enabled or not).