### PR TITLE
Fedora 30 tests

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -283,7 +283,7 @@ elif is_command rpm ; then
     UPDATE_PKG_CACHE=":"
     PKG_INSTALL=("${PKG_MANAGER}" install -y)
     PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
-    INSTALLER_DEPS=(dialog git iproute newt procps-ng which)
+    INSTALLER_DEPS=(dialog git iproute newt procps-ng which chkconfig)
     PIHOLE_DEPS=(bind-utils cronie curl findutils nmap-ncat sudo unzip wget libidn2 psmisc sqlite libcap)
     PIHOLE_WEB_DEPS=(lighttpd lighttpd-fastcgi php-common php-cli php-pdo)
     LIGHTTPD_USER="lighttpd"

--- a/test/fedora.Dockerfile
+++ b/test/fedora.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:29
+FROM fedora:30
 
 ENV GITDIR /etc/.pihole
 ENV SCRIPTDIR /opt/pihole

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -486,6 +486,13 @@ def test_FTL_download_aarch64_no_errors(Pihole):
     '''
     confirms only aarch64 package is downloaded for FTL engine
     '''
+    # mock whiptail answers and ensure installer dependencies
+    mock_command('whiptail', {'*': ('', '0')}, Pihole)
+    Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    distro_check
+    install_dependent_packages ${INSTALLER_DEPS[@]}
+    ''')
     download_binary = Pihole.run('''
     source /opt/pihole/basic-install.sh
     binary="pihole-FTL-aarch64-linux-gnu"
@@ -501,6 +508,13 @@ def test_FTL_download_unknown_fails_no_errors(Pihole):
     '''
     confirms unknown binary is not downloaded for FTL engine
     '''
+    # mock whiptail answers and ensure installer dependencies
+    mock_command('whiptail', {'*': ('', '0')}, Pihole)
+    Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    distro_check
+    install_dependent_packages ${INSTALLER_DEPS[@]}
+    ''')
     download_binary = Pihole.run('''
     source /opt/pihole/basic-install.sh
     binary="pihole-FTL-mips"
@@ -519,6 +533,13 @@ def test_FTL_download_binary_unset_no_errors(Pihole):
     '''
     confirms unset binary variable does not download FTL engine
     '''
+    # mock whiptail answers and ensure installer dependencies
+    mock_command('whiptail', {'*': ('', '0')}, Pihole)
+    Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    distro_check
+    install_dependent_packages ${INSTALLER_DEPS[@]}
+    ''')
     download_binary = Pihole.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Allow tests to pass using Fedora 30 container

**How does this PR accomplish the above?:**
Ensure `chkconfig` is installed prior to attempting to deploy to `/etc/init.d`

The following dependency chain already exists: `lighttpd` -> `spawn-fcgi` -> `chkconfig`.
Since `chkconfig` is already a project dependency, add `chkconfig` to `INSTALLER_DEPS`.

I have updated the 3x FTL download tests to ensure the installer dependencies are present prior to testing deployments to `/etc/init.d` 

**What documentation changes (if any) are needed to support this PR?:**
N/A

