### PR TITLE
Append versions (after the first) instead of overwriting in updatecheck

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -54,11 +54,11 @@ if [[ "$2" == "remote" ]]; then
 
     if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
         GITHUB_WEB_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null)")"
-        echo -n " ${GITHUB_WEB_VERSION}" > "${GITHUB_VERSION_FILE}"
+        echo -n " ${GITHUB_WEB_VERSION}" >> "${GITHUB_VERSION_FILE}"
     fi
 
     GITHUB_FTL_VERSION="$(json_extract tag_name "$(curl -q 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null)")"
-    echo -n " ${GITHUB_FTL_VERSION}" > "${GITHUB_VERSION_FILE}"
+    echo -n " ${GITHUB_FTL_VERSION}" >> "${GITHUB_VERSION_FILE}"
 
 else
 
@@ -69,11 +69,11 @@ else
 
     if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
         WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
-        echo -n " ${WEB_BRANCH}" > "${LOCAL_BRANCH_FILE}"
+        echo -n " ${WEB_BRANCH}" >> "${LOCAL_BRANCH_FILE}"
     fi
 
     FTL_BRANCH="$(pihole-FTL branch)"
-    echo -n " ${FTL_BRANCH}" > "${LOCAL_BRANCH_FILE}"
+    echo -n " ${FTL_BRANCH}" >> "${LOCAL_BRANCH_FILE}"
 
     LOCAL_VERSION_FILE="/etc/pihole/localversions"
 
@@ -82,10 +82,10 @@ else
 
     if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
         WEB_VERSION="$(get_local_version /var/www/html/admin)"
-        echo -n " ${WEB_VERSION}" > "${LOCAL_VERSION_FILE}"
+        echo -n " ${WEB_VERSION}" >> "${LOCAL_VERSION_FILE}"
     fi
 
     FTL_VERSION="$(pihole-FTL version)"
-    echo -n " ${FTL_VERSION}" > "${LOCAL_VERSION_FILE}"
+    echo -n " ${FTL_VERSION}" >> "${LOCAL_VERSION_FILE}"
 
 fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fixes an issue brought up in #2435 where the versions were not saved properly and showed up incorrectly on the web interface.

**How does this PR accomplish the above?:**
After writing the first version to the file, append the rest of the versions so nothing else gets overwritten.

**What documentation changes (if any) are needed to support this PR?:**
None (this is a regression from master)