### PR TITLE
Installer | Remove "dialog" dep and failsafe APT package check

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -205,6 +205,8 @@ if is_command apt-get ; then
             printf "  %b Enabled %s\\n" "${TICK}" "'universe' repository"
         fi
     fi
+    # Update package cache. This is required already here to assure apt-cache calls have package lists available.
+    update_package_cache || exit 1
     # Debian 7 doesn't have iproute2 so check if it's available first
     if apt-cache show iproute2 > /dev/null 2>&1; then
         iproute_pkg="iproute2"
@@ -293,8 +295,6 @@ elif is_command rpm ; then
         PKG_MANAGER="yum"
     fi
 
-    # Fedora and family update cache on every PKG_INSTALL call, no need for a separate update.
-    UPDATE_PKG_CACHE=":"
     PKG_INSTALL=("${PKG_MANAGER}" install -y)
     PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
     INSTALLER_DEPS=(dialog git iproute newt procps-ng which chkconfig)
@@ -2536,9 +2536,6 @@ main() {
     else
         verifyFreeDiskSpace
     fi
-
-    # Update package cache
-    update_package_cache || exit 1
 
     # Notify user of package availability
     notify_package_updates_available


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
+ "dialog" is never used throughout the script, all dialogs are whiptail-based. So it is removed from installer dependencies. This is done for Debian/Ubuntu only for now, since I don't have a chance to test it on Fedora/RH, and they lack whiptail as dependency.
+ When checking for available packages in APT repository, running a dry-run install can fail for other reasons, even if the package is available. Currently, in such case, wrong fallback packages are selected: #2888 
+ In rare cases, the APT list files can be not available when the installer is started. Either as it is on a fresh system or because APT lists have been moved to RAM. "apt-cache" calls will then fail, same as dry-run installs were.

**How does this PR accomplish the above?:**
+ "apt-cache show <pkg>" is a quicker method to check for available packages. This is now done as well to check if the fallbacks are available. If non is found, the installer exits with meaningful error message.
+ To assure that current package lists are checked, update the package cache directly after the Ubuntu universe repo has been added, only in the Debian/Ubuntu block. This renders the variable handling in RH/Fedora block obsolete.

Fixes: #2888 

**Signed-off-by: Micha Felle <micha@dietpi.com>**