### PR TITLE
Exit installation when SELinux in unsupported state

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1968,22 +1968,22 @@ checkSelinux() {
         DEFAULT_SELINUX=$(awk -F= '/^SELINUX=/ {print $2}' /etc/selinux/config)
         case "${DEFAULT_SELINUX,,}" in
             enforcing)
-                echo -e "${CROSS} ${COL_RED}Default SELinux: $DEFAULT_SELINUX${COL_NC}"
+                printf "%b %bDefault SELinux: %s%b\\n" "${CROSS}" "${COL_RED}" "${DEFAULT_SELINUX}" "${COL_NC}"
                 SELINUX_ENFORCING=1
                 ;;
             *)  # 'permissive' and 'disabled'
-                echo -e "${TICK} ${COL_GREEN}Default SELinux: $DEFAULT_SELINUX${COL_NC}";
+                printf "%b %bDefault SELinux: %s%b\\n" "${TICK}" "${COL_GREEN}" "${DEFAULT_SELINUX}" "${COL_NC}"
                 ;;
         esac
         # Check the current state of SELinux
         CURRENT_SELINUX=$(getenforce)
         case "${CURRENT_SELINUX,,}" in
             enforcing)
-                echo -e "${CROSS} ${COL_RED}Current SELinux: $CURRENT_SELINUX${COL_NC}"
+                printf "%b %bCurrent SELinux: %s%b\\n" "${CROSS}" "${COL_RED}" "${CURRENT_SELINUX}" "${COL_NC}"
                 SELINUX_ENFORCING=1
                 ;;
             *)  # 'permissive' and 'disabled'
-                echo -e "${TICK} ${COL_GREEN}Current SELinux: $CURRENT_SELINUX${COL_NC}";
+                printf "%b %bCurrent SELinux: %s%b\\n" "${TICK}" "${COL_GREEN}" "${CURRENT_SELINUX}" "${COL_NC}"
                 ;;
         esac
     else
