### PR TITLE
fix debug service check via sysvinit

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -836,9 +836,13 @@ process_status(){
             local status_of_process
             status_of_process=$(systemctl is-active "${i}")
         else
-            # Otherwise, use the service command
+            # Otherwise, use the service command and mock the output of `systemctl is-active`
             local status_of_process
-            status_of_process=$(service "${i}" status | awk '/Active:/ {print $2}') &> /dev/null
+            if service "${i}" status | grep -E 'is\srunning' &> /dev/null; then
+                status_of_process="active"
+            else
+                status_of_process="inactive"
+            fi
         fi
         # and print it out to the user
         if [[ "${status_of_process}" == "active" ]]; then


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. 

---
**What does this PR aim to accomplish?:**
Currently the debug script will only properly report process/service status on on systems with systemd present due to the check for systemd style stdout.  

Init only distro service status stdout:
```
root@debian-wheezy:~# service lighttpd status
[ ok ] lighttpd is running.
root@debian-wheezy:~# service lighttpd stop
[ ok ] Stopping web server: lighttpd.
root@debian-wheezy:~# service lighttpd status
[FAIL] lighttpd is not running ... failed!
root@debian-wheezy:~# 
```
Another init based distro (unsupported but still an example of init stdout)
```
[root@centos6 ~]# service lighttpd status
lighttpd (pid  3423) is running...
[root@centos6 ~]# service lighttpd stop
Stopping lighttpd:                                         [  OK  ]
[root@centos6 ~]# service lighttpd status
lighttpd is stopped
[root@centos6 ~]# 
```
When systemd is present, all calls to the `service` command are re-directed to `systemctl`:
```
[bcambl@localhost ~]$ systemctl status docker
● docker.service - Docker Application Container Engine
   Loaded: loaded (/usr/lib/systemd/system/docker.service; enabled; vendor preset: disabled)
   Active: active (running) since ...

[bcambl@localhost ~]$ service docker status
Redirecting to /bin/systemctl status docker.service
● docker.service - Docker Application Container Engine
   Loaded: loaded (/usr/lib/systemd/system/docker.service; enabled; vendor preset: disabled)
   Active: active (running) since ...
[bcambl@localhost pi-hole]$ 

```

**How does this PR accomplish the above?:**
Change the stdout check of the service command to use `is running` instead of `Active`.


**What documentation changes (if any) are needed to support this PR?:**
The in-line comment has been updated.
