### PR TITLE
Relative URLs for when PiHole interface is accessed via a (virtual) subfolder

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -58,8 +58,8 @@ if ($serverName === "pi.hole") {
     $splashPage = "
     <html><head>
         $viewPort
-        <link rel='stylesheet' href='/pihole/blockingpage.css' type='text/css'/>
-    </head><body id='splashpage'><img src='/admin/img/logo.svg'/><br/>Pi-<b>hole</b>: Your black hole for Internet advertisements<br><a href='/admin'>Did you mean to go to the admin panel?</a></body></html>
+        <link rel='stylesheet' href='./pihole/blockingpage.css' type='text/css'/>
+    </head><body id='splashpage'><img src='./admin/img/logo.svg'/><br/>Pi-<b>hole</b>: Your black hole for Internet advertisements<br><a href='./admin'>Did you mean to go to the admin panel?</a></body></html>
     ";
 
     // Set splash/landing page based off presence of $landPage


### PR DESCRIPTION
Signed-off-by: obones <obones@free.fr>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
This is a proposed fix for https://github.com/pi-hole/pi-hole/issues/2699


**How does this PR accomplish the above?:**
This adds a `.` dot in front of all URLs in the generated Splash page so that URLs are relative to the folder from where the content is served instead of being forced at the root of the webserver.


**What documentation changes (if any) are needed to support this PR?:**
None that comes to mind