### PR TITLE
Remove Norton Connect Safe as its EOL 2018-11-15

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -858,7 +858,6 @@ setDNS() {
     DNSChooseOptions=(Google ""
         OpenDNS ""
         Level3 ""
-        Norton ""
         Comodo ""
         DNSWatch ""
         Quad9 ""
@@ -889,11 +888,6 @@ setDNS() {
             echo "Level3 servers"
             PIHOLE_DNS_1="4.2.2.1"
             PIHOLE_DNS_2="4.2.2.2"
-            ;;
-        Norton)
-            echo "Norton ConnectSafe servers"
-            PIHOLE_DNS_1="199.85.126.10"
-            PIHOLE_DNS_2="199.85.127.10"
             ;;
         Comodo)
             echo "Comodo Secure servers"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [] I have commented my proposed changes within the code.
- [] I have tested my proposed changes, and have included unit tests where possible.
- [] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*

While looking at the docs I looked at Norton Connect safe and noticed its EOL soon, so thought to send in a PR to remove it, See https://connectsafe.norton.com

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

Removes the offending option

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*

Wiki page (https://github.com/pi-hole/pi-hole/wiki/Upstream-DNS-Providers) needs updating

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

