### PR TITLE
Ignore COL_TABLE if the the file does not exists

### DIFF
--- a/pihole
+++ b/pihole
@@ -19,7 +19,9 @@ readonly blacklist="/etc/pihole/black.list"
 setupVars="/etc/pihole/setupVars.conf"
 
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
-source "${colfile}"
+if [[ -e "${colfile}" ]]; then
+  source "${colfile}"
+fi
 
 resolver="pihole-FTL"
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Ignore COL_TABLE if the the file does not exists

If the file "${PI_HOLE_SCRIPT_DIR}/COL_TABLE" does not exists then pihole displayed an error:
```
$ ./pihole -h
./pihole: line 22: /opt/pihole/COL_TABLE: No such file or directory
```

Now the file is used *only* if it exists.

**How does this PR accomplish the above?:**
pihole now first check the file exists before using it.

I reused the same `if [[ -e "file" ]]; then` construction as found in other parts pihole.

**What documentation changes (if any) are needed to support this PR?:**
No documentation change needed.