### PR TITLE
Per-client blocking changes

### DIFF
--- a/advanced/Scripts/database_migration/gravity-db.sh
+++ b/advanced/Scripts/database_migration/gravity-db.sh
@@ -39,4 +39,9 @@ upgrade_gravityDB(){
 		sqlite3 "${database}" < "/etc/.pihole/advanced/Scripts/database_migration/gravity/2_to_3.sql"
 		version=3
 	fi
+	if [[ "$version" == "3" ]]; then
+		# This migration script upgrades ...
+		sqlite3 "${database}" < "/etc/.pihole/advanced/Scripts/database_migration/gravity/3_to_4.sql"
+		version=3
+	fi
 }

--- a/advanced/Scripts/database_migration/gravity-db.sh
+++ b/advanced/Scripts/database_migration/gravity-db.sh
@@ -10,6 +10,8 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
+readonly scriptPath="/etc/.pihole/advanced/Scripts/database_migration/gravity"
+
 upgrade_gravityDB(){
 	local database piholeDir auditFile version
 	database="${1}"
@@ -23,7 +25,7 @@ upgrade_gravityDB(){
 		# This migration script upgrades the gravity.db file by
 		# adding the domain_audit table
 		echo -e "  ${INFO} Upgrading gravity database from version 1 to 2"
-		sqlite3 "${database}" < "/etc/.pihole/advanced/Scripts/database_migration/gravity/1_to_2.sql"
+		sqlite3 "${database}" < "${scriptPath}/1_to_2.sql"
 		version=2
 
 		# Store audit domains in database table
@@ -38,13 +40,13 @@ upgrade_gravityDB(){
 		# renaming the regex table to regex_blacklist, and
 		# creating a new regex_whitelist table + corresponding linking table and views
 		echo -e "  ${INFO} Upgrading gravity database from version 2 to 3"
-		sqlite3 "${database}" < "/etc/.pihole/advanced/Scripts/database_migration/gravity/2_to_3.sql"
+		sqlite3 "${database}" < "${scriptPath}/2_to_3.sql"
 		version=3
 	fi
 	if [[ "$version" == "3" ]]; then
 		# This migration script upgrades the gravity and adlist views
 		# implementing necessary changes for per-client blocking
-		sqlite3 "${database}" < "/etc/.pihole/advanced/Scripts/database_migration/gravity/3_to_4.sql"
+		sqlite3 "${database}" < "${scriptPath}/3_to_4.sql"
 		version=3
 	fi
 }

--- a/advanced/Scripts/database_migration/gravity-db.sh
+++ b/advanced/Scripts/database_migration/gravity-db.sh
@@ -44,9 +44,17 @@ upgrade_gravityDB(){
 		version=3
 	fi
 	if [[ "$version" == "3" ]]; then
-		# This migration script upgrades the gravity and adlist views
+		# This migration script upgrades the gravity and list views
 		# implementing necessary changes for per-client blocking
+		echo -e "  ${INFO} Upgrading gravity database from version 3 to 4"
 		sqlite3 "${database}" < "${scriptPath}/3_to_4.sql"
-		version=3
+		version=4
+	fi
+	if [[ "$version" == "4" ]]; then
+		# This migration script upgrades the adlist view
+		# to return an ID used in gravity.sh
+		echo -e "  ${INFO} Upgrading gravity database from version 4 to 5"
+		sqlite3 "${database}" < "${scriptPath}/4_to_5.sql"
+		version=5
 	fi
 }

--- a/advanced/Scripts/database_migration/gravity-db.sh
+++ b/advanced/Scripts/database_migration/gravity-db.sh
@@ -40,7 +40,8 @@ upgrade_gravityDB(){
 		version=3
 	fi
 	if [[ "$version" == "3" ]]; then
-		# This migration script upgrades ...
+		# This migration script upgrades the gravity and adlist views
+		# implementing necessary changes for per-client blocking
 		sqlite3 "${database}" < "/etc/.pihole/advanced/Scripts/database_migration/gravity/3_to_4.sql"
 		version=3
 	fi

--- a/advanced/Scripts/database_migration/gravity/3_to_4.sql
+++ b/advanced/Scripts/database_migration/gravity/3_to_4.sql
@@ -1,0 +1,25 @@
+.timeout 30000
+
+PRAGMA FOREIGN_KEYS=OFF;
+
+BEGIN TRANSACTION;
+
+DROP TABLE gravity;
+CREATE TABLE gravity
+(
+	domain TEXT NOT NULL,
+	adlist_id INTEGER NOT NULL REFERENCES adlist (id),
+	PRIMARY KEY(domain, adlist_id)
+);
+
+DROP VIEW vw_gravity;
+CREATE VIEW vw_gravity AS SELECT domain, gravity.adlist_id
+    FROM gravity
+    LEFT JOIN adlist_by_group ON adlist_by_group.adlist_id = gravity.adlist_id
+    LEFT JOIN adlist ON adlist.id = gravity.adlist_id
+    LEFT JOIN "group" ON "group".id = adlist_by_group.group_id
+    WHERE adlist.enabled = 1 AND (adlist_by_group.group_id IS NULL OR "group".enabled = 1);
+
+UPDATE info SET value = 4 WHERE property = 'version';
+
+COMMIT;

--- a/advanced/Scripts/database_migration/gravity/3_to_4.sql
+++ b/advanced/Scripts/database_migration/gravity/3_to_4.sql
@@ -21,7 +21,7 @@ CREATE VIEW vw_gravity AS SELECT domain, adlist_by_group.group_id AS group_id
     WHERE adlist.enabled = 1 AND (adlist_by_group.group_id IS NULL OR "group".enabled = 1);
 
 DROP VIEW vw_whitelist;
-CREATE VIEW vw_whitelist AS SELECT domain, whitelist_by_group.group_id AS group_id
+CREATE VIEW vw_whitelist AS SELECT domain, whitelist.id AS id, whitelist_by_group.group_id AS group_id
     FROM whitelist
     LEFT JOIN whitelist_by_group ON whitelist_by_group.whitelist_id = whitelist.id
     LEFT JOIN "group" ON "group".id = whitelist_by_group.group_id
@@ -29,12 +29,28 @@ CREATE VIEW vw_whitelist AS SELECT domain, whitelist_by_group.group_id AS group_
     ORDER BY whitelist.id;
 
 DROP VIEW vw_blacklist;
-CREATE VIEW vw_blacklist AS SELECT domain, blacklist_by_group.group_id AS group_id
+CREATE VIEW vw_blacklist AS SELECT domain, blacklist.id AS id, blacklist_by_group.group_id AS group_id
     FROM blacklist
     LEFT JOIN blacklist_by_group ON blacklist_by_group.blacklist_id = blacklist.id
     LEFT JOIN "group" ON "group".id = blacklist_by_group.group_id
     WHERE blacklist.enabled = 1 AND (blacklist_by_group.group_id IS NULL OR "group".enabled = 1)
     ORDER BY blacklist.id;
+
+DROP VIEW vw_regex_whitelist;
+CREATE VIEW vw_regex_whitelist AS SELECT DISTINCT domain, regex_whitelist.id AS id, regex_whitelist_by_group.group_id AS group_id
+    FROM regex_whitelist
+    LEFT JOIN regex_whitelist_by_group ON regex_whitelist_by_group.regex_whitelist_id = regex_whitelist.id
+    LEFT JOIN "group" ON "group".id = regex_whitelist_by_group.group_id
+    WHERE regex_whitelist.enabled = 1 AND (regex_whitelist_by_group.group_id IS NULL OR "group".enabled = 1)
+    ORDER BY regex_whitelist.id;
+
+DROP VIEW vw_regex_blacklist;
+CREATE VIEW vw_regex_blacklist AS SELECT DISTINCT domain, regex_blacklist.id AS id, regex_blacklist_by_group.group_id AS group_id
+    FROM regex_blacklist
+    LEFT JOIN regex_blacklist_by_group ON regex_blacklist_by_group.regex_blacklist_id = regex_blacklist.id
+    LEFT JOIN "group" ON "group".id = regex_blacklist_by_group.group_id
+    WHERE regex_blacklist.enabled = 1 AND (regex_blacklist_by_group.group_id IS NULL OR "group".enabled = 1)
+    ORDER BY regex_blacklist.id;
 
 CREATE TABLE client
 (

--- a/advanced/Scripts/database_migration/gravity/3_to_4.sql
+++ b/advanced/Scripts/database_migration/gravity/3_to_4.sql
@@ -13,12 +13,34 @@ CREATE TABLE gravity
 );
 
 DROP VIEW vw_gravity;
-CREATE VIEW vw_gravity AS SELECT domain, gravity.adlist_id
+CREATE VIEW vw_gravity AS SELECT domain, adlist_by_group.group_id AS group_id
     FROM gravity
     LEFT JOIN adlist_by_group ON adlist_by_group.adlist_id = gravity.adlist_id
     LEFT JOIN adlist ON adlist.id = gravity.adlist_id
     LEFT JOIN "group" ON "group".id = adlist_by_group.group_id
     WHERE adlist.enabled = 1 AND (adlist_by_group.group_id IS NULL OR "group".enabled = 1);
+
+DROP VIEW vw_whitelist;
+CREATE VIEW vw_whitelist AS SELECT domain, whitelist_by_group.group_id AS group_id
+    FROM whitelist
+    LEFT JOIN whitelist_by_group ON whitelist_by_group.whitelist_id = whitelist.id
+    LEFT JOIN "group" ON "group".id = whitelist_by_group.group_id
+    WHERE whitelist.enabled = 1 AND (whitelist_by_group.group_id IS NULL OR "group".enabled = 1)
+    ORDER BY whitelist.id;
+
+DROP VIEW vw_blacklist;
+CREATE VIEW vw_blacklist AS SELECT domain, blacklist_by_group.group_id AS group_id
+    FROM blacklist
+    LEFT JOIN blacklist_by_group ON blacklist_by_group.blacklist_id = blacklist.id
+    LEFT JOIN "group" ON "group".id = blacklist_by_group.group_id
+    WHERE blacklist.enabled = 1 AND (blacklist_by_group.group_id IS NULL OR "group".enabled = 1)
+    ORDER BY blacklist.id;
+
+CREATE TABLE client
+(
+	ip TEXT NOL NULL PRIMARY KEY,
+	"groups" TEXT NOT NULL
+);
 
 UPDATE info SET value = 4 WHERE property = 'version';
 

--- a/advanced/Scripts/database_migration/gravity/3_to_4.sql
+++ b/advanced/Scripts/database_migration/gravity/3_to_4.sql
@@ -38,8 +38,15 @@ CREATE VIEW vw_blacklist AS SELECT domain, blacklist_by_group.group_id AS group_
 
 CREATE TABLE client
 (
-	ip TEXT NOL NULL PRIMARY KEY,
-	"groups" TEXT NOT NULL
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	ip TEXT NOL NULL UNIQUE
+);
+
+CREATE TABLE client_by_group
+(
+	client_id INTEGER NOT NULL REFERENCES client (id),
+	group_id INTEGER NOT NULL REFERENCES "group" (id),
+	PRIMARY KEY (client_id, group_id)
 );
 
 UPDATE info SET value = 4 WHERE property = 'version';

--- a/advanced/Scripts/database_migration/gravity/4_to_5.sql
+++ b/advanced/Scripts/database_migration/gravity/4_to_5.sql
@@ -1,0 +1,17 @@
+.timeout 30000
+
+PRAGMA FOREIGN_KEYS=OFF;
+
+BEGIN TRANSACTION;
+
+DROP VIEW vw_adlist;
+CREATE VIEW vw_adlist AS SELECT DISTINCT address, adlist.id AS id
+    FROM adlist
+    LEFT JOIN adlist_by_group ON adlist_by_group.adlist_id = adlist.id
+    LEFT JOIN "group" ON "group".id = adlist_by_group.group_id
+    WHERE adlist.enabled = 1 AND (adlist_by_group.group_id IS NULL OR "group".enabled = 1)
+    ORDER BY adlist.id;
+
+UPDATE info SET value = 5 WHERE property = 'version';
+
+COMMIT;

--- a/gravity.sh
+++ b/gravity.sh
@@ -529,19 +529,24 @@ gravity_ParseFileIntoDomains() {
 gravity_Table_Count() {
   local table="${1}"
   local str="${2}"
-  local extra="${3}"
   local num
-  num="$(sqlite3 "${gravityDBfile}" "SELECT COUNT(*) FROM ${table} ${extra};")"
-  echo -e "  ${INFO} Number of ${str}: ${num}"
+  num="$(sqlite3 "${gravityDBfile}" "SELECT COUNT(*) FROM ${table};")"
+  if [[ "${table}" == "vw_gravity" ]]; then
+    local unique
+    unique="$(sqlite3 "${gravityDBfile}" "SELECT COUNT(DISTINCT domain) FROM ${table};")"
+    echo -e "  ${INFO} Number of ${str}: ${num} (${unique} unique domains)"
+  else
+    echo -e "  ${INFO} Number of ${str}: ${num}"
+  fi
 }
 
 # Output count of blacklisted domains and regex filters
 gravity_ShowCount() {
-  gravity_Table_Count "gravity" "gravity domains" ""
-  gravity_Table_Count "blacklist" "exact blacklisted domains" "WHERE enabled = 1"
-  gravity_Table_Count "regex_blacklist" "regex blacklist filters" "WHERE enabled = 1"
-  gravity_Table_Count "whitelist" "exact whitelisted domains" "WHERE enabled = 1"
-  gravity_Table_Count "regex_whitelist" "regex whitelist filters" "WHERE enabled = 1"
+  gravity_Table_Count "vw_gravity" "gravity domains" ""
+  gravity_Table_Count "vw_blacklist" "exact blacklisted domains"
+  gravity_Table_Count "vw_regex_blacklist" "regex blacklist filters"
+  gravity_Table_Count "vw_whitelist" "exact whitelisted domains"
+  gravity_Table_Count "vw_regex_whitelist" "regex whitelist filters"
 }
 
 # Parse list of domains into hosts format

--- a/gravity.sh
+++ b/gravity.sh
@@ -40,9 +40,6 @@ gravityDBschema="${piholeGitDir}/advanced/Templates/gravity.db.sql"
 optimize_database=false
 
 domainsExtension="domains"
-matterAndLight="${basename}.0.matterandlight.txt"
-parsedMatter="${basename}.1.parsedmatter.txt"
-preEventHorizon="list.preEventHorizon"
 
 resolver="pihole-FTL"
 
@@ -92,7 +89,7 @@ generate_gravity_database() {
 
 update_gravity_timestamp() {
   # Update timestamp when the gravity table was last updated successfully
-  output=$( { sqlite3 "${gravityDBfile}" <<< "INSERT OR REPLACE INTO info (property,value) values (\"updated\",cast(strftime('%s', 'now') as int));"; } 2>&1 )
+  output=$( { sqlite3 "${gravityDBfile}" <<< "INSERT OR REPLACE INTO info (property,value) values ('updated',cast(strftime('%s', 'now') as int));"; } 2>&1 )
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
@@ -459,7 +456,7 @@ gravity_DownloadBlocklistFromUrl() {
 
 # Parse source files into domains format
 gravity_ParseFileIntoDomains() {
-  local source="${1}" destination="${2}" firstLine abpFilter
+  local source="${1}" destination="${2}" firstLine
 
   # Determine if we are parsing a consolidated list
   #if [[ "${source}" == "${piholeDir}/${matterAndLight}" ]]; then
@@ -612,7 +609,7 @@ gravity_Cleanup() {
   # Ensure this function only runs when gravity_SetDownloadOptions() has completed
   if [[ "${gravity_Blackbody:-}" == true ]]; then
     # Remove any unused .domains files
-    for file in ${piholeDir}/*.${domainsExtension}; do
+    for file in "${piholeDir}"/*."${domainsExtension}"; do
       # If list is not in active array, then remove it
       if [[ ! "${activeDomains[*]}" == *"${file}"* ]]; then
         rm -f "${file}" 2> /dev/null || \

--- a/gravity.sh
+++ b/gravity.sh
@@ -434,7 +434,7 @@ gravity_DownloadBlocklistFromUrl() {
       # Determine if blocklist is non-standard and parse as appropriate
       gravity_ParseFileIntoDomains "${patternBuffer}" "${saveLocation}"
       # Add domains to database table
-      str="Adding to database table"
+      str="Adding adlist with ID ${adlistID} to database table"
       echo -ne "  ${INFO} ${str}..."
       database_table_from_file "gravity" "${saveLocation}" "${adlistID}"
       echo -e "${OVER}  ${TICK} ${str}"
@@ -677,9 +677,9 @@ if [[ "${recreate_database:-}" == true ]]; then
   str="Restoring from migration backup"
   echo -ne "${INFO} ${str}..."
   rm "${gravityDBfile}"
-  pushd "${piholeDir}" > /dev/null
+  pushd "${piholeDir}" > /dev/null || exit
   cp migration_backup/* .
-  popd > /dev/null
+  popd > /dev/null || exit
   echo -e "${OVER}  ${TICK} ${str}"
 fi
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Implement back-end changes for https://github.com/pi-hole/FTL/pull/642

**How does this PR accomplish the above?:**

- Update database from 3 to 4 (add client-specific group support, modify existing views)
- Change `gravity.sh`
  - Instead of unifying and sorting domains during gravity, we parse and store the entire adlists in the database. This allows us to assign adlists to groups which would not be possible with unified data.
  - Fix an issue where disabled list entries are still counted towards to total list count

**What documentation changes (if any) are needed to support this PR?:**

Many changes are required as the entire handling is changed to be group-based.