### PR TITLE
Restore 'pihole -q' hosts format support and improve matching in edge cases

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -176,11 +176,12 @@ fi
 # 2. Remove comments after domain
 # 3. Remove hosts format IP address
 # 4. Remove any lines that no longer contain the queried domain name (in case the matched domain name was in a comment)
+esc_domain="${domainQuery//./\\.}"
 mapfile -t results <<< "$(IFS=$'\n'; sed \
 	-e "/:#/d" \
 	-e "s/[ \\t]#.*//g" \
 	-e "s/:.*[ \\t]/:/g" \
-	-e "/${domainQuery}/!d" \
+	-e "/${esc_domain}/!d" \
 	<<< "${results[*]}")"
 # Exit if result was in a comment
 [[ -z "${results[*]}" ]] && exit 0

--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -54,7 +54,7 @@ scanList(){
     # /dev/null forces filename to be printed when only one list has been generated
     # shellcheck disable=SC2086
     case "${type}" in
-        "exact" ) grep -i -E -l "(^|(?<!#)\\s)${domain}($|\\s|#)" ${lists} /dev/null 2>/dev/null;;
+        "exact" ) grep -i -E "(^|\\s)${domain}($|\\s|#)" ${lists} /dev/null 2>/dev/null;;
         "wc"    ) grep -i -o -m 1 "/${domain}/" ${lists} 2>/dev/null;;
         *       ) grep -i "${domain}" ${lists} /dev/null 2>/dev/null;;
     esac
@@ -170,19 +170,20 @@ elif [[ -z "${all}" ]] && [[ "${#results[*]}" -ge 100 ]]; then
     exit 0
 fi
 
-# Remove unwanted content from non-exact $results
-if [[ -z "${exact}" ]]; then
-    # Delete lines starting with #
-    # Remove comments after domain
-    # Remove hosts format IP address
-    mapfile -t results <<< "$(IFS=$'\n'; sed \
-        -e "/:#/d" \
-        -e "s/[ \\t]#.*//g" \
-        -e "s/:.*[ \\t]/:/g" \
-        <<< "${results[*]}")"
-    # Exit if result was in a comment
-    [[ -z "${results[*]}" ]] && exit 0
-fi
+# Remove unwanted content from $results
+# Each line in $results is formatted as such: [fileName]:[line]
+# 1. Delete lines starting with #
+# 2. Remove comments after domain
+# 3. Remove hosts format IP address
+# 4. Remove any lines that no longer contain the queried domain name (in case the matched domain name was in a comment)
+mapfile -t results <<< "$(IFS=$'\n'; sed \
+	-e "/:#/d" \
+	-e "s/[ \\t]#.*//g" \
+	-e "s/:.*[ \\t]/:/g" \
+	-e "/${domainQuery}/!d" \
+	<<< "${results[*]}")"
+# Exit if result was in a comment
+[[ -z "${results[*]}" ]] && exit 0
 
 # Get adlist file content as array
 if [[ -n "${adlist}" ]] || [[ -n "${blockpage}" ]]; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

The `grep` command for exact matching does not work after [PR 2688](https://github.com/pi-hole/pi-hole/pull/2688). As a result, Pi-hole is unable to find domains in lists in hosts format  (e.g. `0.0.0.0 example.org`). This PR aims to correct that without causing regressions.

**How does this PR accomplish the above?:**

`grep -E` uses POSIX ERE which does not support lookaround, this PR reverts PR 2688 in favour of removing comments at a later time. The code to remove comments was already in place. By changing the `grep` command for exact queries to return lines in the same format as non-exact queries, this PR can simplify the clean-up logic to apply to both types of queries.

This PR uses `sed` to remove any lines not containing the queried domain *after* trying to remove comments. The lines should not contain commented domain names at that point so lines that do not contain the queried domain must have been matched by mistake.


*Test lists:*
list.shouldmatch.domains:
```
# Exact queries for 'example.org' will not match this list on Pi-hole v4.3.1 / dev, but regular queries will.
# After the PR, both regular and exact queries will return this list.

0.0.0.0 example.org
google.com
```

list.incorrectmatch.domains:
```
# Queries for 'example.org' will not match this list on Pi-hole v4.3.1 / dev.
# No regression after the PR.

#0.0.0.0 example.com # needed for example.org and example.net

# The case that PR #2688 was originally meant to solve. Exact queries for 'google.com' should not match.
#74.125.127.105 g        # google.com
```

list.duplicatematch.domains:
```
# Exact queries for 'example.org' will not match this list and regular queries will incorrectly match both domains.
# After the PR, both regular and exact queries return this list once.

0.0.0.0 example.com # needed for example.org and example.net
0.0.0.0 example.org
```

Pi-hole v4.3.1 / v4.3-220-g9f77810 output:
```
pihole -q example.org
 Match found in list.duplicatematch.domains:
   example.com
   example.org
 Match found in list.shouldmatch.domains:
   example.org

pihole -q -exact example.org
  [i] No exact results found for example.org within the block lists

pihole -q -exact google.com
 Exact match for google.com found in:
   list.shouldmatch.domains
```

Expected output:
```
pihole -q example.org
 Match found in list.duplicatematch.domains:
   example.org
 Match found in list.shouldmatch.domains:
   example.org

pihole -q -exact example.org
 Exact matches for example.org found in:
   list.duplicatematch.domains
   list.shouldmatch.domains
   
pihole -q -exact google.com
 Exact match for google.com found in:
   list.shouldmatch.domains
```

**What documentation changes (if any) are needed to support this PR?:**

None. The PR does not introduce new features or change any interfaces.
