### PR TITLE
Full systemd support

### DIFF
--- a/advanced/Templates/pihole-FTL.service.ini
+++ b/advanced/Templates/pihole-FTL.service.ini
@@ -1,0 +1,37 @@
+[Unit]
+Description=pihole-FTL Domain Name Server
+Documentation=man:pihole-FTL(8)
+After=remote-fs.target
+
+# Alternative based on https://wiki.debian.org/Hardening/Daemons#bind
+#   allows other services which rely on DNS to use pihole-FTL, but means
+#   breaking if config relies on remote-fs
+# After=network.target
+# Wants=nss-lookup.target
+# Before=nss-lookup.target
+
+After=resolvconf.service
+Wants=resolvconf.service
+# fail since dnsmasq is embedded
+Conflicts=dnsmasq.service
+
+[Service]
+# Run as unprivileged user, use AmbientCapabilities to assign capabilities
+User=pihole
+Group=pihole
+
+# start()
+ExecStartPre=+/bin/sh /etc/pihole/fix_files.sh
+ExecStartPre=+/bin/sh -c "echo \"nameserver 127.0.0.1\" | /sbin/resolvconf -a lo.piholeFTL"
+# Assign capabilities to the pihole user slice
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN
+ExecStart=/usr/bin/pihole-FTL no-daemon
+
+## stop()
+# Clean up resolv.conf before shutting down service
+ExecStop=+/sbin/resolvconf -d lo.piholeFTL
+# Send SIGKILL 5 seconds after SIGTERM
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/advanced/Templates/pihole-FTL.service.ini
+++ b/advanced/Templates/pihole-FTL.service.ini
@@ -21,7 +21,7 @@ User=pihole
 Group=pihole
 
 # start()
-ExecStartPre=+/bin/sh /etc/pihole/fix_files.sh
+ExecStartPre=+/bin/sh /opt/pihole/fix_files.sh
 ExecStartPre=+/bin/sh -c "echo \"nameserver 127.0.0.1\" | /sbin/resolvconf -a lo.piholeFTL"
 # Assign capabilities to the pihole user slice
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN

--- a/advanced/Templates/pihole-FTL.service.ini
+++ b/advanced/Templates/pihole-FTL.service.ini
@@ -2,10 +2,10 @@
 Description=pihole-FTL Domain Name Server
 Documentation=man:pihole-FTL(8)
 After=remote-fs.target
+After=network.target
 
 # Alternative based on https://wiki.debian.org/Hardening/Daemons#bind
-#   allows other services which rely on DNS to use pihole-FTL, but means
-#   breaking if config relies on remote-fs
+#   enabling this could cause dependency cycles through remote-fs.target
 # After=network.target
 # Wants=nss-lookup.target
 # Before=nss-lookup.target

