### PR TITLE
Alternative approach to fixing `tbd` error

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -46,6 +46,16 @@ checkout() {
     local corebranches
     local webbranches
 
+    #Determine which binary we should download
+    local ftlBinary
+
+    if [[ -f "/etc/pihole/ftlBinary" ]];then
+        ftlBinary=$(</etc/pihole/ftlBinary)
+    else
+        get_binary_name
+        ftlBinary=$(</etc/pihole/ftlBinary)
+    fi
+
     # Avoid globbing
     set -f
 
@@ -88,7 +98,7 @@ checkout() {
 
         get_binary_name
         local path
-        path="development/${binary}"
+        path="development/${ftlBinary}"
         echo "development" > /etc/pihole/ftlbranch
         chmod 644 /etc/pihole/ftlbranch
     elif [[ "${1}" == "master" ]] ; then
@@ -103,7 +113,7 @@ checkout() {
         #echo -e "  ${TICK} Web Interface"
         get_binary_name
         local path
-        path="master/${binary}"
+        path="master/${ftlBinary}"
         echo "master" > /etc/pihole/ftlbranch
         chmod 644 /etc/pihole/ftlbranch
     elif [[ "${1}" == "core" ]] ; then
@@ -163,13 +173,13 @@ checkout() {
     elif [[ "${1}" == "ftl" ]] ; then
         get_binary_name
         local path
-        path="${2}/${binary}"
+        path="${2}/${ftlBinary}"
 
         if check_download_exists "$path"; then
             echo "  ${TICK} Branch ${2} exists"
             echo "${2}" > /etc/pihole/ftlbranch
             chmod 644 /etc/pihole/ftlbranch
-            FTLinstall "${binary}"
+            FTLinstall "${ftlBinary}"
             restart_service pihole-FTL
             enable_service pihole-FTL
         else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2219,6 +2219,16 @@ FTLinstall() {
         ftlBranch="master"
     fi
 
+    #Determine which binary we should download
+    local ftlBinary
+
+    if [[ -f "/etc/pihole/ftlBinary" ]];then
+        ftlBinary=$(</etc/pihole/ftlBinary)
+    else
+        get_binary_name
+        ftlBinary=$(</etc/pihole/ftlBinary)
+    fi
+
     # Determine which version of FTL to download
     if [[ "${ftlBranch}" == "master" ]];then
         url="https://github.com/pi-hole/FTL/releases/download/${latesttag%$'\r'}"
@@ -2227,12 +2237,12 @@ FTLinstall() {
     fi
 
     # If the download worked,
-    if curl -sSL --fail "${url}/${binary}" -o "${binary}"; then
+    if curl -sSL --fail "${url}/${ftlBinary}" -o "${ftlBinary}"; then
         # get sha1 of the binary we just downloaded for verification.
-        curl -sSL --fail "${url}/${binary}.sha1" -o "${binary}.sha1"
+        curl -sSL --fail "${url}/${ftlBinary}.sha1" -o "${ftlBinary}.sha1"
 
         # If we downloaded binary file (as opposed to text),
-        if sha1sum --status --quiet -c "${binary}".sha1; then
+        if sha1sum --status --quiet -c "${ftlBinary}".sha1; then
             printf "transferred... "
 
             # Before stopping FTL, we download the macvendor database
@@ -2244,7 +2254,7 @@ FTLinstall() {
             stop_service pihole-FTL &> /dev/null
 
             # Install the new version with the correct permissions
-            install -T -m 0755 "${binary}" /usr/bin/pihole-FTL
+            install -T -m 0755 "${ftlBinary}" /usr/bin/pihole-FTL
 
             # Move back into the original directory the user was in
             popd > /dev/null || { printf "Unable to return to original directory after FTL binary download.\\n"; return 1; }
@@ -2257,7 +2267,7 @@ FTLinstall() {
             # the download failed, so just go back to the original directory
             popd > /dev/null || { printf "Unable to return to original directory after FTL binary download.\\n"; return 1; }
             printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
-            printf "  %bError: Download of %s/%s failed (checksum error)%b\\n" "${COL_LIGHT_RED}" "${url}" "${binary}" "${COL_NC}"
+            printf "  %bError: Download of %s/%s failed (checksum error)%b\\n" "${COL_LIGHT_RED}" "${url}" "${ftlBinary}" "${COL_NC}"
             return 1
         fi
     # Otherwise,
@@ -2265,7 +2275,7 @@ FTLinstall() {
         popd > /dev/null || { printf "Unable to return to original directory after FTL binary download.\\n"; return 1; }
         printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
         # The URL could not be found
-        printf "  %bError: URL %s/%s not found%b\\n" "${COL_LIGHT_RED}" "${url}" "${binary}" "${COL_NC}"
+        printf "  %bError: URL %s/%s not found%b\\n" "${COL_LIGHT_RED}" "${url}" "${ftlBinary}" "${COL_NC}"
         return 1
     fi
 }
@@ -2297,6 +2307,8 @@ get_binary_name() {
     local machine
     machine=$(uname -m)
 
+    local ftlBinary
+
     local str="Detecting architecture"
     printf "  %b %s..." "${INFO}" "${str}"
     # If the machine is arm or aarch
@@ -2312,24 +2324,24 @@ get_binary_name() {
         if [[ "${lib}" == "/lib/ld-linux-aarch64.so.1" ]]; then
             printf "%b  %b Detected ARM-aarch64 architecture\\n" "${OVER}" "${TICK}"
             # set the binary to be used
-            binary="pihole-FTL-aarch64-linux-gnu"
+            ftlBinary="pihole-FTL-aarch64-linux-gnu"
         #
         elif [[ "${lib}" == "/lib/ld-linux-armhf.so.3" ]]; then
             #
             if [[ "${rev}" -gt 6 ]]; then
                 printf "%b  %b Detected ARM-hf architecture (armv7+)\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                binary="pihole-FTL-arm-linux-gnueabihf"
+                ftlBinary="pihole-FTL-arm-linux-gnueabihf"
             # Otherwise,
             else
                 printf "%b  %b Detected ARM-hf architecture (armv6 or lower) Using ARM binary\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                binary="pihole-FTL-arm-linux-gnueabi"
+                ftlBinary="pihole-FTL-arm-linux-gnueabi"
             fi
         else
             printf "%b  %b Detected ARM architecture\\n" "${OVER}" "${TICK}"
             # set the binary to be used
-            binary="pihole-FTL-arm-linux-gnueabi"
+            ftlBinary="pihole-FTL-arm-linux-gnueabi"
         fi
     elif [[ "${machine}" == "x86_64" ]]; then
         # This gives the architecture of packages dpkg installs (for example, "i386")
@@ -2342,12 +2354,12 @@ get_binary_name() {
         # in the past (see https://github.com/pi-hole/pi-hole/pull/2004)
         if [[ "${dpkgarch}" == "i386" ]]; then
             printf "%b  %b Detected 32bit (i686) architecture\\n" "${OVER}" "${TICK}"
-            binary="pihole-FTL-linux-x86_32"
+            ftlBinary="pihole-FTL-linux-x86_32"
         else
             # 64bit
             printf "%b  %b Detected x86_64 architecture\\n" "${OVER}" "${TICK}"
             # set the binary to be used
-            binary="pihole-FTL-linux-x86_64"
+            ftlBinary="pihole-FTL-linux-x86_64"
         fi
     else
         # Something else - we try to use 32bit executable and warn the user
@@ -2358,13 +2370,14 @@ get_binary_name() {
         else
             printf "%b  %b Detected 32bit (i686) architecture\\n" "${OVER}" "${TICK}"
         fi
-        binary="pihole-FTL-linux-x86_32"
+        ftlBinary="pihole-FTL-linux-x86_32"
     fi
+
+    echo "${ftlBinary}" > /etc/pihole/ftlBinary
+    chmod 644 /etc/pihole/ftlBinary
 }
 
 FTLcheckUpdate() {
-    get_binary_name
-
     #In the next section we check to see if FTL is already installed (in case of pihole -r).
     #If the installed version matches the latest version, then check the installed sha1sum of the binary vs the remote sha1sum. If they do not match, then download
     printf "  %b Checking for existing FTL binary...\\n" "${INFO}"
@@ -2372,12 +2385,23 @@ FTLcheckUpdate() {
     local ftlLoc
     ftlLoc=$(which pihole-FTL 2>/dev/null)
 
+    #Determine which branch FTL should be on
     local ftlBranch
 
     if [[ -f "/etc/pihole/ftlbranch" ]];then
         ftlBranch=$(</etc/pihole/ftlbranch)
     else
         ftlBranch="master"
+    fi
+
+    #Determine which binary we should download
+    local ftlBinary
+
+    if [[ -f "/etc/pihole/ftlBinary" ]];then
+        ftlBinary=$(</etc/pihole/ftlBinary)
+    else
+        get_binary_name
+        ftlBinary=$(</etc/pihole/ftlBinary)
     fi
 
     local remoteSha1
@@ -2393,7 +2417,7 @@ FTLcheckUpdate() {
     if [[ ! "${ftlBranch}" == "master" ]]; then
         #Check whether or not the binary for this FTL branch actually exists. If not, then there is no update!
         local path
-        path="${ftlBranch}/${binary}"
+        path="${ftlBranch}/${ftlBinary}"
         # shellcheck disable=SC1090
         if ! check_download_exists "$path"; then
             printf "  %b Branch \"%s\" is not available.\\n" "${INFO}" "${ftlBranch}"
@@ -2404,7 +2428,7 @@ FTLcheckUpdate() {
         if [[ ${ftlLoc} ]]; then
             # We already have a pihole-FTL binary downloaded.
             # Alt branches don't have a tagged version against them, so just confirm the checksum of the local vs remote to decide whether we download or not
-            remoteSha1=$(curl -sSL --fail "https://ftl.pi-hole.net/${ftlBranch}/${binary}.sha1" | cut -d ' ' -f 1)
+            remoteSha1=$(curl -sSL --fail "https://ftl.pi-hole.net/${ftlBranch}/${ftlBinary}.sha1" | cut -d ' ' -f 1)
             localSha1=$(sha1sum "$(which pihole-FTL)" | cut -d ' ' -f 1)
 
             if [[ "${remoteSha1}" != "${localSha1}" ]]; then
@@ -2437,7 +2461,7 @@ FTLcheckUpdate() {
             else
                 printf "  %b Latest FTL Binary already installed (%s). Confirming Checksum...\\n" "${INFO}" "${FTLlatesttag}"
 
-                remoteSha1=$(curl -sSL --fail "https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1" | cut -d ' ' -f 1)
+                remoteSha1=$(curl -sSL --fail "https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${ftlBinary}.sha1" | cut -d ' ' -f 1)
                 localSha1=$(sha1sum "$(which pihole-FTL)" | cut -d ' ' -f 1)
 
                 if [[ "${remoteSha1}" != "${localSha1}" ]]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2222,12 +2222,7 @@ FTLinstall() {
     #Determine which binary we should download
     local ftlBinary
 
-    if [[ -f "/etc/pihole/ftlBinary" ]];then
-        ftlBinary=$(</etc/pihole/ftlBinary)
-    else
-        get_binary_name
-        ftlBinary=$(</etc/pihole/ftlBinary)
-    fi
+    ftlBinary=$(get_binary_name)
 
     # Determine which version of FTL to download
     if [[ "${ftlBranch}" == "master" ]];then
@@ -2307,8 +2302,8 @@ get_binary_name() {
     local machine
     machine=$(uname -m)
 
-    local ftlBinary
-
+    local -n output=$1
+    
     local str="Detecting architecture"
     printf "  %b %s..." "${INFO}" "${str}"
     # If the machine is arm or aarch
@@ -2324,24 +2319,24 @@ get_binary_name() {
         if [[ "${lib}" == "/lib/ld-linux-aarch64.so.1" ]]; then
             printf "%b  %b Detected ARM-aarch64 architecture\\n" "${OVER}" "${TICK}"
             # set the binary to be used
-            ftlBinary="pihole-FTL-aarch64-linux-gnu"
+            output="pihole-FTL-aarch64-linux-gnu"
         #
         elif [[ "${lib}" == "/lib/ld-linux-armhf.so.3" ]]; then
             #
             if [[ "${rev}" -gt 6 ]]; then
                 printf "%b  %b Detected ARM-hf architecture (armv7+)\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                ftlBinary="pihole-FTL-arm-linux-gnueabihf"
+                output="pihole-FTL-arm-linux-gnueabihf"
             # Otherwise,
             else
                 printf "%b  %b Detected ARM-hf architecture (armv6 or lower) Using ARM binary\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                ftlBinary="pihole-FTL-arm-linux-gnueabi"
+                output="pihole-FTL-arm-linux-gnueabi"
             fi
         else
             printf "%b  %b Detected ARM architecture\\n" "${OVER}" "${TICK}"
             # set the binary to be used
-            ftlBinary="pihole-FTL-arm-linux-gnueabi"
+            output="pihole-FTL-arm-linux-gnueabi"
         fi
     elif [[ "${machine}" == "x86_64" ]]; then
         # This gives the architecture of packages dpkg installs (for example, "i386")
@@ -2354,12 +2349,12 @@ get_binary_name() {
         # in the past (see https://github.com/pi-hole/pi-hole/pull/2004)
         if [[ "${dpkgarch}" == "i386" ]]; then
             printf "%b  %b Detected 32bit (i686) architecture\\n" "${OVER}" "${TICK}"
-            ftlBinary="pihole-FTL-linux-x86_32"
+            output="pihole-FTL-linux-x86_32"
         else
             # 64bit
             printf "%b  %b Detected x86_64 architecture\\n" "${OVER}" "${TICK}"
             # set the binary to be used
-            ftlBinary="pihole-FTL-linux-x86_64"
+            output="pihole-FTL-linux-x86_64"
         fi
     else
         # Something else - we try to use 32bit executable and warn the user
@@ -2370,11 +2365,8 @@ get_binary_name() {
         else
             printf "%b  %b Detected 32bit (i686) architecture\\n" "${OVER}" "${TICK}"
         fi
-        ftlBinary="pihole-FTL-linux-x86_32"
-    fi
-
-    echo "${ftlBinary}" > /etc/pihole/ftlBinary
-    chmod 644 /etc/pihole/ftlBinary
+        output="pihole-FTL-linux-x86_32"
+    fi    
 }
 
 FTLcheckUpdate() {
@@ -2394,15 +2386,10 @@ FTLcheckUpdate() {
         ftlBranch="master"
     fi
 
-    #Determine which binary we should download
-    local ftlBinary
+    #Determine which binary we should download    
+    get_binary_name ftlBinary
 
-    if [[ -f "/etc/pihole/ftlBinary" ]];then
-        ftlBinary=$(</etc/pihole/ftlBinary)
-    else
-        get_binary_name
-        ftlBinary=$(</etc/pihole/ftlBinary)
-    fi
+    echo "${ftlBinary}"
 
     local remoteSha1
     local localSha1


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Rather than storing the binary type in a global variable, store the result of `get_binary_type` into a file (`/etc/pihole/ftlBinary`) and read it when needed. If, for whatever reason, the file gets deleted after install, it will be recreated each time it needs to be referenced.
