### PR TITLE
 Silence updateGravity cron job unless errors occur

### DIFF
--- a/advanced/Templates/pihole.cron
+++ b/advanced/Templates/pihole.cron
@@ -16,7 +16,9 @@
 
 # Pi-hole: Update the ad sources once a week on Sunday at a random time in the
 #          early morning. Download any updates from the adlists
-59 1    * * 7   root    PATH="$PATH:/usr/local/bin/" pihole updateGravity
+#          Squash output to log, then splat the log to stdout on error to allow for
+#          standard crontab job error handling.
+59 1    * * 7   root    PATH="$PATH:/usr/local/bin/" pihole updateGravity >/var/log/pihole_updateGravity.log || cat /var/log/pihole_updateGravity.log
 
 # Pi-hole: Flush the log daily at 00:00
 #          The flush script will use logrotate if available

--- a/pihole
+++ b/pihole
@@ -80,7 +80,7 @@ reconfigurePiholeFunc() {
 
 updateGravityFunc() {
   "${PI_HOLE_SCRIPT_DIR}"/gravity.sh "$@"
-  exit 0
+  exit $?
 }
 
 queryFunc() {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Quieten the updateGravity cron job for successful runs.
Fixes pi-hole/pi-hole#2424

**How does this PR accomplish the above?:**
Update the Pi-hole cron file to pipe all stdout to a log file.
Display all logged output to stdout if exit code not zero, via || command linking.
Requires minor tweak of pihole master script to return exit code from gravity.sh to cron parent process.

**What documentation changes (if any) are needed to support this PR?:**
None.  Cron file contains comments to explain the more complex command structure.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

