### PR TITLE
Fix --check-only argument name.

### DIFF
--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -35,7 +35,7 @@ pihole -g\fR
 .br
 \fBpihole\fR \fB-l\fR (\fBon|off|off noflush\fR)
 .br
-\fBpihole -up \fR[--checkonly]
+\fBpihole -up \fR[--check-only]
 .br
 \fBpihole -v\fR [-p|-a|-f] [-c|-l|-hash]
 .br


### PR DESCRIPTION
Argument is "--check-only", not "--checkonly".

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fix documentation.

**How does this PR accomplish the above?:**
Since this is the first place where a user sees the "--check-only" argument he would have raised a REAL update when using the broken argument.


**What documentation changes (if any) are needed to support this PR?:**
This IS documentation.

---

