### PR TITLE
fix pihole user creation function

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1633,15 +1633,18 @@ create_pihole_user() {
     # If the user pihole exists,
     if id -u pihole &> /dev/null; then
         # just show a success
-        echo -ne "${OVER}  ${TICK} ${str}"
+        echo -e "${OVER}  ${TICK} ${str}"
     # Otherwise,
     else
         echo -ne "${OVER}  ${CROSS} ${str}"
         local str="Creating user 'pihole'"
-        echo -ne "  ${INFO} ${str}..."
+        echo -ne "${OVER}  ${INFO} ${str}..."
         # create her with the useradd command
-        useradd -r -s /usr/sbin/nologin pihole
-        echo -ne "${OVER}  ${TICK} ${str}"
+        if useradd -r -s /usr/sbin/nologin pihole; then
+          echo -e "${OVER}  ${TICK} ${str}"
+        else
+          echo -e "${OVER}  ${CROSS} ${str}"
+        fi
     fi
 }
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
 - fix stdout newlines
 - catch failed user creation

BEFORE:
```
  [✓] Enabling lighttpd service to start on reboot
  [✓] Creating user 'pihole'  [i] Warning: 'lighty-enable-mod' utility not found
                Please ensure fastcgi is enabled if you experience issues

  [✓] Installing scripts from /etc/.pihole
```
AFTER:
```
  [✓] Enabling lighttpd service to start on reboot
  [✓] Creating user 'pihole'
  [i] Warning: 'lighty-enable-mod' utility not found
                Please ensure fastcgi is enabled if you experience issues

  [✓] Installing scripts from /etc/.pihole
```

**How does this PR accomplish the above?:**
- replace `echo -ne` with `echo -e` where applicable
- wrap the useradd command with an `if` statement

**What documentation changes (if any) are needed to support this PR?:**
n/a
