### PR TITLE
Fix pihole -up showing FTL update when network is down

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2404,6 +2404,7 @@ FTLcheckUpdate() {
 
             if ! FTLreleaseData=$(curl -sI https://github.com/pi-hole/FTL/releases/latest); then
                 # There was an issue while retrieving the latest version
+                printf "  %b Failed to retrieve latest FTL release metadata" "${CROSS}"
                 return 3
             fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2402,6 +2402,11 @@ FTLcheckUpdate() {
             local FTLlatesttag
             FTLlatesttag=$(curl -sI https://github.com/pi-hole/FTL/releases/latest | grep 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n')
 
+            if [[ $? != 0 ]]; then
+                # There was an issue while retrieving the latest version
+                return 3
+            fi
+
             if [[ "${FTLversion}" != "${FTLlatesttag}" ]]; then
                 return 0
             else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2399,13 +2399,15 @@ FTLcheckUpdate() {
         if [[ ${ftlLoc} ]]; then
             local FTLversion
             FTLversion=$(/usr/bin/pihole-FTL tag)
+            local FTLreleaseData
             local FTLlatesttag
-            FTLlatesttag=$(curl -sI https://github.com/pi-hole/FTL/releases/latest | grep 'Location' | awk -F '/' '{print $NF}' | tr -d '\r\n')
 
-            if [[ $? != 0 ]]; then
+            if ! FTLreleaseData=$(curl -sI https://github.com/pi-hole/FTL/releases/latest); then
                 # There was an issue while retrieving the latest version
                 return 3
             fi
+
+            FTLlatesttag=$(grep 'Location' < "${FTLreleaseData}" | awk -F '/' '{print $NF}' | tr -d '\r\n')
 
             if [[ "${FTLversion}" != "${FTLlatesttag}" ]]; then
                 return 0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Fix #1877

**How does this PR accomplish the above?:**
Check for error when retrieving latest FTL version before proceeding with the version comparison.

**What documentation changes (if any) are needed to support this PR?:**
None