### PR TITLE
basic-install.sh: Allow dhcpd traffic in firewall-cmd

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1786,7 +1786,7 @@ create_pihole_user() {
     fi
 }
 
-# Allow HTTP and DNS traffic
+# Allow HTTP, DHCP and DNS traffic
 configureFirewall() {
     printf "\\n"
     # If a firewall is running,
@@ -1794,9 +1794,9 @@ configureFirewall() {
         # ask if the user wants to install Pi-hole's default firewall rules
         whiptail --title "Firewall in use" --yesno "We have detected a running firewall\\n\\nPi-hole currently requires HTTP and DNS port access.\\n\\n\\n\\nInstall Pi-hole default firewall rules?" "${r}" "${c}" || \
         { printf "  %b Not installing firewall rulesets.\\n" "${INFO}"; return 0; }
-        printf "  %b Configuring FirewallD for httpd and pihole-FTL\\n" "${TICK}"
-        # Allow HTTP and DNS traffic
-        firewall-cmd --permanent --add-service=http --add-service=dns
+        printf "  %b Configuring FirewallD for httpd, dhcpd and pihole-FTL\\n" "${TICK}"
+        # Allow HTTP, DHCP and DNS traffic
+        firewall-cmd --permanent --add-service=http --add-service=dns --add-service=dhcp
         # Reload the firewall to apply these changes
         firewall-cmd --reload
         return 0

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -104,14 +104,15 @@ def test_configureFirewall_firewalld_running_no_errors(Pihole):
     source /opt/pihole/basic-install.sh
     configureFirewall
     ''')
-    expected_stdout = 'Configuring FirewallD for httpd and pihole-FTL'
+    expected_stdout = 'Configuring FirewallD for httpd, dhcpd and pihole-FTL'
     assert expected_stdout in configureFirewall.stdout
     firewall_calls = Pihole.run('cat /var/log/firewall-cmd').stdout
     assert 'firewall-cmd --state' in firewall_calls
     assert ('firewall-cmd '
             '--permanent '
             '--add-service=http '
-            '--add-service=dns') in firewall_calls
+            '--add-service=dns '
+            '--add-service=dhcp') in firewall_calls
     assert 'firewall-cmd --reload' in firewall_calls
 
 


### PR DESCRIPTION
When poking hole in firewall-cmd to allow http and dns, also allow
traffic destined to dhcpd to account for cases when pi-hole is used
as dhcp server.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*

Fix issue related to enabling dhcpd in a system configured with firewall-cmd.
While firewall-cmd is changed to allow http and dns traffic, it is currently not allowing dhcp
packets. The outcome of that is that no clients are able to use Pie-Hole as dhcp server, which
is a big sad panda experience.

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

In addition to allowing http and dns, the proposed fix also allows dhcp packets.

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*

Folks who do not use firewall-cmd must be ensure that dhcp packets must not
be blocked if Pi-Hole is configured to have dhcp server enabled.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

