### PR TITLE
Pi-hole Core v4.2.2

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -33,7 +33,8 @@ start() {
     mkdir -p /var/run/pihole
     mkdir -p /var/log/pihole
     chown pihole:pihole /var/run/pihole /var/log/pihole
-    rm /var/run/pihole/FTL.sock 2> /dev/null
+    # Remove possible leftovers from previous pihole-FTL processes in /var/run/pihole
+    rm -f /var/run/pihole/* 2> /dev/null
     # Ensure that permissions are set so that pihole-FTL can edit all necessary files
     chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port
     chown pihole:pihole /etc/pihole /etc/pihole/dhcp.leases 2> /dev/null


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Fix permission errors with shared memory objects

**How does this PR accomplish the above?:**

Make sure the `run` directory is emptied when starting `pihole-FTL`. If there are leftovers from previous `pihole-FTL` instances, we might get FTL crashes as the system prevents us from reading/writing to the shared memory objects if they are owned by a different user (e.g., `root`).

**What documentation changes (if any) are needed to support this PR?:**

None