### PR TITLE
Improve list reloading

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -257,5 +257,5 @@ echo "DONE"
 fi
 
 if [[ "${reload}" != false ]]; then
-    pihole restartdns reload
+    pihole restartdns reload-lists
 fi

--- a/pihole
+++ b/pihole
@@ -105,17 +105,25 @@ restartDNS() {
   svcOption="${1:-restart}"
 
   # Determine if we should reload or restart
-  if [[ "${svcOption}" =~ "reload" ]]; then
-    # Reload has been requested
+  if [[ "${svcOption}" =~ "reload-lists" ]]; then
+    # Reloading of the lists has been requested
+    # Note: This will NOT re-read any *.conf files
+    # Note 2: We cannot use killall here as it does
+    #         not know about real-time signals
+    svc="kill -SIGRTMIN $(pidof ${resolver})"
+    str="Reloading DNS lists"
+  elif [[ "${svcOption}" =~ "reload" ]]; then
+    # Reloading of the DNS cache has been requested
     # Note: This will NOT re-read any *.conf files
     svc="killall -s SIGHUP ${resolver}"
+    str="Flushing DNS cache"
   else
     # A full restart has been requested
     svc="service ${resolver} restart"
+    str="Restarting DNS server"
   fi
 
   # Print output to Terminal, but not to Web Admin
-  str="${svcOption^}ing DNS service"
   [[ -t 1 ]] && echo -ne "  ${INFO} ${str}..."
 
   output=$( { ${svc}; } 2>&1 )


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Since merging of `new/internal-blocking`, we have more flexibility in selecting which cache to clear.

**How does this PR accomplish the above?:**

On modification of lists, we should send real-time signal 0 instead of SIGHUP. This also preserves the DNS cache of not-blocked domains.

In other words: FTL's (who wants what blocked) cache is reset while dnsmasq's general DNS cache can stay untouched when adding/removing/whatever any domains through the  `pihole` command.

**What documentation changes (if any) are needed to support this PR?:**

None