### PR TITLE
Use capsh instead of setcap to start pihole-FTL

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -10,6 +10,7 @@
 ### END INIT INFO
 
 FTLUSER=pihole
+FTLBINARY=/usr/bin/pihole-FTL
 PIDFILE=/var/run/pihole-FTL.pid
 
 get_pid() {
@@ -42,10 +43,11 @@ start() {
     chown pihole:pihole /var/log/pihole-FTL.log /var/log/pihole.log
     chmod 0644 /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole.log
     echo "nameserver 127.0.0.1" | /sbin/resolvconf -a lo.piholeFTL
-    if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip "$(which pihole-FTL)"; then
-      su -s /bin/sh -c "/usr/bin/pihole-FTL" "$FTLUSER"
-    else
-      echo "Warning: Starting pihole-FTL as root because setting capabilities is not supported on this system"
+    # capsh --keep=1 --secbits=0x04 enables SECBIT_NO_SETUID_FIXUP preventing the kernel from
+    # stripping capabilities when changing from UID=0 to UID=nonzero
+    capsh --keep=1 --secbits=0x04 --caps="CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip" -- -c "runuser -u ${FTLUSER} ${FTLBINARY}"
+    if [ $? -ne 0 ]; then
+      echo "Warning: Starting pihole-FTL as root because capsh is not available on this system"
       pihole-FTL
     fi
     echo


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Change from using `setcap` to `capsh`.

This is done for two reasons:

1. Use `capsh` instead of `setcap` to allow running `pihole-FTL` as non-privileged user on filesystems that don't support capabilities.
2. Fixing a security issue. When using `setcap`, the binary is hot so that any user can now call it and take priv'd ports. When using `capsh` only `root` has that ability and it's only done during the `/etc/init.d/` calls, so the binary itself is just as normal as any other binary on the system.


**How does this PR accomplish the above?:**

Change from using `setcap` to `capsh`.

**What documentation changes (if any) are needed to support this PR?:**

None