### PR TITLE
Handle an empty local.list

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -184,8 +184,8 @@ migrate_to_database() {
 gravity_CheckDNSResolutionAvailable() {
   local lookupDomain="pi.hole"
 
-  # Determine if $localList does not exist
-  if [[ ! -e "${localList}" ]]; then
+  # Determine if $localList does not exist, and ensure it is not empty
+  if [[ ! -e "${localList}" ]] || [[ -s "${localList}" ]]; then
     lookupDomain="raw.githubusercontent.com"
   fi
 


### PR DESCRIPTION
Handle the case of an empty local.list file which would otherwise prevent the system from starting

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
I've encountered situations where this file (local.list) has become corrupted/empty due to device power loss which then prevents the software from starting on reboot. This aims to handle that issue by checking for an empty (as well as missing) file. Example: https://forums.balena.io/t/cannot-reach-pi-hole-console/11495/16

**How does this PR accomplish the above?:**
Add check for empty file alongside missing file check

**What documentation changes (if any) are needed to support this PR?:**
None


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

