### PR TITLE
Store gravity update timestamp only after database swapping

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -120,11 +120,11 @@ gravity_swap_databases() {
 
 # Update timestamp when the gravity table was last updated successfully
 update_gravity_timestamp() {
-  output=$( { printf ".timeout 30000\\nINSERT OR REPLACE INTO info (property,value) values ('updated',cast(strftime('%%s', 'now') as int));" | sqlite3 "${gravityTEMPfile}"; } 2>&1 )
+  output=$( { printf ".timeout 30000\\nINSERT OR REPLACE INTO info (property,value) values ('updated',cast(strftime('%%s', 'now') as int));" | sqlite3 "${gravityDBfile}"; } 2>&1 )
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to update gravity timestamp in database ${gravityTEMPfile}\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to update gravity timestamp in database ${gravityDBfile}\\n  ${output}"
     return 1
   fi
   return 0
@@ -749,11 +749,11 @@ gravity_DownloadBlocklists
 # Create local.list
 gravity_generateLocalList
 
-# Update gravity timestamp
-update_gravity_timestamp
-
 # Migrate rest of the data from old to new database
 gravity_swap_databases
+
+# Update gravity timestamp
+update_gravity_timestamp
 
 # Ensure proper permissions are set for the database
 chown pihole:pihole "${gravityDBfile}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix bug described on [Discourse](https://discourse.pi-hole.net/t/last-update-date-for-gravity-doesnt-change/28026).

**How does this PR accomplish the above?:**

We updated the timestamp in the new database, however, the swapping of the databases overwrote this update, effectively keeping the timestamp stored in the old database (this is why it never advanced).

We overwrite the timestamp now **after** database swapping.

**What documentation changes (if any) are needed to support this PR?:**

None