### PR TITLE
DROP and reCREATE TRIGGERs during gravity swapping.

### DIFF
--- a/advanced/Templates/gravity_copy.sql
+++ b/advanced/Templates/gravity_copy.sql
@@ -4,6 +4,10 @@ ATTACH DATABASE '/etc/pihole/gravity.db' AS OLD;
 
 BEGIN TRANSACTION;
 
+DROP TRIGGER tr_domainlist_add;
+DROP TRIGGER tr_client_add;
+DROP TRIGGER tr_adlist_add;
+
 INSERT OR REPLACE INTO "group" SELECT * FROM OLD."group";
 INSERT OR REPLACE INTO domain_audit SELECT * FROM OLD.domain_audit;
 
@@ -17,5 +21,22 @@ INSERT OR REPLACE INTO info SELECT * FROM OLD.info;
 
 INSERT OR REPLACE INTO client SELECT * FROM OLD.client;
 INSERT OR REPLACE INTO client_by_group SELECT * FROM OLD.client_by_group;
+
+
+CREATE TRIGGER tr_domainlist_add AFTER INSERT ON domainlist
+    BEGIN
+      INSERT INTO domainlist_by_group (domainlist_id, group_id) VALUES (NEW.id, 0);
+    END;
+
+CREATE TRIGGER tr_client_add AFTER INSERT ON client
+    BEGIN
+      INSERT INTO client_by_group (client_id, group_id) VALUES (NEW.id, 0);
+    END;
+
+CREATE TRIGGER tr_adlist_add AFTER INSERT ON adlist
+    BEGIN
+      INSERT INTO adlist_by_group (adlist_id, group_id) VALUES (NEW.id, 0);
+    END;
+
 
 COMMIT;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix v5.0 bug reported on [Discourse](https://discourse.pi-hole.net/t/running-gravity-resets-group-management-client-assignments/27490/5?u=dl6er).

**How does this PR accomplish the above?:**

`DROP` triggers before copying data from the old to the new gravity database that create an association to all newly `INSERT`es clients/domains/adlists. Recreate them afterwards.
If we do not drop these triggers, they will force the Unassociated group onto all entries even if the user deleted them before. This is a bug.

**What documentation changes (if any) are needed to support this PR?:**

None