### PR TITLE
Prevent "pihole disable $timeout" from messing up future state changes

### DIFF
--- a/advanced/Scripts/pihole-reenable.sh
+++ b/advanced/Scripts/pihole-reenable.sh
@@ -12,5 +12,7 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
+readonly PI_HOLE_BIN_DIR="/usr/local/bin"
+
 sleep "${1}"
-pihole enable
+"${PI_HOLE_BIN_DIR}"/pihole enable

--- a/advanced/Scripts/pihole-reenable.sh
+++ b/advanced/Scripts/pihole-reenable.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+# Network-wide ad blocking via your own hardware.
+#
+# Wrapper script to re-enable Pi-hole after a period of it being disabled.
+#
+# This script will be aborted by the `pihole enable` command using `killall`.
+# As a consequence, the filename of this script is limited to max 15 characters
+# and the script does not use `env`.
+#
+# This file is copyright under the latest version of the EUPL.
+# Please see LICENSE file for your rights under this license.
+
+sleep "${1}"
+pihole enable

--- a/advanced/Scripts/pihole-reenable.sh
+++ b/advanced/Scripts/pihole-reenable.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 # Pi-hole: A black hole for Internet advertisements
-# (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+# (c) 2020 Pi-hole, LLC (https://pi-hole.net)
 # Network-wide ad blocking via your own hardware.
-#
-# Wrapper script to re-enable Pi-hole after a period of it being disabled.
-#
-# This script will be aborted by the `pihole enable` command using `killall`.
-# As a consequence, the filename of this script is limited to max 15 characters
-# and the script does not use `env`.
 #
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
+#
+#
+# The pihole disable command has the option to set a specified time before
+# blocking is automatically re-enabled.
+#
+# Present script is responsible for the sleep & re-enable part of the job and
+# is automatically terminated if it is still running when pihole is enabled by
+# other means.
+#
+# This ensures that pihole ends up in the correct state after a sequence of
+# commands suchs as: `pihole disable 30s; pihole enable; pihole disable`
 
 readonly PI_HOLE_BIN_DIR="/usr/local/bin"
 

--- a/pihole
+++ b/pihole
@@ -164,7 +164,7 @@ Time:
           local str="Disabling blocking for ${tt} seconds"
           echo -e "  ${INFO} ${str}..."
           local str="Blocking will be re-enabled in ${tt} seconds"
-          nohup bash -c "sleep ${tt}; ${PI_HOLE_BIN_DIR}/pihole enable" </dev/null &>/dev/null &
+          nohup "${PI_HOLE_SCRIPT_DIR}"/pihole-reenable.sh ${tt} </dev/null &>/dev/null &
         else
           local error=true
         fi
@@ -175,7 +175,7 @@ Time:
           echo -e "  ${INFO} ${str}..."
           local str="Blocking will be re-enabled in ${tt} minutes"
           tt=$((${tt}*60))
-          nohup bash -c "sleep ${tt}; ${PI_HOLE_BIN_DIR}/pihole enable" </dev/null &>/dev/null &
+          nohup "${PI_HOLE_SCRIPT_DIR}"/pihole-reenable.sh ${tt} </dev/null &>/dev/null &
         else
           local error=true
         fi
@@ -197,6 +197,7 @@ Time:
     fi
   else
     # Enable Pi-hole
+    killall -q pihole-reenable
     if grep -cq "BLOCKING_ENABLED=true" "${setupVars}"; then
       echo -e "  ${INFO} Blocking already enabled, nothing to do"
       exit 0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, ~~and have included unit tests where possible.~~
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fixes #2879
Prevent "pihole disable $timeout" from messing up future state changes.

Example:
```
pihole disable 30s
pihole enable
pihole disable
sleep 30
pihole status
```

Without this fix the following command sequence produces a somewhat surprising result, namely that pihole ends up being enabled. This is because pihole was enabled by a "reenable" job 30s after the first "disable" command. The operator, however, did not expect this because the last command to pihole was to disable itself.

With this fix the above command sequence will leave pihole disabled.

~Please note that this fix **depends** on the existence of the `pkill` command.~

~I can confirm that pkill exists on my device running Raspbian GNU/Linux 10 (buster).~