### PR TITLE
Fix issue with missing newline at the end of adlists

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -486,13 +486,15 @@ gravity_DownloadBlocklistFromUrl() {
     if [[ "${httpCode}" == "304" ]]; then
       # Add domains to database table file
       #Append ,${arg} to every line and then remove blank lines before import
-      sed -e "s/$/,${adlistID}/;/^$/d" "${saveLocation}" >> "${target}"
+      # /.$/a\\ ensures there is a newline on the last line
+      sed -e "s/$/,${adlistID}/;/^$/d;/.$/a\\" "${saveLocation}" >> "${target}"
     # Check if $patternbuffer is a non-zero length file
     elif [[ -s "${patternBuffer}" ]]; then
       # Determine if blocklist is non-standard and parse as appropriate
       gravity_ParseFileIntoDomains "${patternBuffer}" "${saveLocation}"
       #Append ,${arg} to every line and then remove blank lines before import
-      sed -e "s/$/,${adlistID}/;/^$/d" "${saveLocation}" >> "${target}"
+      # /.$/a\\ ensures there is a newline on the last line
+      sed -e "s/$/,${adlistID}/;/^$/d;/.$/a\\" "${saveLocation}" >> "${target}"
     else
       # Fall back to previously cached list if $patternBuffer is empty
       echo -e "  ${INFO} Received empty file: ${COL_LIGHT_GREEN}using previously cached list${COL_NC}"
@@ -502,7 +504,8 @@ gravity_DownloadBlocklistFromUrl() {
     if [[ -r "${saveLocation}" ]]; then
       echo -e "  ${CROSS} List download failed: ${COL_LIGHT_GREEN}using previously cached list${COL_NC}"
       #Append ,${arg} to every line and then remove blank lines before import
-      sed -e "s/$/,${adlistID}/;/^$/d" "${saveLocation}" >> "${target}"
+      # /.$/a\\ ensures there is a newline on the last line
+      sed -e "s/$/,${adlistID}/;/^$/d;/.$/a\\" "${saveLocation}" >> "${target}"
     else
       echo -e "  ${CROSS} List download failed: ${COL_LIGHT_RED}no cached list available${COL_NC}"
     fi

--- a/gravity.sh
+++ b/gravity.sh
@@ -400,6 +400,11 @@ gravity_DownloadBlocklists() {
   gravity_Blackbody=true
 }
 
+parseList() {
+  local adlistID="${1}" src="${2}" target="${3}"
+  sed -e "s/$/,${adlistID}/;/^$/d;/.$/a\\" "${src}" >> "${target}"
+}
+
 # Download specified URL and perform checks on HTTP status and file content
 gravity_DownloadBlocklistFromUrl() {
   local url="${1}" cmd_ext="${2}" agent="${3}" adlistID="${4}" saveLocation="${5}" target="${6}"
@@ -487,14 +492,14 @@ gravity_DownloadBlocklistFromUrl() {
       # Add domains to database table file
       #Append ,${arg} to every line and then remove blank lines before import
       # /.$/a\\ ensures there is a newline on the last line
-      sed -e "s/$/,${adlistID}/;/^$/d;/.$/a\\" "${saveLocation}" >> "${target}"
+      parseList "${adlistID}" "${saveLocation}" "${target}"
     # Check if $patternbuffer is a non-zero length file
     elif [[ -s "${patternBuffer}" ]]; then
       # Determine if blocklist is non-standard and parse as appropriate
       gravity_ParseFileIntoDomains "${patternBuffer}" "${saveLocation}"
       #Append ,${arg} to every line and then remove blank lines before import
       # /.$/a\\ ensures there is a newline on the last line
-      sed -e "s/$/,${adlistID}/;/^$/d;/.$/a\\" "${saveLocation}" >> "${target}"
+      parseList "${adlistID}" "${saveLocation}" "${target}"
     else
       # Fall back to previously cached list if $patternBuffer is empty
       echo -e "  ${INFO} Received empty file: ${COL_LIGHT_GREEN}using previously cached list${COL_NC}"
@@ -505,7 +510,7 @@ gravity_DownloadBlocklistFromUrl() {
       echo -e "  ${CROSS} List download failed: ${COL_LIGHT_GREEN}using previously cached list${COL_NC}"
       #Append ,${arg} to every line and then remove blank lines before import
       # /.$/a\\ ensures there is a newline on the last line
-      sed -e "s/$/,${adlistID}/;/^$/d;/.$/a\\" "${saveLocation}" >> "${target}"
+      parseList "${adlistID}" "${saveLocation}" "${target}"
     else
       echo -e "  ${CROSS} List download failed: ${COL_LIGHT_RED}no cached list available${COL_NC}"
     fi

--- a/gravity.sh
+++ b/gravity.sh
@@ -390,6 +390,10 @@ gravity_DownloadBlocklists() {
     echo -e "${OVER}  ${TICK} ${str}"
   fi
 
+  if [[ "${status}" -eq 0 && ! -z "${output}" ]]; then
+    echo -e "  Encountered non-critical SQL warnings. Please check the suitability of the list you're using!\\nSQL warnings:\\n${output}\\n"
+  fi
+
   rm "${target}" > /dev/null 2>&1 || \
     echo -e "  ${CROSS} Unable to remove ${target}"
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -402,6 +402,8 @@ gravity_DownloadBlocklists() {
 
 parseList() {
   local adlistID="${1}" src="${2}" target="${3}"
+  #Append ,${arg} to every line and then remove blank lines before import
+  # /.$/a\\ ensures there is a newline on the last line
   sed -e "s/$/,${adlistID}/;/^$/d;/.$/a\\" "${src}" >> "${target}"
 }
 
@@ -490,15 +492,12 @@ gravity_DownloadBlocklistFromUrl() {
   if [[ "${success}" == true ]]; then
     if [[ "${httpCode}" == "304" ]]; then
       # Add domains to database table file
-      #Append ,${arg} to every line and then remove blank lines before import
-      # /.$/a\\ ensures there is a newline on the last line
       parseList "${adlistID}" "${saveLocation}" "${target}"
     # Check if $patternbuffer is a non-zero length file
     elif [[ -s "${patternBuffer}" ]]; then
       # Determine if blocklist is non-standard and parse as appropriate
       gravity_ParseFileIntoDomains "${patternBuffer}" "${saveLocation}"
-      #Append ,${arg} to every line and then remove blank lines before import
-      # /.$/a\\ ensures there is a newline on the last line
+      # Add domains to database table file
       parseList "${adlistID}" "${saveLocation}" "${target}"
     else
       # Fall back to previously cached list if $patternBuffer is empty
@@ -508,8 +507,7 @@ gravity_DownloadBlocklistFromUrl() {
     # Determine if cached list has read permission
     if [[ -r "${saveLocation}" ]]; then
       echo -e "  ${CROSS} List download failed: ${COL_LIGHT_GREEN}using previously cached list${COL_NC}"
-      #Append ,${arg} to every line and then remove blank lines before import
-      # /.$/a\\ ensures there is a newline on the last line
+      # Add domains to database table file
       parseList "${adlistID}" "${saveLocation}" "${target}"
     else
       echo -e "  ${CROSS} List download failed: ${COL_LIGHT_RED}no cached list available${COL_NC}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix issue with missing newline at the end of adlists. Also, always display warnings, even if they are non-fatal, like:
![Screenshot from 2020-02-18 17-18-52](https://user-images.githubusercontent.com/16748619/74755996-39f0fc80-5274-11ea-99f3-2e9dd8c498f8.png)
(however, you will **not** see this warning yourself as this PR fixes it in its second commit)

**How does this PR accomplish the above?:**

Ensure the last line of what we add to the batch-import file is a newline (this uses `sed`-magic):
This command searches for the end of the file (`$`) and checks if there is anything here (`.$` will ONLY match when the last character is not a newline `\n` as this is the only thing that doesn't match `.`). Only if this is true (newline is not the last character), we append nothing (which will effectively insert a newline in `sed`-world).

**What documentation changes (if any) are needed to support this PR?:**

None