### PR TITLE
Fix for 404 error when browsing to pi.hole (without /admin)

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -27,7 +27,7 @@ server.modules = (
 )
 
 server.document-root        = "/var/www/html"
-server.error-handler-404    = "pihole/index.php"
+server.error-handler-404    = "/pihole/index.php"
 server.upload-dirs          = ( "/var/cache/lighttpd/uploads" )
 server.errorlog             = "/var/log/lighttpd/error.log"
 server.pid-file             = "/var/run/lighttpd.pid"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x ] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ x] I have made only one major change in my proposed changes.
- [ x] I have commented my proposed changes within the code.
- [ x] I have tested my proposed changes, and have included unit tests where possible.
- [ x] I am willing to help maintain this change if there are issues with it later.
- [ x] I give this submission freely and claim no ownership.
- [ x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
When browsing to "pi.hole" on raspbian buster, we are greeted with a 404. This should fix that.


**How does this PR accomplish the above?:**
As mentioned in the pihole discourse (https://discourse.pi-hole.net/t/getting-ready-for-buster/21001/22?u=forceflow), this change to the lighthttpd.conf file is necessary.

**What documentation changes (if any) are needed to support this PR?:**
(none)
