### PR TITLE
Fix dependency install when debconf-apt-progress is not available

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -191,10 +191,10 @@ if is_command apt-get ; then
     # grep -c will return 1 retVal on 0 matches, block this throwing the set -e with an OR TRUE
     PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
     # Some distros vary slightly so these fixes for dependencies may apply
-    # on Ubuntu 18.04.1 LTS we need to add the universe repository to gain access to dialog and dhcpcd5
+    # on Ubuntu 18.04.1 LTS we need to add the universe repository to gain access to dhcpcd5
     APT_SOURCES="/etc/apt/sources.list"
     if awk 'BEGIN{a=1;b=0}/bionic main/{a=0}/bionic.*universe/{b=1}END{exit a + b}' ${APT_SOURCES}; then
-        if ! whiptail --defaultno --title "Dependencies Require Update to Allowed Repositories" --yesno "Would you like to enable 'universe' repository?\\n\\nThis repository is required by the following packages:\\n\\n- dhcpcd5\\n- dialog" "${r}" "${c}"; then
+        if ! whiptail --defaultno --title "Dependencies Require Update to Allowed Repositories" --yesno "Would you like to enable 'universe' repository?\\n\\nThis repository is required by the following packages:\\n\\n- dhcpcd5" "${r}" "${c}"; then
             printf "  %b Aborting installation: dependencies could not be installed.\\n" "${CROSS}"
             exit # exit the installer
         else
@@ -245,7 +245,7 @@ if is_command apt-get ; then
     fi
     # Since our install script is so large, we need several other programs to successfully get a machine provisioned
     # These programs are stored in an array so they can be looped through later
-    INSTALLER_DEPS=(apt-utils dialog debconf dhcpcd5 git "${iproute_pkg}" whiptail)
+    INSTALLER_DEPS=(apt-utils debconf dhcpcd5 git "${iproute_pkg}" whiptail)
     # Pi-hole itself has several dependencies that also need to be installed
     PIHOLE_DEPS=(cron curl dnsutils iputils-ping lsof netcat psmisc sudo unzip wget idn2 sqlite3 libcap2-bin dns-root-data resolvconf libcap2)
     # The Web dashboard has some that also need to be installed

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -288,7 +288,7 @@ elif is_command rpm ; then
     UPDATE_PKG_CACHE=":"
     PKG_INSTALL=("${PKG_MANAGER}" install -y)
     PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
-    INSTALLER_DEPS=(dialog git iproute newt procps-ng which chkconfig)
+    INSTALLER_DEPS=(git iproute newt procps-ng which chkconfig)
     PIHOLE_DEPS=(bind-utils cronie curl findutils nmap-ncat sudo unzip wget libidn2 psmisc sqlite libcap)
     PIHOLE_WEB_DEPS=(lighttpd lighttpd-fastcgi php-common php-cli php-pdo)
     LIGHTTPD_USER="lighttpd"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1626,7 +1626,7 @@ install_dependent_packages() {
     # amount of download traffic.
     # NOTE: We may be able to use this installArray in the future to create a list of package that were
     # installed by us, and remove only the installed packages, and not the entire list.
-    if is_command debconf-apt-progress ; then
+    if is_command apt-get ; then
         # For each package,
         for i in "$@"; do
             printf "  %b Checking for %s..." "${INFO}" "${i}"
@@ -1639,8 +1639,14 @@ install_dependent_packages() {
         done
         if [[ "${#installArray[@]}" -gt 0 ]]; then
             test_dpkg_lock
-            debconf-apt-progress -- "${PKG_INSTALL[@]}" "${installArray[@]}"
-            return
+            if is_command debconf-apt-progress ; then
+                # display progress if debconf-apt-progress is available
+                debconf-apt-progress -- "${PKG_INSTALL[@]}" "${installArray[@]}"
+                return
+            else
+                "${PKG_INSTALL[@]}" "${installArray[@]}" &> /dev/null
+                return
+            fi
         fi
         printf "\\n"
         return 0

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1639,6 +1639,12 @@ install_dependent_packages() {
         done
         if [[ "${#installArray[@]}" -gt 0 ]]; then
             test_dpkg_lock
+            # If whiptail is found in the package array, install before calls to debconf-apt-progress
+            if [[ " ${installArray[*]} " =~ " whiptail " ]]; then
+                "${PKG_INSTALL[@]}" "whiptail" &> /dev/null
+                # remove whiptail from the package array
+                installArray=( "${installArray[@]/whiptail}" )
+            fi
             if is_command debconf-apt-progress ; then
                 # display progress if debconf-apt-progress is available
                 debconf-apt-progress -- "${PKG_INSTALL[@]}" "${installArray[@]}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. 

---
**What does this PR aim to accomplish?:**
- Fix a bug where dependencies would not be installed if the `debconf-apt-progress` command was unavailable. 
- Ensure the _"suggested" dialog box library_ is installed prior to `debconf-apt-progress` calls. 
(see: https://packages.debian.org/buster/debconf)

Original issue report #1278 and fix was #1280 with additional discussion on #2892 

**How does this PR accomplish the above?:**
- add fall-back to `install_dependent_packages()` when `debconf-apt-progress` command does not exist
- ensure `whiptail` is installed before calls to `debconf-apt-progress`
- remove unused `dialog` dependency for Debian (commit by @MichaIng)
- remove unused `dialog` dependency for Fedora

**What documentation changes (if any) are needed to support this PR?:**
n/a
