### PR TITLE
Fix wrong number of blocking domains shown on the dashboard

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -760,13 +760,13 @@ gravity_swap_databases
 chown pihole:pihole "${gravityDBfile}"
 chmod g+w "${piholeDir}" "${gravityDBfile}"
 
+# Compute numbers to be displayed
+gravity_ShowCount
+
 # Determine if DNS has been restarted by this instance of gravity
 if [[ -z "${dnsWasOffline:-}" ]]; then
   "${PIHOLE_COMMAND}" restartdns reload
 fi
-
-# Compute numbers to be displayed
-gravity_ShowCount
 
 gravity_Cleanup
 echo ""


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix wrong number of blocking domains shown on the dashboard.

**How does this PR accomplish the above?:**

Compute number of domains (and store it in the database) BEFORE calling FTL to re-read said value.

**What documentation changes (if any) are needed to support this PR?:**

None