### PR TITLE
Remove duplicates from adlists before importing

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -163,7 +163,7 @@ database_table_from_file() {
   inputfile="${tmpFile}"
 
   # Remove possible duplicates found in lower-quality adlists
-  uniq -u "${inputfile}" "${inputfile}"
+  sort -u -o "${inputfile}" "${inputfile}"
 
   # Store domains in database table specified by ${table}
   # Use printf as .mode and .import need to be on separate lines

--- a/gravity.sh
+++ b/gravity.sh
@@ -160,9 +160,10 @@ database_table_from_file() {
       fi
     done
   fi
-
-
   inputfile="${tmpFile}"
+
+  # Remove possible duplicates found in lower-quality adlists
+  uniq -u "${inputfile}" "${inputfile}"
 
   # Store domains in database table specified by ${table}
   # Use printf as .mode and .import need to be on separate lines


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Some adlists contain domains more than once ([example 1](https://hosts.nfz.moe/basic/hosts), [example 2](https://hosts-file.net/exp.txt)). We need to ensure that these duplicates are removed before importing the list into the database to suppress unfriendly messages such as
```
/tmp/tmp.7BBrbzxJ0t.gravity:2908: INSERT failed: UNIQUE constraint failed: gravity.domain, gravity.adlist_id
/tmp/tmp.7BBrbzxJ0t.gravity:2909: INSERT failed: UNIQUE constraint failed: gravity.domain, gravity.adlist_id
/tmp/tmp.7BBrbzxJ0t.gravity:2910: INSERT failed: UNIQUE constraint failed: gravity.domain, gravity.adlist_id
/tmp/tmp.7BBrbzxJ0t.gravity:2911: INSERT failed: UNIQUE constraint failed: gravity.domain, gravity.adlist_id
[...]
```

**How does this PR accomplish the above?:**

Run `sort -u` on the to be imported domains to filter out duplicates. Benchmarking results:
```
  [i] Adding adlist with ID 1 to database table...
real    0m0.032s                                                           
user    0m0.024s                                                                                           
sys     0m0.008s                                               
  [✓] Adding adlist with ID 1 to database table
                                            
  [i] Target: mirror1.malwaredomains.com (justdomains)
  [✓] Status: Retrieval successful            
  [i] Adding adlist with ID 2 to database table...
real    0m0.019s            
user    0m0.019s                               
sys     0m0.001s                  
  [✓] Adding adlist with ID 2 to database table
                                           
  [i] Target: sysctl.org (hosts)                      
  [✓] Status: Retrieval successful
  [i] Adding adlist with ID 3 to database table...
real    0m0.010s
user    0m0.006s                                
sys     0m0.005s                  
  [✓] Adding adlist with ID 3 to database table
                                                              
  [i] Target: zeustracker.abuse.ch (blocklist.php?download=domainblocklist)
  [✓] Status: Retrieval successful              
  [i] Adding adlist with ID 4 to database table...
real    0m0.002s                                          
user    0m0.000s                                                 
sys     0m0.002s                                                                                                                                      
  [✓] Adding adlist with ID 4 to database table
```
(only the additonal `sort -u` command, measurement done on a low-power x86 server)

**What documentation changes (if any) are needed to support this PR?:**
None, this PR restores expected behavior