### PR TITLE
Update webpage.sh to allow remove of DHCP-Lease

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -16,6 +16,7 @@ readonly dhcpconfig="/etc/dnsmasq.d/02-pihole-dhcp.conf"
 readonly FTLconf="/etc/pihole/pihole-FTL.conf"
 # 03 -> wildcards
 readonly dhcpstaticconfig="/etc/dnsmasq.d/04-pihole-static-dhcp.conf"
+readonly dhcpleasefile="/etc/pihole/dhcp.leases"
 readonly PI_HOLE_BIN_DIR="/usr/local/bin"
 
 coltable="/opt/pihole/COL_TABLE"
@@ -454,6 +455,14 @@ RemoveDHCPStaticAddress() {
     sed -i "/dhcp-host=${mac}.*/d" "${dhcpstaticconfig}"
 }
 
+RemoveDHCPLeaseAddress() {
+    mac="${args[2]}"
+    sed -i "/${mac}.*/d" "${dhcpleasefile}"
+    echo "${mac} -> lease deleted -> restart dnsmasq..."
+    # Restart dnsmasq to reload leases
+    RestartDNS
+}
+
 SetHostRecord() {
     if [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
         echo "Usage: pihole -a hostrecord <domain> [IPv4-address],[IPv6-address]
@@ -587,6 +596,7 @@ main() {
         "resolve"             ) ResolutionSettings;;
         "addstaticdhcp"       ) AddDHCPStaticAddress;;
         "removestaticdhcp"    ) RemoveDHCPStaticAddress;;
+        "removedhcplease"     ) RemoveDHCPLeaseAddress;;
         "-r" | "hostrecord"   ) SetHostRecord "$3";;
         "-e" | "email"        ) SetAdminEmail "$3";;
         "-i" | "interface"    ) SetListeningMode "$@";;


### PR DESCRIPTION
Enable Backend to remove DHCP-Lease-Entry from /etc/pihole/dhcp.leases

**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
The current GUI does not allow to remove DHCP-Leases from /etc/pihole/dhcp.leases
This is the first step to make such a feature possible. The core will be able to remove DHCP-Leases via an added commandline-parameter.
The next step is to expand the Admin-GUI to allow removing Leases from the Web-Management like already implemented for Static-DHCP-Entries.
This part will be a PR in AdminLTE-Repository

**How does this PR accomplish the above?:**
The existing function RemoveDHCPStaticAddress() is copied and rewritten to RemoveDHCPLeaseAddress()
The existing commandline parameter 'removestaticdhcp' is copied and rewritten to 'removedhcplease'

**What documentation changes (if any) are needed to support this PR?:**
Commandline-parameter can be added to https://docs.pi-hole.net/core/pihole-command/
Syntax is the same as for 'removestaticdhcp' but this one is missing at the moment, too.
