### PR TITLE
Improve pihole-FTL.conf template

### DIFF
--- a/advanced/Templates/pihole-FTL.conf
+++ b/advanced/Templates/pihole-FTL.conf
@@ -1,84 +1,84 @@
-### This file contains parameters for FTL behavior.
-### At install, all parameters are commented out. The user can select desired options.
-### Options shown are the default configuration. No modification is needed for most
-### installations.
-### Visit https://docs.pi-hole.net/ftldns/configfile/ for more detailed parameter explanations
+;;; This file contains parameters for FTL behavior.
+;;; At install, all parameters are commented out. The user can select desired options.
+;;; Options shown are the default configuration. No modification is needed for most
+;;; installations.
+;;; Visit https://docs.pi-hole.net/ftldns/configfile/ for more detailed parameter explanations
 
-## Socket Listening
-## Listen only for local socket connections or permit all connections
-## Options: localonly, all
-#SOCKET_LISTENING=localonly
+;; Socket Listening
+;; Listen only for local socket connections or permit all connections
+;; Options: localonly, all
+;SOCKET_LISTENING=localonly
 
-## Query Display
-## Display all queries? Set to no to hide query display
-## Options: yes, no
-#QUERY_DISPLAY=yes
+;; Query Display
+;; Display all queries? Set to no to hide query display
+;; Options: yes, no
+;QUERY_DISPLAY=yes
 
-## AAA Query Analysis
-## Allow FTL to analyze AAAA queries from pihole.log?
-## Options: yes, no
-#AAAA_QUERY_ANALYSIS=yes
+;; AAA Query Analysis
+;; Allow FTL to analyze AAAA queries from pihole.log?
+;; Options: yes, no
+;AAAA_QUERY_ANALYSIS=yes
 
-## Resolve IPv6
-## Should FTL try to resolve IPv6 addresses to host names?
-## Options: yes, no
-#RESOLVE_IPV6=yes
+;; Resolve IPv6
+;; Should FTL try to resolve IPv6 addresses to host names?
+;; Options: yes, no
+;RESOLVE_IPV6=yes
 
-## Resolve IPv4
-## Should FTL try to resolve IPv4 addresses to host names?
-## Options: yes, no
-#RESOLVE_IPV4=yes
+;; Resolve IPv4
+;; Should FTL try to resolve IPv4 addresses to host names?
+;; Options: yes, no
+;RESOLVE_IPV4=yes
 
-## Max Database Days
-## How long should queries be stored in the database (days)?
-## Setting this to 0 disables the database
-## See: https://docs.pi-hole.net/ftldns/database/
-## Options: number of days
-#MAXDBDAYS=365
+;; Max Database Days
+;; How long should queries be stored in the database (days)?
+;; Setting this to 0 disables the database
+;; See: https://docs.pi-hole.net/ftldns/database/
+;; Options: number of days
+;MAXDBDAYS=365
 
-## Database Interval
-## How often do we store queries in FTL's database (minutes)?
-## See: https://docs.pi-hole.net/ftldns/database/
-## Options: number of minutes
-#DBINTERVAL=1.0
+;; Database Interval
+;; How often do we store queries in FTL's database (minutes)?
+;; See: https://docs.pi-hole.net/ftldns/database/
+;; Options: number of minutes
+;DBINTERVAL=1.0
 
-## Database File
-## Specify path and filename of FTL's SQLite3 long-term database.
-## Setting this to DBFILE= disables the database altogether
-## See: https://docs.pi-hole.net/ftldns/database/
-## Option: path to db file
-#DBFILE=/etc/pihole/pihole-FTL.db
+;; Database File
+;; Specify path and filename of FTL's SQLite3 long-term database.
+;; Setting this to DBFILE= disables the database altogether
+;; See: https://docs.pi-hole.net/ftldns/database/
+;; Option: path to db file
+;DBFILE=/etc/pihole/pihole-FTL.db
 
-## Max Log Age
-## Up to how many hours of queries should be imported from the database and logs (hours)?
-## Maximum is 744 (31 days)
-## Options: number of days
-#MAXLOGAGE=24.0
+;; Max Log Age
+;; Up to how many hours of queries should be imported from the database and logs (hours)?
+;; Maximum is 744 (31 days)
+;; Options: number of days
+;MAXLOGAGE=24.0
 
-## FTL Port
-## On which port should FTL be listening?
-## Options: tcp port
-#FTLPORT=4711
+;; FTL Port
+;; On which port should FTL be listening?
+;; Options: tcp port
+;FTLPORT=4711
 
-## Privacy Level
-## Which privacy level is used?
-## See: https://docs.pi-hole.net/ftldns/privacylevels/
-## Options: 0, 1, 2, 3
-#PRIVACYLEVEL=0
+;; Privacy Level
+;; Which privacy level is used?
+;; See: https://docs.pi-hole.net/ftldns/privacylevels/
+;; Options: 0, 1, 2, 3
+;PRIVACYLEVEL=0
 
-## Ignore Localhost
-## Should FTL ignore queries coming from the local machine?
-## Options: yes, no
-#IGNORE_LOCALHOST=no
+;; Ignore Localhost
+;; Should FTL ignore queries coming from the local machine?
+;; Options: yes, no
+;IGNORE_LOCALHOST=no
 
-## Blocking Mode
-## How should FTL reply to blocked queries?
-## See: https://docs.pi-hole.net/ftldns/blockingmode/
-## Options: NULL, IP-AAAA-NODATA, IP, NXDOMAIN
-#BLOCKINGMODE=NULL
+;; Blocking Mode
+;; How should FTL reply to blocked queries?
+;; See: https://docs.pi-hole.net/ftldns/blockingmode/
+;; Options: NULL, IP-AAAA-NODATA, IP, NXDOMAIN
+;BLOCKINGMODE=NULL
 
-## Regex Debug Mode
-## Controls if FTLDNS should print extended details about regex matching into pihole-FTL.log.
-## See: https://docs.pi-hole.net/ftldns/regex/overview/
-## Options: true, false
-#REGEX_DEBUGMODE=false
+;; Regex Debug Mode
+;; Controls if FTLDNS should print extended details about regex matching into pihole-FTL.log.
+;; See: https://docs.pi-hole.net/ftldns/regex/overview/
+;; Options: true, false
+;REGEX_DEBUGMODE=false


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

According to the PHP documentation, PHP 7.0.0+ does not longer recognize hash marks (`#`) as comments. As FTL has been trained to understand PHP-style (comment lines start with `;`) as well, we switch to using them.

This solves https://github.com/pi-hole/FTL/issues/391


**How does this PR accomplish the above?:**

Replace `#` by `;` in advances/Templates/pihole-FTL.conf


**What documentation changes (if any) are needed to support this PR?:**

None