### PR TITLE
Minor installer output enhancements

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -838,7 +838,8 @@ setDHCPCD() {
         # Then use the ip command to immediately set the new address
         ip addr replace dev "${PIHOLE_INTERFACE}" "${IPV4_ADDRESS}"
         # Also give a warning that the user may need to reboot their system
-        printf "  %b Set IP address to %s \\n  You may need to restart after the install is complete\\n" "${TICK}" "${IPV4_ADDRESS%/*}"
+        printf "  %b Set IP address to %s\\n" "${TICK}" "${IPV4_ADDRESS%/*}"
+        printf "  %b You may need to restart after the install is complete\\n" "${INFO}"
     fi
 }
 
@@ -984,8 +985,6 @@ setDNS() {
     # exit if Cancel is selected
     { printf "  %bCancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"; exit 1; }
 
-    # Display the selection
-    printf "  %b Using " "${INFO}"
     # Depending on the user's choice, set the GLOBAl variables to the IP of the respective provider
     if [[ "${DNSchoices}" == "Custom" ]]
     then
@@ -1037,14 +1036,14 @@ setDNS() {
                 if [[ "${PIHOLE_DNS_2}" == "${strInvalid}" ]]; then
                     PIHOLE_DNS_2=""
                 fi
-            # Since the settings will not work, stay in the loop
-            DNSSettingsCorrect=False
+                # Since the settings will not work, stay in the loop
+                DNSSettingsCorrect=False
             # Otherwise,
             else
                 # Show the settings
                 if (whiptail --backtitle "Specify Upstream DNS Provider(s)" --title "Upstream DNS Provider(s)" --yesno "Are these settings correct?\\n    DNS Server 1:   $PIHOLE_DNS_1\\n    DNS Server 2:   ${PIHOLE_DNS_2}" "${r}" "${c}"); then
-                # and break from the loop since the servers are valid
-                DNSSettingsCorrect=True
+                    # and break from the loop since the servers are valid
+                    DNSSettingsCorrect=True
                 # Otherwise,
                 else
                     # If the settings are wrong, the loop continues
@@ -1052,7 +1051,7 @@ setDNS() {
                 fi
             fi
         done
-     else
+    else
         # Save the old Internal Field Separator in a variable
         OIFS=$IFS
         # and set the new one to newline
@@ -1062,7 +1061,6 @@ setDNS() {
             DNSName="$(cut -d';' -f1 <<< "${DNSServer}")"
             if [[ "${DNSchoices}" == "${DNSName}" ]]
             then
-                printf "%s\\n" "${DNSName}"
                 PIHOLE_DNS_1="$(cut -d';' -f2 <<< "${DNSServer}")"
                 PIHOLE_DNS_2="$(cut -d';' -f3 <<< "${DNSServer}")"
                 break
@@ -1071,6 +1069,9 @@ setDNS() {
         # Restore the IFS to what it was
         IFS=${OIFS}
     fi
+
+    # Display final selection
+    printf "  %b Using upstream DNS: %s %s\\n" "${INFO}" "${PIHOLE_DNS_1}" "${PIHOLE_DNS_2}"
 }
 
 # Allow the user to enable/disable logging

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1071,7 +1071,9 @@ setDNS() {
     fi
 
     # Display final selection
-    printf "  %b Using upstream DNS: %s %s\\n" "${INFO}" "${PIHOLE_DNS_1}" "${PIHOLE_DNS_2}"
+    local DNSIP=${PIHOLE_DNS_1}
+    [[ -z ${PIHOLE_DNS_2} ]] || DNSIP+=", ${PIHOLE_DNS_2}"
+    printf "  %b Using upstream DNS: %s (%s)\\n" "${INFO}" "${DNSchoices}" "${DNSIP}"
 }
 
 # Allow the user to enable/disable logging


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

**Signed-off-by: MichaIng <micha@dietpi.com>**

---
**What does this PR aim to accomplish?:**
+ Print restart hint, after setting IPv4 address, on a separate line with [i] prefix to not break text alignment
+ Print final upstream DNS choice as a single printf call and by this fix missing info and linebreak on "Custom" choices.
+ Minor if/then/else code alignment

**Before, when choosing preset DNS:**
```
  [i] Using Quad9 (filtered, DNSSEC)
  [✓] Set IP address to 192.168.178.30
  You may need to restart after the install is complete
```

**Before, when choosing custom DNS:**
```
  [i] Using   [✓] Set IP address to 192.168.178.30
  You may need to restart after the install is complete
```

**After:**
```
  [i] Using upstream DNS: 192.168.178.1 192.168.178.1
  [✓] Set IP address to 192.168.178.30
  [i] You may need to restart after the install is complete
```
- Note that now in both cases the bare IP addresses are shown instead of the DNS providers name. However this is what is finally stored and shown in web UI.
- An alternative is to keep printing the DNS provider name in case, and only print bare IP when custom DNS was chosen. But I personally prefer the here offered compliant way.