### PR TITLE
Fix "bad address in /etc/pihole/gravity.list" in pihole.log

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -482,7 +482,8 @@ gravity_SortAndFilterConsolidatedList() {
     echo -ne "  ${INFO} ${str}..."
   fi
 
-  sort -u "${piholeDir}/${parsedMatter}" > "${piholeDir}/${preEventHorizon}"
+  sort -u "${piholeDir}/${parsedMatter}" > "${piholeDir}/${preEventHorizon}.tmp"
+  gravity_ParseDomainsIntoHosts "${piholeDir}/${preEventHorizon}.tmp" "${piholeDir}/${preEventHorizon}"
 
   if [[ "${haveSourceUrls}" == true ]]; then
     echo -e "${OVER}  ${TICK} ${str}"


### PR DESCRIPTION
This puts gravity.list in the proper format and
prefixs the IP address of the pi to the beginning
of each line. This allows dnsmasq to properly parse
the file, and actually use the content of gravity.list.

This fixes #758, but works any time the list is built,
not just on install (Example: `pihole -g`)

Signed-off-by: Andrew <agh1467@rcpt.at>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [ ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fix the gravity.list generation so that it will work. If gravity.list is not in the proper format, dnsmasq doesn't use any of the addresses when it parses the list.


**How does this PR accomplish the above?:**
Sends the list through gravity_ParseDomainsIntoHosts() which puts the list in the correct format.


**What documentation changes (if any) are needed to support this PR?:**
I don't think any are necessary here.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

