### PR TITLE
Fix error when reading in new password

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -907,7 +907,7 @@ parse_file() {
         #shellcheck disable=SC2016
         IFS=$'\r\n' command eval 'file_info=( $(cat "${filename}") )'
     else
-        read -a -r file_info <<< "$filename"
+        read -r -a file_info <<< "$filename"
     fi
     # Set a named variable for better readability
     local file_lines

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -110,7 +110,7 @@ SetWebPassword() {
         # Prevents a bug if the user presses Ctrl+C and it continues to hide the text typed.
         # So we reset the terminal via stty if the user does press Ctrl+C
         trap '{ echo -e "\nNo password will be set" ; stty sane ; exit 1; }' INT
-        read -s -p -r "Enter New Password (Blank for no password): " PASSWORD
+        read -s -p "Enter New Password (Blank for no password): " PASSWORD
         echo ""
 
     if [ "${PASSWORD}" == "" ]; then
@@ -119,7 +119,7 @@ SetWebPassword() {
         exit 0
     fi
 
-    read -s -p -r "Confirm Password: " CONFIRM
+    read -s -p "Confirm Password: " CONFIRM
     echo ""
     fi
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -111,7 +111,7 @@ SetWebPassword() {
         # So we reset the terminal via stty if the user does press Ctrl+C
         trap '{ echo -e "\nNo password will be set" ; stty sane ; exit 1; }' INT
         # shellcheck disable=SC2162
-        read -s -p "Enter New Password (Blank for no password): " PASSWORD
+        read -s -r -p "Enter New Password (Blank for no password): " PASSWORD
         echo ""
 
     if [ "${PASSWORD}" == "" ]; then
@@ -121,7 +121,7 @@ SetWebPassword() {
     fi
 
     # shellcheck disable=SC2162
-    read -s -p "Confirm Password: " CONFIRM
+    read -s -r -p "Confirm Password: " CONFIRM
     echo ""
     fi
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -110,6 +110,7 @@ SetWebPassword() {
         # Prevents a bug if the user presses Ctrl+C and it continues to hide the text typed.
         # So we reset the terminal via stty if the user does press Ctrl+C
         trap '{ echo -e "\nNo password will be set" ; stty sane ; exit 1; }' INT
+        # shellcheck disable=SC2162
         read -s -p "Enter New Password (Blank for no password): " PASSWORD
         echo ""
 
@@ -119,6 +120,7 @@ SetWebPassword() {
         exit 0
     fi
 
+    # shellcheck disable=SC2162
     read -s -p "Confirm Password: " CONFIRM
     echo ""
     fi

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -110,7 +110,6 @@ SetWebPassword() {
         # Prevents a bug if the user presses Ctrl+C and it continues to hide the text typed.
         # So we reset the terminal via stty if the user does press Ctrl+C
         trap '{ echo -e "\nNo password will be set" ; stty sane ; exit 1; }' INT
-        # shellcheck disable=SC2162
         read -s -r -p "Enter New Password (Blank for no password): " PASSWORD
         echo ""
 
@@ -120,7 +119,6 @@ SetWebPassword() {
         exit 0
     fi
 
-    # shellcheck disable=SC2162
     read -s -r -p "Confirm Password: " CONFIRM
     echo ""
     fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix crash when setting new password. See #2435 

**How does this PR accomplish the above?:**
Revert use of `-r` flag on the `read` command in `webpage.sh`'s `SetWebPassword` function.

**What documentation changes (if any) are needed to support this PR?:**
None