@@ -1991,8 +1991,8 @@ checkSelinux() {
     fi
     # Exit the installer if any SELinux checks toggled the flag
     if [[ "${SELINUX_ENFORCING}" -eq 1 ]] && [[ -z "${PIHOLE_SELINUX}" ]]; then
-        echo -e "Pi-hole does not provide an SELinux policy as the required changes modify the security of your system."
-        echo -e "Please refer to https://wiki.centos.org/HowTos/SELinux if SELinux is required for your deployment."
+        printf "Pi-hole does not provide an SELinux policy as the required changes modify the security of your system.\\n"
+        printf "Please refer to https://wiki.centos.org/HowTos/SELinux if SELinux is required for your deployment.\\n"
         printf "\\n%bSELinux Enforcing detected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}";
         exit 1;
     fi

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -254,73 +254,16 @@ def test_configureFirewall_IPTables_enabled_not_exist_no_errors(Pihole):
     assert len(re.findall(r'tcp --dport 4711:4720', firewall_calls)) == 2
 
 
-def test_selinux_enforcing_default_exit(Pihole):
+def test_selinux_not_detected(Pihole):
     '''
-    confirms installer prompts to exit when SELinux is Enforcing by default
+    confirms installer continues when SELinux configuration file does not exist
     '''
-    # getenforce returns the running state of SELinux
-    mock_command('getenforce', {'*': ('Enforcing', '0')}, Pihole)
-    # Whiptail dialog returns Cancel for user prompt
-    mock_command('whiptail', {'*': ('', '1')}, Pihole)
     check_selinux = Pihole.run('''
+    rm -f /etc/selinux/config
     source /opt/pihole/basic-install.sh
     checkSelinux
     ''')
-    expected_stdout = info_box + ' SELinux mode detected: Enforcing'
-    assert expected_stdout in check_selinux.stdout
-    expected_stdout = 'SELinux Enforcing detected, exiting installer'
-    assert expected_stdout in check_selinux.stdout
-    assert check_selinux.rc == 1
-
-
-def test_selinux_enforcing_continue(Pihole):
-    '''
-    confirms installer prompts to continue with custom policy warning
-    '''
-    # getenforce returns the running state of SELinux
-    mock_command('getenforce', {'*': ('Enforcing', '0')}, Pihole)
-    # Whiptail dialog returns Continue for user prompt
-    mock_command('whiptail', {'*': ('', '0')}, Pihole)
-    check_selinux = Pihole.run('''
-    source /opt/pihole/basic-install.sh
-    checkSelinux
-    ''')
-    expected_stdout = info_box + ' SELinux mode detected: Enforcing'
-    assert expected_stdout in check_selinux.stdout
-    expected_stdout = info_box + (' Continuing installation with SELinux '
-                                  'Enforcing')
-    assert expected_stdout in check_selinux.stdout
-    expected_stdout = info_box + (' Please refer to official SELinux '
-                                  'documentation to create a custom policy')
-    assert expected_stdout in check_selinux.stdout
-    assert check_selinux.rc == 0
-
-
-def test_selinux_permissive(Pihole):
-    '''
-    confirms installer continues when SELinux is Permissive
-    '''
-    # getenforce returns the running state of SELinux
-    mock_command('getenforce', {'*': ('Permissive', '0')}, Pihole)
-    check_selinux = Pihole.run('''
-    source /opt/pihole/basic-install.sh
-    checkSelinux
-    ''')
-    expected_stdout = info_box + ' SELinux mode detected: Permissive'
-    assert expected_stdout in check_selinux.stdout
-    assert check_selinux.rc == 0
-
-
-def test_selinux_disabled(Pihole):
-    '''
-    confirms installer continues when SELinux is Disabled
-    '''
-    mock_command('getenforce', {'*': ('Disabled', '0')}, Pihole)
-    check_selinux = Pihole.run('''
-    source /opt/pihole/basic-install.sh
-    checkSelinux
-    ''')
-    expected_stdout = info_box + ' SELinux mode detected: Disabled'
+    expected_stdout = info_box + ' SELinux not detected'
     assert expected_stdout in check_selinux.stdout
     assert check_selinux.rc == 0
 

--- a/test/test_centos_fedora_support.py
+++ b/test/test_centos_fedora_support.py
@@ -7,6 +7,68 @@ from conftest import (
     mock_command_2,
 )
 
+def mock_selinux_config(state, Pihole):
+    '''
+    Creates a mock SELinux config file with expected content
+    '''
+    # validate state string
+    valid_states = ['enforcing', 'permissive', 'disabled']
+    assert state in valid_states
+    # getenforce returns the running state of SELinux
+    mock_command('getenforce', {'*': (state.capitalize(), '0')}, Pihole)
+    # create mock configuration with desired content
+    Pihole.run('''
+    mkdir /etc/selinux
+    echo "SELINUX={state}" > /etc/selinux/config
+    '''.format(state=state.lower()))
+
+
+@pytest.mark.parametrize("tag", [('centos'), ('fedora'), ])
+def test_selinux_enforcing_exit(Pihole):
+    '''
+    confirms installer prompts to exit when SELinux is Enforcing by default
+    '''
+    mock_selinux_config("enforcing", Pihole)
+    check_selinux = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    checkSelinux
+    ''')
+    expected_stdout = cross_box + ' Current SELinux: Enforcing'
+    assert expected_stdout in check_selinux.stdout
+    expected_stdout = 'SELinux Enforcing detected, exiting installer'
+    assert expected_stdout in check_selinux.stdout
+    assert check_selinux.rc == 1
+
+
+@pytest.mark.parametrize("tag", [('centos'), ('fedora'), ])
+def test_selinux_permissive(Pihole):
+    '''
+    confirms installer continues when SELinux is Permissive
+    '''
+    mock_selinux_config("permissive", Pihole)
+    check_selinux = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    checkSelinux
+    ''')
+    expected_stdout = tick_box + ' Current SELinux: Permissive'
+    assert expected_stdout in check_selinux.stdout
+    assert check_selinux.rc == 0
+
+
+@pytest.mark.parametrize("tag", [('centos'), ('fedora'), ])
+def test_selinux_disabled(Pihole):
+    '''
+    confirms installer continues when SELinux is Disabled
+    '''
+    mock_selinux_config("disabled", Pihole)
+    check_selinux = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    checkSelinux
+    ''')
+    expected_stdout = tick_box + ' Current SELinux: Disabled'
+    assert expected_stdout in check_selinux.stdout
+    assert check_selinux.rc == 0
+
 
 @pytest.mark.parametrize("tag", [('fedora'), ])
 def test_epel_and_remi_not_installed_fedora(Pihole):

--- a/test/test_centos_fedora_support.py
+++ b/test/test_centos_fedora_support.py
@@ -7,6 +7,7 @@ from conftest import (
     mock_command_2,
 )
 
+
 def mock_selinux_config(state, Pihole):
     '''
     Creates a mock SELinux config file with expected content


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits.

---
**What does this PR aim to accomplish?:**
Lower support staff stress levels for when users fail to read the SELinux installer prompts.  
The installer currently notifies the user that SELinux Enforcing is not supported and would result in a broken installation.  
The install dialogs would even default to 'no' and exit for users who spam _enter_ through the installer forcing them to select 'yes'. These users would then start creating issues and support requests inquiring why their installations were unsuccessful.

**How does this PR accomplish the above?:**
- Remove SELinux `whiptail` prompt
- Exit installer when SELinux is detected in a enforcing state.
- Add environment variable to allow advanced users to override this restriction
- Update test suite accordingly
    - Move SELinux tests from the main installer test suite to the fedora/centos test suite.
    - Update test assertions for code changes
    - Create additional test for when SElinux is _not found_ in the main installer test suite.

**What documentation changes (if any) are needed to support this PR?:**
Documentation required for `PIHOLE_SELINUX` environment variable.
SELinux savvy users administrators can allow an an installation with SELinux enforcing by prefixing the install command:
```
PIHOLE_SELINUX=1 ./basic_install.sh
```
This variable can be _anything_ so long as it exists.
