### PR TITLE
Fix restartDNS returning code 1 even when it worked

### DIFF
--- a/pihole
+++ b/pihole
@@ -134,9 +134,11 @@ restartDNS() {
 
   if [[ "${status}" -eq 0 ]]; then
     [[ -t 1 ]] && echo -e "${OVER}  ${TICK} ${str}"
+    return 0
   else
     [[ ! -t 1 ]] && local OVER=""
     echo -e "${OVER}  ${CROSS} ${output}"
+    return 1
   fi
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
If stdout was not a terminal (the `-t 1` check), `restartDNS` wouldreturn code 1 in the success case. This caused the API to fail whenever it tried to restart the DNS server.

**How does this PR accomplish the above?:**
`restartDNS` now returns the right success or error code (0 or 1) at the end of the function.

**What documentation changes (if any) are needed to support this PR?:**
None