### PR TITLE
Fix missed start_service -> restart_service call

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -167,7 +167,7 @@ checkout() {
             echo "  ${TICK} Branch ${2} exists"
             echo "${2}" > /etc/pihole/ftlbranch
             FTLinstall "${binary}"
-            start_service pihole-FTL
+            restart_service pihole-FTL
             enable_service pihole-FTL
         else
             echo "  ${CROSS} Requested branch \"${2}\" is not available"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
start_service was changed to restart_service, causing a bug in the checkout command.


**How does this PR accomplish the above?:**
Change the start_service call to restart_service.


**What documentation changes (if any) are needed to support this PR?:**
None