### PR TITLE
Serve JS files with utf-8 charset too

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -49,7 +49,7 @@ mimetype.assign   = ( ".png"  => "image/png",
                       ".jpeg" => "image/jpeg",
                       ".html" => "text/html",
                       ".css" => "text/css; charset=utf-8",
-                      ".js" => "application/javascript",
+                      ".js" => "application/javascript; charset=utf-8",
                       ".json" => "application/json",
                       ".txt"  => "text/plain",
                       ".svg"  => "image/svg+xml" )

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -51,7 +51,7 @@ mimetype.assign   = ( ".png"  => "image/png",
                       ".jpeg" => "image/jpeg",
                       ".html" => "text/html",
                       ".css" => "text/css; charset=utf-8",
-                      ".js" => "application/javascript",
+                      ".js" => "application/javascript; charset=utf-8",
                       ".json" => "application/json",
                       ".txt"  => "text/plain",
                       ".svg"  => "image/svg+xml" )


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [ ] I give this submission freely and claim no ownership.
- [ ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Fixes #3026

---

Some thoughts:

1. It seems Debian and Raspbian do have https://github.com/lighttpd/lighttpd1.4/blob/master/doc/scripts/create-mime.conf.pl Maybe this should be included? Although I don't see JS files there from a quick look
2. Shouldn't there be a common config so that we don't duplicate stuff for Debian and Fedora? Not sure familiar with lighttpd myself
3. Personally I'd change the JS MIME to `text/javascript`. I'd also look into adding UTF-8 charset for more types

    >A nice list can be found here: https://github.com/h5bp/server-configs-apache/blob/master/src/media_types/character_encodings.conf and https://github.com/h5bp/server-configs-apache/blob/master/src/media_types/media_types.conf

I tested this on Raspbian Buster by editing `/etc/lighttpd/lighttpd.conf` temporarily and restarting `lighttpd`.