### PR TITLE
Pin the Fedora test docker container to 29

### DIFF
--- a/test/fedora.Dockerfile
+++ b/test/fedora.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:29
 
 ENV GITDIR /etc/.pihole
 ENV SCRIPTDIR /opt/pihole


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix the Fedora CI tests.

**How does this PR accomplish the above?:**
Pin the Fedora image to Fedora 29, as we do not yet support Fedora 30.


**What documentation changes (if any) are needed to support this PR?:**
None