### PR TITLE
Fix checkout error due to readonly variable

### DIFF
--- a/pihole
+++ b/pihole
@@ -12,7 +12,12 @@
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 readonly gravitylist="/etc/pihole/gravity.list"
 readonly blacklist="/etc/pihole/black.list"
-readonly setupVars="/etc/pihole/setupVars.conf"
+
+# setupVars is not readonly here because in some funcitons (checkout),
+# it might get set again when the installer is sourced. This causes an
+# error due to modifying a readonly variable.
+setupVars="/etc/pihole/setupVars.conf"
+
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix this `pihole checkout` error:
```
$ pihole checkout master
/etc/.pihole/automated install/basic-install.sh: line 34: setupVars: readonly variable
```

**How does this PR accomplish the above?:**
Change the `setupVars` variable in `pihole` from read only to not read only.

**What documentation changes (if any) are needed to support this PR?:**
None, this issue is only in dev.