### PR TITLE
Account for non-standard ports in DNS server addresses.

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -257,11 +257,11 @@ gravity_DownloadBlocklistFromUrl() {
    esac
 
   if [[ "${blocked}" == true ]]; then
-    printf -v ip_addr "%s" ${PIHOLE_DNS_1%#*}
+    printf -v ip_addr "%s" "${PIHOLE_DNS_1%#*}"
     if [[ ${PIHOLE_DNS_1} != *"#"* ]]; then
         port=53
     else
-        printf -v port "%s" ${PIHOLE_DNS_1#*#}
+        printf -v port "%s" "${PIHOLE_DNS_1#*#}"
     fi
     ip=$(dig "@${ip_addr}" -p "${port}" +short "${domain}")
     if [[ $(echo "${url}" | awk -F '://' '{print $1}') = "https" ]]; then

--- a/gravity.sh
+++ b/gravity.sh
@@ -257,7 +257,13 @@ gravity_DownloadBlocklistFromUrl() {
    esac
 
   if [[ "${blocked}" == true ]]; then
-    ip=$(dig "@${PIHOLE_DNS_1}" +short "${domain}")
+    printf -v ip_addr "%s" ${PIHOLE_DNS_1%#*}
+    if [[ ${PIHOLE_DNS_1} != *"#"* ]]; then
+        port=53
+    else
+        printf -v port "%s" ${PIHOLE_DNS_1#*#}
+    fi
+    ip=$(dig "@${ip_addr}" -p "${port}" +short "${domain}")
     if [[ $(echo "${url}" | awk -F '://' '{print $1}') = "https" ]]; then
       port=443;
     else port=80


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fixes #2482 

Accommodate for '#' in PIHOLE_DNS_1 from setupVars.conf

**How does this PR accomplish the above?:**
Test and split on '#'