### PR TITLE
Print human-readable timestamps in the debugger's gravity output

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1105,7 +1105,7 @@ show_db_entries() {
 }
 
 show_groups() {
-    show_db_entries "Groups" "SELECT * FROM \"group\"" "4 4 30 50"
+    show_db_entries "Groups" "SELECT id,name,enabled,datetime(date_added,'unixepoch','localtime') date_added,datetime(date_modified,'unixepoch','localtime') date_modified,description FROM \"group\"" "4 50 7 19 19 50"
 }
 
 show_adlists() {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Improve debugger output readability

**How does this PR accomplish the above?:**

Change SQL query.


**Before**
```
id          enabled     name          date_added  date_modified  description
----------  ----------  ------------  ----------  -------------  -----------
0           1           Unassociated  1578329578  1578329578     Nothing to see here
```

**Now**
```
id    name                                                enabled  date_added           date_modified        description
----  --------------------------------------------------  -------  -------------------  -------------------  --------------------------------------------------
0     Unassociated                                        1        2020-01-06 17:52:58  2020-01-06 17:52:58  Nothing to see here

```

**What documentation changes (if any) are needed to support this PR?:**

None