### PR TITLE
Fix incorrect adlist query when an adlist is blocked during gravity

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -268,7 +268,7 @@ gravity_DownloadBlocklistFromUrl() {
       port=443;
     else port=80
     fi
-    bad_list=$(pihole -q -adlist hosts-file.net | head -n1 | awk -F 'Match found in ' '{print $2}')
+    bad_list=$(pihole -q -adlist "${domain}" | head -n1 | awk -F 'Match found in ' '{print $2}')
     echo -e "${OVER}  ${CROSS} ${str} ${domain} is blocked by ${bad_list%:}. Using DNS on ${PIHOLE_DNS_1} to download ${url}";
     echo -ne "  ${INFO} ${str} Pending..."
     cmd_ext="--resolve $domain:$port:$ip $cmd_ext"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fix the reason for an adlist being blocked to be empty, or if hosts-file.net was blocked, incorrect.

Example output:
```
  [i] Target: sysctl.org (hosts)
  [✗] Status: sysctl.org is blocked by . Using DNS on 8.8.8.8 to download http://sysctl.org/cameleon/hosts
  [✓] Status: No changes detected
```

**How does this PR accomplish the above?:**
hosts-file.net was hard-coded as the domain to check instead of the actual domain. Now the actual domain is checked.


**What documentation changes (if any) are needed to support this PR?:**
None