--- a/advanced/Templates/pihole-FTL.sh
+++ b/advanced/Templates/pihole-FTL.sh
@@ -33,21 +33,9 @@ start() {
   if is_running; then
     echo "pihole-FTL is already running"
   else
-    # Touch files to ensure they exist (create if non-existing, preserve if existing)
-    touch /var/log/pihole-FTL.log /var/log/pihole.log
-    touch /run/pihole-FTL.pid /run/pihole-FTL.port
-    touch /etc/pihole/dhcp.leases
-    mkdir -p /var/run/pihole
-    mkdir -p /var/log/pihole
-    chown pihole:pihole /var/run/pihole /var/log/pihole
-    # Remove possible leftovers from previous pihole-FTL processes
-    rm -f /dev/shm/FTL-* 2> /dev/null
-    rm /var/run/pihole/FTL.sock 2> /dev/null
-    # Ensure that permissions are set so that pihole-FTL can edit all necessary files
-    chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port
-    chown pihole:pihole /etc/pihole /etc/pihole/dhcp.leases 2> /dev/null
-    chown pihole:pihole /var/log/pihole-FTL.log /var/log/pihole.log
-    chmod 0644 /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole.log
+    USER=$FTLUSER
+    source /etc/pihole/fix_files.sh
+
     echo "nameserver 127.0.0.1" | /sbin/resolvconf -a lo.piholeFTL
     if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip "$(which pihole-FTL)"; then
       su -s /bin/sh -c "/usr/bin/pihole-FTL" "$FTLUSER"

--- a/advanced/Templates/pihole-FTL.sh
+++ b/advanced/Templates/pihole-FTL.sh
@@ -34,7 +34,7 @@ start() {
     echo "pihole-FTL is already running"
   else
     USER=$FTLUSER
-    source /etc/pihole/fix_files.sh
+    source /opt/pihole/fix_files.sh
 
     echo "nameserver 127.0.0.1" | /sbin/resolvconf -a lo.piholeFTL
     if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN+eip "$(which pihole-FTL)"; then

--- a/advanced/fix_files.sh
+++ b/advanced/fix_files.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Pi-hole: A black hole for Internet advertisements
-# (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+# (c) 2019 Pi-hole, LLC (https://pi-hole.net)
 # Network-wide ad blocking via your own hardware.
 #
-# Completely uninstalls Pi-hole
+# Adjust file permissions for pihole-FTL
 #
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.

--- a/advanced/fix_files.sh
+++ b/advanced/fix_files.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+# Network-wide ad blocking via your own hardware.
+#
+# Completely uninstalls Pi-hole
+#
+# This file is copyright under the latest version of the EUPL.
+# Please see LICENSE file for your rights under this license.
+
+# Touch files to ensure they exist (create if non-existing, preserve if existing)
+touch /var/log/pihole-FTL.log /var/log/pihole.log
+touch /run/pihole-FTL.pid /run/pihole-FTL.port
+touch /etc/pihole/dhcp.leases
+mkdir -p /var/{run,log}/pihole
+chown -f "$USER": /var/run/pihole /var/log/pihole
+# Remove possible leftovers from previous pihole-FTL processes
+rm -f /dev/shm/FTL-*
+rm -f /var/run/pihole/FTL.sock
+# Ensure that permissions are set so that pihole-FTL can edit all necessary files
+chown -f "$USER": /run/pihole-FTL.pid /run/pihole-FTL.port
+chown -f "$USER": /etc/pihole /etc/pihole/dhcp.leases
+chown -f "$USER": /var/log/pihole-FTL.log /var/log/pihole.log
+chmod 0644 /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole.log

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2222,9 +2222,6 @@ FTLinstall() {
         fi
         
         install -T -m 0755 "${PI_HOLE_LOCAL_REPO}/advanced/Templates/pihole-FTL.service.ini" "${systemd_unit_file}"
-        
-        # Required to remove old generated services, before calls to systemctl enable or systemctl start
-        systemctl daemon-reload
     fi
 
     local ftlBranch
@@ -2683,6 +2680,11 @@ main() {
 
     printf "  %b Restarting services...\\n" "${INFO}"
     # Start services
+
+    # Ensure systemd is picking up the latest configuration, if present.
+    if is_command systemctl ; then
+        systemctl daemon-reload
+    fi
 
     # Enable FTL
     # Ensure the service is enabled before trying to start it

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2207,7 +2207,8 @@ FTLinstall() {
     # Move into the temp ftl directory
     pushd "$(mktemp -d)" > /dev/null || { printf "Unable to make temporary directory for FTL binary download\\n"; return 1; }
 
-    install -T -m 0755 "${PI_HOLE_LOCAL_REPO}/advanced/fix_files.sh" "/etc/pihole/fix_files.sh"
+    # Ensure /opt/pihole exists, then install fix_files.sh
+    install -T -D -m 0755 "${PI_HOLE_LOCAL_REPO}/advanced/fix_files.sh" "${PI_HOLE_INSTALL_DIR}/fix_files.sh"
     # Always replace pihole-FTL
     install -T -m 0755 "${PI_HOLE_LOCAL_REPO}/advanced/Templates/pihole-FTL.sh" "/etc/init.d/pihole-FTL"
     

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -165,10 +165,12 @@ removeNoPurge() {
         echo -ne "  ${INFO} Removing pihole-FTL..."
         if [[ -x "$(command -v systemctl)" ]]; then
             systemctl stop pihole-FTL
+            systemctl disable pihole-FTL
         else
             service pihole-FTL stop
         fi
         ${SUDO} rm -f /etc/init.d/pihole-FTL
+        ${SUDO} rm -f /etc/systemd/system/pihole-FTL.service
         ${SUDO} rm -f /usr/bin/pihole-FTL
         echo -e "${OVER}  ${TICK} Removed pihole-FTL"
     fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Replaces the systemd service unit generated by sysv-generator with a custom one that manages the pihole-FTL service without using its daemon feature, since they seem to be incompatible. This resolves the restarting issue in #2869.

![systemd output](https://i.imgur.com/ulyncAF.png)


**How does this PR accomplish the above?:**
* The service itself is a mirror of the actions defined in `/etc/init.d/pihole-FTL`, however instead of allowing the pihole binary to fork it uses the `no-daemon` flag to keep it in a systemctl-managed process.
* In order to share the code for initialization all the common code was split off into `/etc/pihole/fix_files.sh`, which is included in the sysv file using `source` and executed in systemd with `ExecStartPre=+` (to execute it as a privileged user).
* Running the daemon as an unprivileged user and granting of capabilities is done using native systemctl features instead of `setcap`/`su`.


**What documentation changes (if any) are needed to support this PR?:**
The change should be totally transparent to users, since it simply replaces the generated pihole-FTL.service with an actual implementation. The only exception is when a user has previously defined systemd overrides for the generated service. The automated install will detect and error out if these exist to avoid complication.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

