### PR TITLE
Read without -r will mangle backslashes. (Fix)

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -907,7 +907,7 @@ parse_file() {
         #shellcheck disable=SC2016
         IFS=$'\r\n' command eval 'file_info=( $(cat "${filename}") )'
     else
-        read -a file_info <<< $filename
+        read -a -r file_info <<< $filename
     fi
     # Set a named variable for better readability
     local file_lines

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -110,7 +110,7 @@ SetWebPassword() {
         # Prevents a bug if the user presses Ctrl+C and it continues to hide the text typed.
         # So we reset the terminal via stty if the user does press Ctrl+C
         trap '{ echo -e "\nNo password will be set" ; stty sane ; exit 1; }' INT
-        read -s -p "Enter New Password (Blank for no password): " PASSWORD
+        read -s -p -r "Enter New Password (Blank for no password): " PASSWORD
         echo ""
 
     if [ "${PASSWORD}" == "" ]; then
@@ -119,7 +119,7 @@ SetWebPassword() {
         exit 0
     fi
 
-    read -s -p "Confirm Password: " CONFIRM
+    read -s -p -r "Confirm Password: " CONFIRM
     echo ""
     fi
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
*As the title says I just added a "-r" to stop `read` from mangling backslashes.*


**How does this PR accomplish the above?:**
*I added `-r` in front of `read`*

---
Signed-off-by: Auron Hines <ghostslayer989@outlook.com> (Sorry I forgot)

