### PR TITLE
recursively set correct directory and file permission on webroot at t…

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1926,13 +1926,13 @@ installPihole() {
             install -d -m 0755 ${webroot}
         fi
 
+        # Repair permissions if /var/www/html is not world readable
+        find "${webroot}" -type d -exec chmod 0775 {} \;;
+        find "${webroot}" -type f -exec chmod 0664 {} \;;
+
         if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
             # Set the owner and permissions
             chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} ${webroot}
-            chmod 0775 ${webroot}
-            # Repair permissions if /var/www/html is not world readable
-            chmod a+rx /var/www
-            chmod a+rx /var/www/html
             # Give pihole access to the Web server group
             usermod -a -G ${LIGHTTPD_GROUP} pihole
             # Give lighttpd access to the pihole group so the web interface can


### PR DESCRIPTION
…he right time during installation

Signed-off-by: corbolais <corbolais@gmail.com>

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)

---
**What does this PR aim to accomplish?:**
As detailed in issue #3175 (and apparently having occurred in #2195, too), there happen to be bad permissions of the `webroot` directory tree, the pihole-installation fails at the webroot stage. 

Having had a non-default `umask`, the resulting permissions on `${webroot}` lead to a _dysfunctional admin interface_.

**How does this PR accomplish the above?:**
Correctly set permissions recursively for `webroot` subdirectories and any file therein.

The removed original `chmod` only executed if `"${INSTALL_WEB_SERVER}" == true`. However, the webroot directory tree exists once `"${INSTALL_WEB_INTERFACE}" == true` is entered. So it seems sensible to move the statements above the original condition.

Now, why exactly the original chmod was where it was is unknown to me, this patch might be well intensioned but wrong nevertheless. Possible reason: the placement was intentional and not modifyable. In this case, I'm happy to rework this PR. Please explain the reasons.

There's more to it:
https://github.com/pi-hole/pi-hole/blob/782fec841ea85b29a8bf26023e615972de9d4717/automated%20install/basic-install.sh#L1932-L1935
In commit https://github.com/pi-hole/pi-hole/commit/f187b42a98b984f49d2df2ba20672f5f2497ceca the literal webroot path was refactored into `$webroot`, however, three months later commit https://github.com/pi-hole/pi-hole/commit/e19adccd9c623eeba20e46a6347108e917af133e regressed and reintroduced the literal webroot path, in addition to a move of chmod inside the condition (as already mentioned above). The regression looks like an oversight, the intention of the move of chmod is still unknown to me as the commit does not detail any reason behind the move but merely states the obvious.

_Furthermore, the permissions introduced are equally insufficient and do not account for a non-default umask._

As a result of the above, this PR moves the permission change again out of the condition _and_ enforces correct permissions _recursively_ on subdirectories and files of `webroot`. Only this warrants that
a) permissions are correct regardless of any umask setting
b) permissions are enforced from the moment the `webroot` directory exists.

It is debatable whether the parent directory of `$webroot` shall be included. Please advise on this.

Thank you.

**What documentation changes (if any) are needed to support this PR?:**
none.