### PR TITLE
Replacing the hardcoded installation path in basic-install.sh and gravity.sh

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -49,8 +49,6 @@ setupVars=/etc/pihole/setupVars.conf
 # Pi-hole uses lighttpd as a Web server, and this is the config file for it
 # shellcheck disable=SC2034
 lighttpdConfig=/etc/lighttpd/lighttpd.conf
-# This is a file used for the colorized output
-coltable=/opt/pihole/COL_TABLE
 
 # Root of the web server
 webroot="/var/www/html"
@@ -67,6 +65,10 @@ PI_HOLE_INSTALL_DIR="/opt/pihole"
 PI_HOLE_CONFIG_DIR="/etc/pihole"
 PI_HOLE_BLOCKPAGE_DIR="${webroot}/pihole"
 useUpdateVars=false
+
+# This is a file used for the colorized output
+coltable="${PI_HOLE_INSTALL_DIR}/COL_TABLE"
+
 
 adlistFile="/etc/pihole/adlists.list"
 regexFile="/etc/pihole/regex.list"
@@ -1722,7 +1724,7 @@ installCron() {
 # which is what Pi-hole needs to begin blocking ads
 runGravity() {
     # Run gravity in the current shell
-    { /opt/pihole/gravity.sh --force; }
+    { ${PI_HOLE_INSTALL_DIR}/gravity.sh --force; }
 }
 
 # Check if the pihole user exists and create if it does not
@@ -2591,7 +2593,7 @@ main() {
             # generate a random password
             pw=$(tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 8)
             # shellcheck disable=SC1091
-            . /opt/pihole/webpage.sh
+            . ${PI_HOLE_INSTALL_DIR}/webpage.sh
             echo "WEBPASSWORD=$(HashPassword ${pw})" >> ${setupVars}
         fi
     fi
@@ -2627,8 +2629,8 @@ main() {
     runGravity
 
     # Force an update of the updatechecker
-    /opt/pihole/updatecheck.sh
-    /opt/pihole/updatecheck.sh x remote
+    ${PI_HOLE_INSTALL_DIR}/updatecheck.sh
+    ${PI_HOLE_INSTALL_DIR}/updatecheck.sh x remote
 
     if [[ "${useUpdateVars}" == false ]]; then
         displayFinalMessage "${pw}"

--- a/gravity.sh
+++ b/gravity.sh
@@ -13,9 +13,9 @@
 
 export LC_ALL=C
 
-coltable="/opt/pihole/COL_TABLE"
+coltable="${PI_HOLE_INSTALL_DIR}/COL_TABLE"
 source "${coltable}"
-regexconverter="/opt/pihole/wildcard_regex_converter.sh"
+regexconverter="${PI_HOLE_INSTALL_DIR}/wildcard_regex_converter.sh"
 source "${regexconverter}"
 
 basename="pihole"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Allow use of a non-standard installation path in `basic-install.sh`

https://github.com/pi-hole/pi-hole/issues/2787

**How does this PR accomplish the above?:**
Replaces the hardcoded `/opt/local` with the `PI_HOLE_INSTALL_DIR` variable


**What documentation changes (if any) are needed to support this PR?:**
None, as far as I am aware.

