### PR TITLE
Pin Python package versions to the versions in the last successful build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-docker-compose
-pytest
-pytest-xdist
-pytest-cov
-testinfra
-tox
+docker-compose==1.23.2
+pytest==4.3.0
+pytest-xdist==1.26.1
+pytest-cov==2.6.1
+testinfra==1.19.0
+tox==3.7.0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fix the CI tests. They have been failing due to unpinned Python package versions.
When `testinfra` became `2.0.0`, it removed the deprecated features that the tests currently use.

**How does this PR accomplish the above?:**
The last successful build was https://travis-ci.org/pi-hole/pi-hole/builds/500825408, so the versions have been pinned to those used in that build.


**What documentation changes (if any) are needed to support this PR?:**
None