### PR TITLE
Do not ask admin password just for help documentation

### DIFF
--- a/pihole
+++ b/pihole
@@ -23,17 +23,6 @@ source "${colfile}"
 
 resolver="pihole-FTL"
 
-# Must be root to use this tool
-if [[ ! $EUID -eq 0 ]];then
-  if [[ -x "$(command -v sudo)" ]]; then
-    exec sudo bash "$0" "$@"
-    exit $?
-  else
-    echo -e "  ${CROSS} sudo is needed to run pihole commands.  Please run this script as root or install sudo."
-    exit 1
-  fi
-fi
-
 webpageFunc() {
   source "${PI_HOLE_SCRIPT_DIR}/webpage.sh"
   main "$@"
@@ -428,6 +417,21 @@ Options:
 
 if [[ $# = 0 ]]; then
   helpFunc
+fi
+
+case "${1}" in
+  "-h" | "help" | "--help"      ) helpFunc;;
+esac
+
+# Must be root to use this tool
+if [[ ! $EUID -eq 0 ]];then
+  if [[ -x "$(command -v sudo)" ]]; then
+    exec sudo bash "$0" "$@"
+    exit $?
+  else
+    echo -e "  ${CROSS} sudo is needed to run pihole commands.  Please run this script as root or install sudo."
+    exit 1
+  fi
 fi
 
 # Handle redirecting to specific functions based on arguments


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
It is not a good idea to ask for an admin password just to get the command documentation.
"pihole -h" should return the arguments documentation with no need to enter a password.

Without the patch I get:
```
$ ./pihole -h
Password:
```

It is easy to reproduce by invalidating the sudo password using `sudo -k` before running pihole again.

**How does this PR accomplish the above?:**
Admin rights are now asked *after* arguments are checked for help.


**What documentation changes (if any) are needed to support this PR?:**
No documentation change needed.