### PR TITLE
Quickfix for CNAME responses of dig

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -263,7 +263,7 @@ gravity_DownloadBlocklistFromUrl() {
     else
         printf -v port "%s" "${PIHOLE_DNS_1#*#}"
     fi
-    ip=$(dig "@${ip_addr}" -p "${port}" +short "${domain}")
+    ip=$(dig "@${ip_addr}" -p "${port}" +short "${domain}" | tail -1)
     if [[ $(echo "${url}" | awk -F '://' '{print $1}') = "https" ]]; then
       port=443;
     else port=80


### PR DESCRIPTION
Always return only the last line, which should always be an ip.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [ ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fix for #2863 

**How does this PR accomplish the above?:**
It filters the output of the dig command, so only the last line will be set to the variable.

**What documentation changes (if any) are needed to support this PR?:**
-

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

