### PR TITLE
Store timestamp when the gravity table was last updated successfully

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -90,6 +90,16 @@ generate_gravity_database() {
   chmod g+w "${piholeDir}" "${gravityDBfile}"
 }
 
+update_gravity_timestamp() {
+  # Update timestamp when the gravity table was last updated successfully
+  output=$( { sqlite3 "${gravityDBfile}" <<< "INSERT OR REPLACE INTO info (property,value) values (\"updated\",cast(strftime('%s', 'now') as int));"; } 2>&1 )
+  status="$?"
+
+  if [[ "${status}" -ne 0 ]]; then
+    echo -e "\\n  ${CROSS} Unable to update gravity timestamp in database ${gravityDBfile}\\n  ${output}"
+  fi
+}
+
 # Import domains from file and store them in the specified database table
 database_table_from_file() {
   # Define locals
@@ -748,6 +758,8 @@ fi
 # Create local.list
 gravity_generateLocalList
 gravity_ShowCount
+
+update_gravity_timestamp
 
 gravity_Cleanup
 echo ""


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Core elements for fixing https://github.com/pi-hole/AdminLTE/issues/989
Note that this referenced bug exists only in `development` and not in `master`.

**How does this PR accomplish the above?:**

Store timestamp when the gravity table was last updated successfully.