### PR TITLE
Add git status/diff to debug log

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -269,6 +269,9 @@ compare_local_version_to_git_version() {
             # The commit they are on
             local remote_commit
             remote_commit=$(git describe --long --dirty --tags --always)
+            # Status of the repo
+            local local_status
+            local_status=$(git status -s)
             # echo this information out to the user in a nice format
             # If the current version matches what pihole -v produces, the user is up-to-date
             if [[ "${remote_version}" == "$(pihole -v | awk '/${search_term}/ {print $6}' | cut -d ')' -f1)" ]]; then
@@ -291,6 +294,16 @@ compare_local_version_to_git_version() {
             fi
             # echo the current commit
             log_write "${INFO} Commit: ${remote_commit}"
+            # if `local_status` is non-null, then the repo is not clean, display details here
+            if [[ ${local_status} ]]; then
+              #Replace new lines in the status with 12 spaces to make the output cleaner
+              log_write "${INFO} Status: ${local_status//$'\n'/'\n            '}"
+              local local_diff
+              local_diff=$(git diff)
+              if [[ ${local_diff} ]]; then
+                log_write "${INFO} Diff: ${local_diff//$'\n'/'\n          '}"
+              fi
+            fi
         # If git status failed,
         else
             # Return an error message


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Add some more verbosity to the debug script as regards the status of local repositories. This will hopefully give us some more insight into any modifications users may have made

Before:
```
*** [ DIAGNOSING ]: Core version
[i] Core: v4.2.2 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249)
[i] Branch: master
[i] Commit: v4.2.2-0-gba1e94d-dirty
```

After:
```
*** [ DIAGNOSING ]: Core version
[i] Core: v4.2.2 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249)
[i] Branch: master
[i] Commit: v4.2.2-0-gba1e94d-dirty
[i] Status:  M "automated install/uninstall.sh"
             M gravity.sh
            ?? anotherfile.exe
            ?? aroguefile.txt
[i] Diff: diff --git a/automated install/uninstall.sh b/automated install/uninstall.sh
          index 52760cf..c7e9389 100755
          --- a/automated install/uninstall.sh

          +++ b/automated install/uninstall.sh
          @@ -2,7 +2,7 @@
           # Pi-hole: A black hole for Internet advertisements
           # (c) 2017 Pi-hole, LLC (https://pi-hole.net)
           # Network-wide ad blocking via your own hardware.
          -#
          +# THIS SCRIPT IS BROKEN
           # Completely uninstalls Pi-hole
           #
           # This file is copyright under the latest version of the EUPL.
          diff --git a/gravity.sh b/gravity.sh
          index 75a5160..2452c96 100755
          --- a/gravity.sh
          +++ b/gravity.sh
          @@ -1,6 +1,6 @@
           #!/usr/bin/env bash
           # shellcheck disable=SC1090
          -
          +#Change
           # Pi-hole: A black hole for Internet advertisements
           # (c) 2017 Pi-hole, LLC (https://pi-hole.net)
           # Network-wide ad blocking via your own hardware.
```