### PR TITLE
Prevent Firefox from automatically switching over to DNS-over-HTTPS

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -41,3 +41,8 @@ log-facility=/var/log/pihole.log
 local-ttl=2
 
 log-async
+
+# Signal to Firefox that the local network is unsuitable for DNS-over-HTTPS
+# This follows https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https
+# (sourced 7th September 2019)
+server=/use-application-dns.net/


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Prevent Firefox from using DNS-over-HTTPS (DoH) as this would corrupt our efforts to block ads.


**How does this PR accomplish the above?:**

We follow the [official Mozilla Support platform](https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https):
> Network administrators may configure their networks as follows to signal that their local DNS resolver implemented special features that make the network unsuitable for DoH:
> 
> DNS queries for the A and AAAA records for the domain “[use-application-dns.net](http://use-application-dns.net)” must respond with NXDOMAIN rather than the IP address retrieved from the authoritative nameserver.

We we implement such a "special feature", we implement this.


**What documentation changes (if any) are needed to support this PR?:**

Probably not necessary.