### PR TITLE
Update blocked strings for pihole -t

### DIFF
--- a/pihole
+++ b/pihole
@@ -307,7 +307,7 @@ tailFunc() {
   # Colour everything else as gray
   tail -f /var/log/pihole.log | sed -E \
     -e "s,($(date +'%b %d ')| dnsmasq[.*[0-9]]),,g" \
-    -e "s,(.*(gravity |black |regex | config ).* is (0.0.0.0|::|NXDOMAIN|${IPV4_ADDRESS%/*}|${IPV6_ADDRESS:-NULL}).*),${COL_RED}&${COL_NC}," \
+    -e "s,(.*(blacklisted |gravity blocked ).* is (0.0.0.0|::|NXDOMAIN|${IPV4_ADDRESS%/*}|${IPV6_ADDRESS:-NULL}).*),${COL_RED}&${COL_NC}," \
     -e "s,.*(query\\[A|DHCP).*,${COL_NC}&${COL_NC}," \
     -e "s,.*,${COL_GRAY}&${COL_NC},"
   exit 0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix a bug mentioned on Discourse: https://discourse.pi-hole.net/t/blacklisted-domains-not-showing-up-red-in-pihole-t/27237/2

![Screenshot from 2020-01-23 19-17-56](https://user-images.githubusercontent.com/16748619/73011986-a31c5600-3e15-11ea-9b0b-c0be5e368b83.png)


**How does this PR accomplish the above?:**

Replace the strings by what Pi-hole v5.0 will show.
1. `regex` -> `regex blacklisted`
2 `black` -> `exactly blacklisted`
3. `gravity` -> `gravity blocked`

**What documentation changes (if any) are needed to support this PR?:**

None