### PR TITLE
New Default BlockList

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1172,11 +1172,11 @@ chooseBlocklists() {
     # In an array, show the options available (all off by default):
     options=(StevenBlack "StevenBlack's Unified Hosts List" on
         MalwareDom "MalwareDomains" on
-        Cameleon "Cameleon" on
-        ZeusTracker "ZeusTracker" on
-        DisconTrack "Disconnect.me Tracking" on
-        DisconAd "Disconnect.me Ads" on
-        HostsFile "Hosts-file.net Ads" on)
+        AdAway "AdAway" on
+        PhishingArmy "Phishing Army" on
+        SquidBlackListADS "SquidBlackList Ads" on
+        SquidBlackListMLC "SquidBlackList Malicious" on
+        DanielWhite "DanielWhite Ads and Tracking" on)
 
     # In a variable, show the choices available; exit if Cancel is selected
     choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty) || { printf "  %bCancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"; rm "${adlistFile}" ;exit 1; }
@@ -1194,11 +1194,11 @@ appendToListsFile() {
     case $1 in
         StevenBlack  )  echo "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" >> "${adlistFile}";;
         MalwareDom   )  echo "https://mirror1.malwaredomains.com/files/justdomains" >> "${adlistFile}";;
-        Cameleon     )  echo "http://sysctl.org/cameleon/hosts" >> "${adlistFile}";;
-        ZeusTracker  )  echo "https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist" >> "${adlistFile}";;
-        DisconTrack  )  echo "https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt" >> "${adlistFile}";;
-        DisconAd     )  echo "https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt" >> "${adlistFile}";;
-        HostsFile    )  echo "https://hosts-file.net/ad_servers.txt" >> "${adlistFile}";;
+        AdAway     )  echo "https://adaway.org/hosts.txt" >> "${adlistFile}";;
+        PhishingArmy  )  echo "https://phishing.army/download/phishing_army_blocklist.txt" >> "${adlistFile}";;
+        SquidBlackListADS  )  echo "https://www.squidblacklist.org/downloads/dg-ads.acl" >> "${adlistFile}";;
+        SquidBlackListMLC     )  echo "https://www.squidblacklist.org/downloads/dg-malicious.acl" >> "${adlistFile}";;
+        DanielWhite    )  echo "https://raw.githubusercontent.com/hoshsadiq/adblock-nocoin-list/master/hosts.txt" >> "${adlistFile}";;
     esac
 }
 
@@ -1212,11 +1212,11 @@ installDefaultBlocklists() {
     fi
     appendToListsFile StevenBlack
     appendToListsFile MalwareDom
-    appendToListsFile Cameleon
-    appendToListsFile ZeusTracker
-    appendToListsFile DisconTrack
-    appendToListsFile DisconAd
-    appendToListsFile HostsFile
+    appendToListsFile AdAway
+    appendToListsFile PhishingArmy
+    appendToListsFile SquidBlackListADS
+    appendToListsFile SquidBlackListMLC
+    appendToListsFile DanielWhite
 }
 
 # Check if /etc/dnsmasq.conf is from pi-hole.  If so replace with an original and install new in .d directory


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

[x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
[x] I have made only one major change in my proposed changes.
[] I have commented my proposed changes within the code.
[] I have tested my proposed changes, and have included unit tests where possible.
[x] I am willing to help maintain this change if there are issues with it later.
[x] I give this submission freely and claim no ownership.
[x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
[] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---

I believe it is time to delete old lists that are no longer maintained in favor of new ones.

In detail:
- Cameleon: last Update 2018-03-17;
- ZeusTracker: has been discontinued on Jul 8th, 2019;
- DisconTrack: last Update 2015-07-31;
- DisconAd: last Update 2016-03-09;
- HostsFile: last Update 2019-06-12 and it often contains false positives and is very similar to the StevenBlack list.

Some lists have not been updated for at least a year, we risk giving new users a negative experience.

For the new lists I preferred:

- AdAway: Updated Weekly to contrast Ads;
- SquidBlackList: Updated Weekly to contrast Ads and Malicious domains;
- PhishingArmy: Updated Daily to contrast Phishing;
- Daniel White: Updated Weekly to contrast Ads.

I personally use these lists with great satisfaction!

I believe that after a period of testing by the community they can be chosen as predefined lists.

Thanks
Andrea



