### PR TITLE
Gravity: Check suitablility of sourced lists

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -404,16 +404,6 @@ gravity_DownloadBlocklists() {
       fi
     done <<< "${output}"
     echo ""
-    local file line
-    while IFS= read -r line; do
-      warning="$(grep -oh "^[^:]*:[0-9]*" <<< "${line}")"
-      file="${warning%:*}"
-      lineno="${warning#*:}"
-      if [[ -n "${file}" && -n "${lineno}" ]]; then
-        echo -n "Line contains: "
-        awk "NR==${lineno}" < ${file}
-      fi
-    done <<< "${output}"
   fi
 
   rm "${target}" > /dev/null 2>&1 || \

--- a/gravity.sh
+++ b/gravity.sh
@@ -431,7 +431,11 @@ parseList() {
   num_correct_lines="$(( num_target_lines-total_num ))"
   total_num="$num_target_lines"
   num_invalid="$(( num_lines-num_correct_lines ))"
-  echo "  ${INFO} Imported ${num_correct_lines} of ${num_lines} domains, ${num_invalid} domains invalid"
+  if [[ "${num_invalid}" -eq 0 ]]; then
+    echo "  ${INFO} Received ${num_lines} domains"
+  else
+    echo "  ${INFO} Received ${num_lines} domains, ${num_invalid} domains invalid!"
+  fi
 
   # Display sample of invalid lines if we found some
   if [[ -n "${incorrect_lines}" ]]; then

--- a/gravity.sh
+++ b/gravity.sh
@@ -423,26 +423,19 @@ parseList() {
   # Find (up to) five domains containing invalid characters (see above)
   incorrect_lines="$(sed -e "/[^a-zA-Z0-9.\_-]/!d" "${src}" | head -n 5)"
 
-  local num_lines num_target_lines num_correct_lines percentage percentage_fraction
+  local num_lines num_target_lines num_correct_lines num_invalid
   # Get number of lines in source file
   num_lines="$(grep -c "^" "${src}")"
   # Get number of lines in destination file
   num_target_lines="$(grep -c "^" "${target}")"
   num_correct_lines="$(( num_target_lines-total_num ))"
   total_num="$num_target_lines"
-  # Compute percentage of valid lines
-  percentage=100
-  percentage_fraction=0
-  if [[ "${num_lines}" -gt 0 ]]; then
-    percentage="$(( 1000*num_correct_lines/num_lines ))"
-    percentage_fraction="$(( percentage%10 ))"
-    percentage="$(( percentage/10 ))"
-  fi
-  echo "  ${INFO} ${num_correct_lines} of ${num_lines} domains imported (${percentage}.${percentage_fraction}%)"
+  num_invalid="$(( num_lines-num_correct_lines ))"
+  echo "  ${INFO} Imported ${num_correct_lines} of ${num_lines} domains, ${num_invalid} domains invalid"
 
   # Display sample of invalid lines if we found some
   if [[ -n "${incorrect_lines}" ]]; then
-    echo "      Sample of invalid domains (showing up to five):"
+    echo "      Sample of invalid domains:"
     while IFS= read -r line; do
       echo "      - ${line}"
     done <<< "${incorrect_lines}"

--- a/gravity.sh
+++ b/gravity.sh
@@ -391,7 +391,29 @@ gravity_DownloadBlocklists() {
   fi
 
   if [[ "${status}" -eq 0 && -n "${output}" ]]; then
-    echo -e "  Encountered non-critical SQL warnings. Please check the suitability of the list you're using!\\nSQL warnings:\\n${output}\\n"
+    echo -e "  Encountered non-critical SQL warnings. Please check the suitability of the lists you're using!\\n\\n  SQL warnings:"
+    local warning file line lineno
+    while IFS= read -r line; do
+      echo "  - ${line}"
+      warning="$(grep -oh "^[^:]*:[0-9]*" <<< "${line}")"
+      file="${warning%:*}"
+      lineno="${warning#*:}"
+      if [[ -n "${file}" && -n "${lineno}" ]]; then
+        echo -n "    Line contains: "
+        awk "NR==${lineno}" < ${file}
+      fi
+    done <<< "${output}"
+    echo ""
+    local file line
+    while IFS= read -r line; do
+      warning="$(grep -oh "^[^:]*:[0-9]*" <<< "${line}")"
+      file="${warning%:*}"
+      lineno="${warning#*:}"
+      if [[ -n "${file}" && -n "${lineno}" ]]; then
+        echo -n "Line contains: "
+        awk "NR==${lineno}" < ${file}
+      fi
+    done <<< "${output}"
   fi
 
   rm "${target}" > /dev/null 2>&1 || \


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Improve gravity.

**How does this PR accomplish the above?:**

- Show lines from the temporary file if SQL errors are detected
- Check domains for validity before importing them (should eliminate all SQL warnings/errors as a side-effect)
- Show how many domains we're considering for import and show how many are invalid (if any)

This all has been done in a performant way so I refrained from adding a switch for enabling it.

Exemplary output provided by a user on Discourse:
```text
  [i] Target: http://www.malwaredomainlist.com/hostslist/hosts.txt
  [✓] Status: No changes detected
  [i] Received 1104 domains

  [i] Target: https://easylist.to/easylistgermany/easylistgermany.txt
  [✓] Status: Retrieval successful
  [i] Received 945 domains, 943 domains invalid!
      Sample of invalid domains:
      - 1.1]
      - easylist.germany@gmail.com
      - ||2mdn.net^$object,third-party,domain=anleger-fernsehen.de|blick.ch|fitforfun.de|focus.de|giga.de|golem.de|helpster.de|myspass.de|netzwelt.de|stol.it|sueddeutsche.de|tvtoday.de
      - ||4rm.de^$third-party
      - ||85.114.133.62^$third-party

  [i] Target: http://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=0&mimetype=plaintext
  [✓] Status: Retrieval successful
  [i] Received 3292 domains
```

**What documentation changes (if any) are needed to support this PR?:**

None