### PR TITLE
Show full URL during gravity download

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -337,7 +337,7 @@ gravity_DownloadBlocklists() {
       *) cmd_ext="";;
     esac
 
-    echo -e "  ${INFO} Target: ${domain} (${url##*/})"
+    echo -e "  ${INFO} Target: ${url}"
     gravity_DownloadBlocklistFromUrl "${url}" "${cmd_ext}" "${agent}" "${sourceIDs[$i]}"
     echo ""
   done


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Change the way the gravity script shows its download targets from
```
  [i] Target: zeustracker.abuse.ch (blocklist.php?download=domainblocklist)
  [✓] Status: Retrieval successful
  [✓] Adding adlist with ID 4 to database table

  [i] Target: s3.amazonaws.com (simple_tracking.txt)
  [✓] Status: Retrieval successful
  [✓] Adding adlist with ID 5 to database table

  [i] Target: s3.amazonaws.com (simple_ad.txt)
  [✓] Status: Retrieval successful
  [✓] Adding adlist with ID 6 to database table

  [i] Target: hosts-file.net (ad_servers.txt)
  [✓] Status: Retrieval successful
  [✓] Adding adlist with ID 7 to database table
```
to
```
  [i] Target: https://zeustracker.abuse.ch/blocklist.php?download=domainblocklist
  [✓] Status: Retrieval successful
  [✓] Adding adlist with ID 4 to database table

  [i] Target: https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
  [✓] Status: Retrieval successful
  [✓] Adding adlist with ID 5 to database table

  [i] Target: https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
  [✓] Status: Retrieval successful
  [✓] Adding adlist with ID 6 to database table

  [i] Target: https://hosts-file.net/ad_servers.txt
  [✓] Status: Retrieval successful
  [✓] Adding adlist with ID 7 to database table
```

Especially with `s3.amazonaws.com` hosted domains, a simplification to domain and file may be too inaccurate.

**How does this PR accomplish the above?:**

Show full URL instead of extracting domain and file.


**What documentation changes (if any) are needed to support this PR?:**

None