### PR TITLE
Ensure proper unprivileged user if pihole-FTL is started as root

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -24,6 +24,9 @@ addn-hosts=/etc/pihole/gravity.list
 addn-hosts=/etc/pihole/black.list
 addn-hosts=/etc/pihole/local.list
 
+user=pihole
+group=pihole
+
 domain-needed
 
 localise-queries


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Ensure that when pihole-FTL is launched as user `root` (it will drop permissions as soon as this is possible), it drops down to `pihole:pihole` instead of the default `nobody:nogroup`.

This is necessary as `pihole-FTL` needs to be able to periodically create new files - namely the [SQLite3 rollback journals](https://www.sqlite.org/lockingv3.html#rollback) - in `/etc/pihole`. As user `nobody`, however, cannot do this, the current way of handling this leads to a failure of our long-term database implementation.

**How does this PR accomplish the above?:**

Use appropriate `dnsmasq` options to instruct the code to not go to `nobody:nogroup` but rather `pihole:pihole`.
