### PR TITLE
Revert "lighttpd conf enhancements"

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -72,4 +72,5 @@ $HTTP["url"] =~ "^/admin/\.(.*)" {
 }
 
 # Add user chosen options held in external file
+# This uses include_shell instead of an include wildcard for compatibility
 include_shell "cat external.conf 2>/dev/null"

--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -64,13 +64,12 @@ $HTTP["url"] =~ "^/admin/" {
         # Allow Block Page access to local fonts
         setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
     }
+}
 
-    # Block . files from being served, such as .git, .github, .gitignore
-    $HTTP["url"] =~ "^/admin/\." {
-         url.access-deny = ("")
-    }
+# Block . files from being served, such as .git, .github, .gitignore
+$HTTP["url"] =~ "^/admin/\.(.*)" {
+     url.access-deny = ("")
 }
 
 # Add user chosen options held in external file
-# (use file glob for optional file)
-include "external*.conf"
+include_shell "cat external.conf 2>/dev/null"

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -90,4 +90,5 @@ $HTTP["url"] =~ "^/admin/\.(.*)" {
 }
 
 # Add user chosen options held in external file
+# This uses include_shell instead of an include wildcard for compatibility
 include_shell "cat external.conf 2>/dev/null"

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -82,13 +82,12 @@ $HTTP["url"] =~ "^/admin/" {
         # Allow Block Page access to local fonts
         setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
     }
+}
 
-    # Block . files from being served, such as .git, .github, .gitignore
-    $HTTP["url"] =~ "^/admin/\." {
-         url.access-deny = ("")
-    }
+# Block . files from being served, such as .git, .github, .gitignore
+$HTTP["url"] =~ "^/admin/\.(.*)" {
+     url.access-deny = ("")
 }
 
 # Add user chosen options held in external file
-# (use file glob for optional file)
-include "external*.conf"
+include_shell "cat external.conf 2>/dev/null"


### PR DESCRIPTION
Based on some internal testing, versions of `lighttpd` lower than `1.4.50` will fall over with this config. 

Suggest we revert this change and stick with the "workaround" fix to create the external config file if it does not exist.