### PR TITLE
Remove user/group from dnsmasq config

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -22,9 +22,6 @@ addn-hosts=/etc/pihole/gravity.list
 addn-hosts=/etc/pihole/black.list
 addn-hosts=/etc/pihole/local.list
 
-user=pihole
-group=pihole
-
 domain-needed
 
 localise-queries


### PR DESCRIPTION
This is a hotfix release (just core), and will be merged to `master` and `development`

In the case that FTL is started under root, dnsmasq changes the user to pihole due to this setting. The shared memory is created before this switch, and may cause issues such as failing to delete or reallocate the shared memory.

These config lines were necessary before dnsmasq became part of FTL, but now since dnsmasq runs under FTL, we can configure the user/group through FTL.