### PR TITLE
Malformed wildcard blocking doesn't crash awk.

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -39,7 +39,7 @@ scanList(){
         # If it does, print the matching regexp and continue looping
         # Input 1 - regexps | Input 2 - domainQuery
         "regex" ) 
-            for list in `echo "${lists}"`; do
+            for list in ${lists}; do
                 if [[ "${domain}" =~ ${list} ]]; then
                     printf "%b\n" "${list}";
                 fi

--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -35,11 +35,15 @@ scanList(){
     # /dev/null forces filename to be printed when only one list has been generated
     case "${type}" in
         "exact" ) grep -i -E -l "(^|(?<!#)\\s)${esc_domain}($|\\s|#)" ${lists} /dev/null 2>/dev/null;;
-        # Create array of regexps
         # Iterate through each regexp and check whether it matches the domainQuery
         # If it does, print the matching regexp and continue looping
         # Input 1 - regexps | Input 2 - domainQuery
-        "regex" ) if [[ "${domain}" =~ ${lists} ]]; then printf "%b\n" "${lists}"; fi;;
+        "regex" ) 
+            for list in `echo "${lists}"`; do
+                if [[ "${domain}" =~ ${list} ]]; then
+                    printf "%b\n" "${list}";
+                fi
+            done;;
         *       ) grep -i "${esc_domain}" ${lists} /dev/null 2>/dev/null;;
     esac
 }

--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -33,15 +33,13 @@ scanList(){
     export LC_CTYPE=C
 
     # /dev/null forces filename to be printed when only one list has been generated
-    # shellcheck disable=SC2086
     case "${type}" in
         "exact" ) grep -i -E -l "(^|(?<!#)\\s)${esc_domain}($|\\s|#)" ${lists} /dev/null 2>/dev/null;;
         # Create array of regexps
         # Iterate through each regexp and check whether it matches the domainQuery
         # If it does, print the matching regexp and continue looping
         # Input 1 - regexps | Input 2 - domainQuery
-        "regex" ) awk 'NR==FNR{regexps[$0];next}{for (r in regexps)if($0 ~ r)print r}' \
-                  <(echo "${lists}") <(echo "${domain}") 2>/dev/null;;
+        "regex" ) if [[ "${domain}" =~ ${lists} ]]; then printf "%b\n" "${lists}"; fi;;
         *       ) grep -i "${esc_domain}" ${lists} /dev/null 2>/dev/null;;
     esac
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fixes #3173 

This allows for users to enter non-canonical values in the white/blacklist entry display. `*.host.domain.com` is valid to use as a wildcard type entry. 

**How does this PR accomplish the above?:**

Use bash regex in place of `awk` for matching. 

**What documentation changes (if any) are needed to support this PR?:**
None.

## _Please squash merge this. I didn't squash the commits as there are people on the branch and I did not want to break them._