### PR TITLE
Check if tty exist before we get screen size

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -85,7 +85,11 @@ fi
 
 
 # Find the rows and columns will default to 80x24 if it can not be detected
-screen_size=$(stty size || printf '%d %d' 24 80)
+if [ -t 0 ] ; then
+  screen_size=$(stty size)
+else
+  screen_size="24 80"
+fi
 # Set rows variable to contain first number
 printf -v rows '%d' "${screen_size%% *}"
 # Set columns variable to contain second number


### PR DESCRIPTION
This change fixes issue #145 "stty: standard input: Inappropriate ioctl for device "
It checks if a real terminal exist, if not it sets the screen size to a fixed value.
This helps to avoid nasty and unnecessary logs when running "pihole -up" via e.g. cron.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
This change fixes issue #145 "stty: standard input: Inappropriate ioctl for device "

**How does this PR accomplish the above?:**
It checks if a real terminal exist, if not it sets the screen size to a fixed value.

**What documentation changes (if any) are needed to support this PR?:**
No changes to the documentation are required


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

