### PR TITLE
Set FTL Privacy Level During Install

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1035,7 +1035,7 @@ setPrivacyLevel() {
     # Get the user's choice
     PRIVACY_LEVEL=$("${LevelCommand[@]}" "${LevelOptions[@]}" 2>&1 >/dev/tty) || (echo -e "  ${COL_LIGHT_RED}Cancel was selected, exiting installer${COL_NC}" && exit 1)
 
-    echo -e "  ${INFO} Privacy level ${PRIVACY_LEVEL}"
+    printf "  %b Privacy level %d" "${INFO}" "${PRIVACY_LEVEL}"
 }
 
 # Function to ask the user if they want to install the dashboard

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1035,7 +1035,7 @@ setPrivacyLevel() {
     # Get the user's choice
     PRIVACY_LEVEL=$("${LevelCommand[@]}" "${LevelOptions[@]}" 2>&1 >/dev/tty) || (echo -e "  ${COL_LIGHT_RED}Cancel was selected, exiting installer${COL_NC}" && exit 1)
 
-    echo -en "  ${INFO} Privacy level ${PRIVACY_LEVEL}"
+    echo -e "  ${INFO} Privacy level ${PRIVACY_LEVEL}"
 }
 
 # Function to ask the user if they want to install the dashboard

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1020,39 +1020,20 @@ setLogging() {
 setPrivacyLevel() {
     local LevelCommand
     local LevelOptions
-    local LevelChoice
 
     LevelCommand=(whiptail --separate-output --radiolist "Select a privacy mode for FTL." "${r}" "${c}" 6)
 
     # The default selection is level 0
     LevelOptions=(
-        "0 - Show everything" on
-        "1 - Hide domains" off
-        "2 - Hide domains and clients" off
-        "3 - Anonymous mode" off
-        "4 - Disabled statistics" off
+        "0" "Show everything" on
+        "1" "Hide domains" off
+        "2" "Hide domains and clients" off
+        "3" "Anonymous mode" off
+        "4" "Disabled statistics" off
     )
 
     # Get the user's choice
-    LevelChoice=$("${LevelCommand[@]}" "${LevelOptions[@]}" 2>&1 >/dev/tty) || (echo -e "  ${COL_LIGHT_RED}Cancel was selected, exiting installer${COL_NC}" && exit 1)
-
-    case "${LevelChoice}" in
-        "0 - Show everything")
-            PRIVACY_LEVEL=0
-            ;;
-        "1 - Hide domains")
-            PRIVACY_LEVEL=1
-            ;;
-        "2 - Hide domains and clients")
-            PRIVACY_LEVEL=2
-            ;;
-        "3 - Anonymous mode")
-            PRIVACY_LEVEL=3
-            ;;
-        "4 - Disabled statistics")
-            PRIVACY_LEVEL=4
-            ;;
-    esac
+    PRIVACY_LEVEL=$("${LevelCommand[@]}" "${LevelOptions[@]}" 2>&1 >/dev/tty) || (echo -e "  ${COL_LIGHT_RED}Cancel was selected, exiting installer${COL_NC}" && exit 1)
 
     echo -en "  ${INFO} Privacy level ${PRIVACY_LEVEL}"
 }

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -81,6 +81,7 @@ def test_setupVars_saved_to_file(Pihole):
     {}
     mkdir -p /etc/dnsmasq.d
     version_check_dnsmasq
+    echo "" > /etc/pihole/pihole-FTL.conf
     finalExports
     cat /etc/pihole/setupVars.conf
     '''.format(set_setup_vars))


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Set privacy level during install.

**How does this PR accomplish the above?:**
Give the user a prompt to select the privacy level during install.

**What documentation changes (if any) are needed to support this PR?:**
Possibly mention that the privacy level can be set during install and when reconfiguring.