### PR TITLE
Added universe repo check for Ubuntu bionic.

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -165,6 +165,14 @@ if is_command apt-get ; then
     # grep -c will return 1 retVal on 0 matches, block this throwing the set -e with an OR TRUE
     PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
     # Some distros vary slightly so these fixes for dependencies may apply
+    # on Ubuntu 18.04.1 LTS we need to add the universe repository to gain access to dialog and dhcpcd5
+    APT_SOURCES="/etc/apt/sources.list"
+    if awk 'BEGIN{a=1;b=0}/bionic main/{a=0}/bionic.*universe/{b=1}END{exit a + b}' ${APT_SOURCES}; then
+        printf "  %b Enabling universe package repository for Ubuntu bionic\\n" "${INFO}"
+        sudo cp ${APT_SOURCES} ${APT_SOURCES}.backup
+        sudo sed -i 's/bionic main/bionic main universe/g' ${APT_SOURCES}
+        printf "  %b Enabled %s\\n" "${TICK}" "universe-repo"
+    fi
     # Debian 7 doesn't have iproute2 so if the dry run install is successful,
     if ${PKG_MANAGER} install --dry-run iproute2 > /dev/null 2>&1; then
         # we can install it


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Commit signed.

---
**What does this PR aim to accomplish?:**
Closes pi-hole/pi-hole#2447


**How does this PR accomplish the above?:**
As noted in the issue documentation, Ubuntu Server 18.04.1 LTS Live installer no longer includes *universe* as an enabled repo.  Upgrades from 18.04 were unaffected, but with the newer installer for Ubuntu Bionic - pihole was unable to pull packages for *dialog* or *dhcpcd5*.

While there may be a better place to position my code, I grouped it in the area where __apt__ has already been identified as the package manager.  From there, I check to see if /etc/apt/sources.list contains *bionic* __without__ *universe*.  If so, I add universe to the repos.  If not, the code does nothing.

I attempted to mimic the code style already present for modifying `EPEL_PKG="epel-release"` in the yum repos.

__I tested my code__ by making this change AND updating the curl reflection to my own GitHub raw source code.  On a freshly installed 18.04.1 LTS Server, the test code was successful.

**What documentation changes (if any) are needed to support this PR?:**
It is not clear if documentation changes are needed.  A backup of the repo sources.list file is conducted for recovery if needed.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

