### PR TITLE
Set permissions and ownership of gravity.db on pihole -g

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -81,10 +81,6 @@ fi
 # Generate new sqlite3 file from schema template
 generate_gravity_database() {
   sqlite3 "${gravityDBfile}" < "${gravityDBschema}"
-
-  # Ensure proper permissions are set for the newly created database
-  chown pihole:pihole "${gravityDBfile}"
-  chmod g+w "${piholeDir}" "${gravityDBfile}"
 }
 
 update_gravity_timestamp() {
@@ -689,6 +685,10 @@ fi
 
 # Move possibly existing legacy files to the gravity database
 migrate_to_database
+
+# Ensure proper permissions are set for the newly created database
+chown pihole:pihole "${gravityDBfile}"
+chmod g+w "${piholeDir}" "${gravityDBfile}"
 
 if [[ "${forceDelete:-}" == true ]]; then
   str="Deleting existing list cache"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Ensure permissions and ownership of gravity.db are correctly set on each run of `pihole -g`. This would have prevented https://github.com/pi-hole/AdminLTE/issues/1077

Strictly speaking, this is not a bug fix as the current way seems to work for most users. Those who see issues have likely done something to their `/etc/pihole` folder manually. There is no harm in ensuring permissions and ownership are as expected from time to time.

**How does this PR accomplish the above?:**

Set permission and ownership on each run of `pihole -g` - not only once during creation of the new database.


**What documentation changes (if any) are needed to support this PR?:**

None