### PR TITLE
Fix uninstalling lighttpd when it's not installed

### DIFF
--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -131,8 +131,7 @@ removeNoPurge() {
         echo -e "  ${TICK} Removed /etc/cron.d/pihole"
     fi
 
-    package_check lighttpd > /dev/null
-    if [[ $? -eq 1 ]]; then
+    if package_check lighttpd > /dev/null; then
         ${SUDO} rm -rf /etc/lighttpd/ &> /dev/null
         echo -e "  ${TICK} Removed lighttpd"
     else


### PR DESCRIPTION
Signed-off-by: Andrei Picus <NiGhTTraX@users.noreply.github.com>

**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Improves the uninstall process when it comes to uninstalling `lighttpd`. It addresses parts of https://github.com/pi-hole/pi-hole/issues/2136.


**How does this PR accomplish the above?:**
The `package_check` function returns exit code `1` if the package is not installed, therefore causing the uninstall script to exit if the function is called "standalone". However, when included in an `if` clause, it works as expected. This is identical to how it's used in the dependency removal step: 

https://github.com/NiGhTTraX/pi-hole/blob/b93fdb6ff19743f1ec6509fad702343f0bd5d7ae/automated%20install/uninstall.sh#L77


**What documentation changes (if any) are needed to support this PR?:**
None.
