### PR TITLE
Don't show web version in pihole -v output if not installed

### DIFF
--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -136,8 +136,16 @@ errorOutput() {
 }
 
 defaultOutput() {
+    # Source the setupvars config file
+    # shellcheck disable=SC1091
+    . /etc/pihole/setupVars.conf
+
     versionOutput "pi-hole" "$@"
-    versionOutput "AdminLTE" "$@"
+
+    if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
+        versionOutput "AdminLTE" "$@"
+    fi
+
     versionOutput "FTL" "$@"
 }
 

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -138,7 +138,7 @@ errorOutput() {
 defaultOutput() {
     # Source the setupvars config file
     # shellcheck disable=SC1091
-    . /etc/pihole/setupVars.conf
+    source /etc/pihole/setupVars.conf
 
     versionOutput "pi-hole" "$@"
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix #2546 

**How does this PR accomplish the above?:**
Only run the web version check if the web interface has been installed.

**What documentation changes (if any) are needed to support this PR?:**
None