### PR TITLE
Fix uninstall causing 403 errors and not removing packages

### DIFF
--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -80,7 +80,7 @@ removeAndPurge() {
                 case ${yn} in
                     [Yy]* )
                         echo -ne "  ${INFO} Removing ${i}...";
-                        ${SUDO} "${PKG_REMOVE}" "${i}" &> /dev/null;
+                        ${SUDO} "${PKG_REMOVE[@]}" "${i}" &> /dev/null;
                         echo -e "${OVER}  ${INFO} Removed ${i}";
                         break;;
                     [Nn]* ) echo -e "  ${INFO} Skipped ${i}"; break;;

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -55,13 +55,13 @@ fi
 # Compatability
 if [ -x "$(command -v apt-get)" ]; then
     # Debian Family
-    PKG_REMOVE="${PKG_MANAGER} -y remove --purge"
+    PKG_REMOVE=("${PKG_MANAGER}" -y remove --purge)
     package_check() {
         dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -c "ok installed"
     }
 elif [ -x "$(command -v rpm)" ]; then
     # Fedora Family
-    PKG_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_REMOVE=("${PKG_MANAGER}" remove -y)
     package_check() {
         rpm -qa | grep "^$1-" > /dev/null
     }
@@ -80,7 +80,7 @@ removeAndPurge() {
                 case ${yn} in
                     [Yy]* )
                         echo -ne "  ${INFO} Removing ${i}...";
-                        ${SUDO} ${PKG_REMOVE} "${i}" &> /dev/null;
+                        ${SUDO} "${PKG_REMOVE}" "${i}" &> /dev/null;
                         echo -e "${OVER}  ${INFO} Removed ${i}";
                         break;;
                     [Nn]* ) echo -e "  ${INFO} Skipped ${i}"; break;;

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -80,7 +80,7 @@ removeAndPurge() {
                 case ${yn} in
                     [Yy]* )
                         echo -ne "  ${INFO} Removing ${i}...";
-                        ${SUDO} "${PKG_REMOVE} ${i}" &> /dev/null;
+                        ${SUDO} ${PKG_REMOVE} "${i}" &> /dev/null;
                         echo -e "${OVER}  ${INFO} Removed ${i}";
                         break;;
                     [Nn]* ) echo -e "  ${INFO} Skipped ${i}"; break;;
@@ -132,12 +132,15 @@ removeNoPurge() {
     fi
 
     if package_check lighttpd > /dev/null; then
-        ${SUDO} rm -rf /etc/lighttpd/ &> /dev/null
-        echo -e "  ${TICK} Removed lighttpd"
-    else
-        if [ -f /etc/lighttpd/lighttpd.conf.orig ]; then
+        if [[ -f /etc/lighttpd/lighttpd.conf.orig ]]; then
             ${SUDO} mv /etc/lighttpd/lighttpd.conf.orig /etc/lighttpd/lighttpd.conf
         fi
+
+        if [[ -f /etc/lighttpd/external.conf ]]; then
+            ${SUDO} rm /etc/lighttpd/external.conf
+        fi
+
+        echo -e "  ${TICK} Removed lighttpd configs"
     fi
 
     ${SUDO} rm -f /etc/dnsmasq.d/adList.conf &> /dev/null


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix the 403 lighttpd error after reinstall, and fix removing packages during uninstall.


**How does this PR accomplish the above?:**
The 403 lighttpd errors were caused by removing the lighttpd config directory and not removing lighttpd itself. This caused a subsequent Pi-hole reinstall to not have all of the required lighttpd config files. Only the Pi-hole lighttpd config files are removed, and the original lighttpd config file is restored.

The error while removing packages was caused by combining arguments into a string instead of listing each argument. The command is now properly formed.

**What documentation changes (if any) are needed to support this PR?:**
None