### PR TITLE
Add dhcp-ignore-names option when enabling DHCP service

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -41,8 +41,3 @@ log-facility=/var/log/pihole.log
 local-ttl=2
 
 log-async
-
-# If a DHCP client claims that its name is "wpad", ignore that.
-# This fixes a security hole. see CERT Vulnerability VU#598349
-dhcp-name-match=set:wpad-ignore,wpad
-dhcp-ignore-names=tag:wpad-ignore

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -366,6 +366,14 @@ EnableDHCP() {
     delete_dnsmasq_setting "dhcp-"
     delete_dnsmasq_setting "quiet-dhcp"
 
+    # If a DHCP client claims that its name is "wpad", ignore that.
+    # This fixes a security hole. see CERT Vulnerability VU#598349
+    # We also ignore "localhost" as Windows behaves strangely if a
+    # device claims this host name
+    add_dnsmasq_setting "dhcp-name-match=set:hostname-ignore,wpad
+dhcp-name-match=set:hostname-ignore,localhost
+dhcp-ignore-names=tag:hostname-ignore"
+
     ProcessDHCPSettings
 
     RestartDNS


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
We currently remove anything that starts with `dhcp-` to have a clean configuration and removed these lines without noticing when enabling the DHCP server.

We also add `localhost` as a privileged hostname we don't want to be claimed by any DHCP device.

This PR fixes a bug mentioned on [Discourse](https://discourse.pi-hole.net/t/fix-for-cert-vulnerability-vu-598349-disappeared/17299/7?u=dl6er).

**How does this PR accomplish the above?:**
Add `dhcp-ignore-names` option when enabling DHCP service.


**What documentation changes (if any) are needed to support this PR?:**
Probably none.