### PR TITLE
force `updatchecker.sh` run if any of the three components are updated

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -199,7 +199,7 @@ main() {
         echo -e "${basicError}" && exit 1
     fi
 
-    if [[ "${FTL_update}" == true || "${core_update}" == true || "${web_update}" == true ]]
+    if [[ "${FTL_update}" == true || "${core_update}" == true || "${web_update}" == true ]]; then
         # Force an update of the updatechecker
         /opt/pihole/updatecheck.sh
         /opt/pihole/updatecheck.sh x remote

--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -198,6 +198,14 @@ main() {
         ${PI_HOLE_FILES_DIR}/automated\ install/basic-install.sh --reconfigure --unattended || \
         echo -e "${basicError}" && exit 1
     fi
+
+    if [[ "${FTL_update}" == true || "${core_update}" == true || "${web_update}" == true ]]
+        # Force an update of the updatechecker
+        /opt/pihole/updatecheck.sh
+        /opt/pihole/updatecheck.sh x remote
+        echo -e "  ${INFO} Local version file information updated."
+    fi
+
     echo ""
     exit 0
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---

Force the update script to update the local versions file on a successful run of `pihole -up`