### PR TITLE
Unattended

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1873,31 +1873,22 @@ finalExports() {
         fi
     fi
     
-    # If the setup variable file exists,
-    if [[ -e "${setupVars}" ]]; then
-        # update the variables in the file
-        sed -i.update.bak '/PIHOLE_INTERFACE/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1/d;/PIHOLE_DNS_2/d;/QUERY_LOGGING/d;/INSTALL_WEB_SERVER/d;/INSTALL_WEB_INTERFACE/d;/LIGHTTPD_ENABLED/d;' "${setupVars}"
-    fi
+    # Updated settings
+    updatedVars= (PIHOLE_INTERFACE IPV4_ADDRESS IPV6_ADDRESS PIHOLE_DNS_1 PIHOLE_DNS_2 QUERY_LOGGING INSTALL_WEB_SERVER INSTALL_WEB_INTERFACE)
+    # Update setupVars.conf with new settings
+    for i in "${updatedVars[@]}"; do
+        replaceAddCreate $i $setupVars
+    done
     # echo the information to the user
-    {
-    echo "PIHOLE_INTERFACE=${PIHOLE_INTERFACE}"
-    echo "IPV4_ADDRESS=${IPV4_ADDRESS}"
-    echo "IPV6_ADDRESS=${IPV6_ADDRESS}"
-    echo "PIHOLE_DNS_1=${PIHOLE_DNS_1}"
-    echo "PIHOLE_DNS_2=${PIHOLE_DNS_2}"
-    echo "QUERY_LOGGING=${QUERY_LOGGING}"
-    echo "INSTALL_WEB_SERVER=${INSTALL_WEB_SERVER}"
-    echo "INSTALL_WEB_INTERFACE=${INSTALL_WEB_INTERFACE}"
-    echo "LIGHTTPD_ENABLED=${LIGHTTPD_ENABLED}"
-    }>> "${setupVars}"
-    chmod 644 "${setupVars}"
+    for i in "${updatedVars[@]}"; do
+        echo "$i=${!i}"
+    done    
 
     # Set the privacy level
     sed -i '/PRIVACYLEVEL/d' "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf"
     echo "PRIVACYLEVEL=${PRIVACY_LEVEL}" >> "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf"
 
     # Bring in the current settings and the functions to manipulate them
-    source "${setupVars}"
     source "${PI_HOLE_LOCAL_REPO}/advanced/Scripts/webpage.sh"
 
     # Look for DNS server settings which would have to be reapplied

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1839,7 +1839,7 @@ finalExports() {
             IPV6_ADDRESS="::/0"
         fi
     fi
-
+    
     # If the setup variable file exists,
     if [[ -e "${setupVars}" ]]; then
         # update the variables in the file
@@ -2637,10 +2637,14 @@ main() {
         # Source ${setupVars} to use predefined user variables in the functions
         source "${setupVars}"
 
-        # Get the privacy level if it exists (default is 0)
+        # Get the privacy level if it exists (default is 0), check pihole-FTL.conf first, then check setupVars.conf
         if [[ -f "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf" ]]; then
             PRIVACY_LEVEL=$(sed -ne 's/PRIVACYLEVEL=\(.*\)/\1/p' "${PI_HOLE_CONFIG_DIR}/pihole-FTL.conf")
-
+            # If no setting was found, default to 0
+            PRIVACY_LEVEL="${PRIVACY_LEVEL:-0}"
+        else
+            # Check setupVars.conf
+            PRIVACY_LEVEL=$(sed -ne 's/PRIVACYLEVEL=\(.*\)/\1/p' "${setupVars}")
             # If no setting was found, default to 0
             PRIVACY_LEVEL="${PRIVACY_LEVEL:-0}"
         fi

--- a/automated install/pihole-setupVars.conf.example
+++ b/automated install/pihole-setupVars.conf.example
@@ -1,0 +1,38 @@
+# ;
+# ; *  IMPORTANT NOTE:  This file is used as a variable file for the Bash install script and
+# ;    as a PHP ini file for /var/www/html/admin/settings.php.
+# ; *  Bash reads comments as "#"
+# ; *  PHP reads comments as ";" (As of PHP 7.0.0, "#" are no longer recognized as PHP comments)
+# ; *  All lines must end with a LF, not CRLF
+# ; *  There must be a blank line at the end of the file.
+# ; *  Options set during or after installation will be appended to the last line.
+# ;
+# ; *  Run ~/pihole-install.sh --unattended >> /var/log/unnattended-pihole-install.log
+# ;    to find the new web GUI password at /var/log/unnattended-pihole-install.log  
+# ;    after installation
+# ;
+# ; *  To create a random Web GUI password, delete "WEBPASSWORD=".  If it is left as is, no password will
+# ;    be required to login.  The password can be changed after installation with 'pihole -a -p'
+# ;
+# ;    To use default settings, remove the variable completely
+# ;
+
+PIHOLE_INTERFACE=ens160
+IPV4_ADDRESS=x.x.x.x/xx
+PIHOLE_DNS_1=x.x.x.x#5353
+PIHOLE_DNS_2=x.x.x.x
+QUERY_LOGGING=true
+INSTALL_WEB_SERVER=true
+INSTALL_WEB_INTERFACE=true
+WEBPASSWORD=63b000e76a263ebe9c247952491a9ed56ffdb060b864b80d31990f6121d129fd
+TEMPERATUREUNIT=F
+WEBUIBOXEDLAYOUT=boxed
+BLOCKING_ENABLED=true
+DNSMASQ_LISTENING=single
+DNS_FQDN_REQUIRED=false
+DNS_BOGUS_PRIV=false
+DNSSEC=false
+CONDITIONAL_FORWARDING=true
+CONDITIONAL_FORWARDING_IP=192.168.1.1
+CONDITIONAL_FORWARDING_DOMAIN=mydomain.net
+CONDITIONAL_FORWARDING_REVERSE=1.168.192.in-addr.arpa

--- a/automated install/pihole-setupVars.conf.example
+++ b/automated install/pihole-setupVars.conf.example
@@ -1,4 +1,8 @@
 # ;
+# ; *  Run '~/pihole-install.sh --unattended >> /var/log/unnattended-pihole-install.log'
+# ;    to find the new web GUI password at /var/log/unnattended-pihole-install.log  
+# ;    after installation
+# ;
 # ; *  IMPORTANT NOTE:  This file is used as a variable file for the Bash install script and
 # ;    as a PHP ini file for /var/www/html/admin/settings.php.
 # ; *  Bash reads comments as "#"
@@ -7,14 +11,10 @@
 # ; *  There must be a blank line at the end of the file.
 # ; *  Options set during or after installation will be appended to the last line.
 # ;
-# ; *  Run ~/pihole-install.sh --unattended >> /var/log/unnattended-pihole-install.log
-# ;    to find the new web GUI password at /var/log/unnattended-pihole-install.log  
-# ;    after installation
+# ; *  To create a random Web GUI password, delete "WEBPASSWORD=".  If it is left as is, the password will
+# ;    be blank.  The password can be changed after installation with 'pihole -a -p'
 # ;
-# ; *  To create a random Web GUI password, delete "WEBPASSWORD=".  If it is left as is, no password will
-# ;    be required to login.  The password can be changed after installation with 'pihole -a -p'
-# ;
-# ;    To use default settings, remove the variable completely
+# ; *  To use default settings, remove the variable completely
 # ;
 
 PIHOLE_INTERFACE=ens160
@@ -24,7 +24,8 @@ PIHOLE_DNS_2=x.x.x.x
 QUERY_LOGGING=true
 INSTALL_WEB_SERVER=true
 INSTALL_WEB_INTERFACE=true
-WEBPASSWORD=63b000e76a263ebe9c247952491a9ed56ffdb060b864b80d31990f6121d129fd
+WEBPASSWORD=
+DNS_CACHE_SIZE=15000
 TEMPERATUREUNIT=F
 WEBUIBOXEDLAYOUT=boxed
 BLOCKING_ENABLED=true


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Using the --unattended flag to install requires the use of setupVars.conf.  If this configuration file is missing required field or not formatted correctly, the installation will fail, with or without displaying errors.

This PR request adds validation for setupVars.conf, adds an example setupVars.conf, and creates a functions to create or update setupVars.conf or any other configuration file.

The function replaceAddCreate will replace existing variables while maintaining any comments and indentation or add variables if they do not exist.  It will also create the file with the correct permissions and format.

The function replaceAddCreateRename will do the same as replaceAddCreate but also allows the ability to rename the variable in the target file.  For example, DNS_CACHE_SIZE is named cache-size in 01-pihole.conf.

This PR also made other minor changes related to the use of setupVars.conf.  

To learn the random password that is created during an unattended installation, displayFinalMessage is enabled for --unattended, with the exception of whiptail message.  Pipe the output to a log file, for example "~/pihole-install.sh --unattended >> /var/log/unattended-pihole-install.log"

If useUpdateVars=true, it will first make sure setupVars.conf exists and has the correct permissions, then run accountForRefactor, then validate_setupVars.

It checks to make sure INSTALL_WEB_SERVER is enabled if INSTALL_WEB_INTERFACE is enabled is (part of the validate_setupVars).

If the undocumented flag "--disable-install-webserver" is used, both INSTALL_WEB_INTERFACE and INSTALL_WEB_SERVER will be set to false.

Initial setting of INSTALL_WEB_SERVER=true was moved up with other variables.

added support for PR #3170.  Any variable can be added by creating a default in basic-install.sh, adding the variable in all caps to pihole-setupVars.conf, and setting the variable in the appropriate file with "replaceAddCreate" or "replaceAddCreateRename", depending on the name of the variable in the target file.  If the variable name has to be changed, use "replaceAddCreateRename".

Also fixed a typo in FTLinstall (changed "grep Location" to "grep location")

**How does this PR accomplish the above?:**
- added pihole-setupVars.conf example
- added validate_setupVars
- added replaceAddCreate
- added replaceAddCreateRename
- updated finalExports to use replaceAddCreate
- validate_setupVars runs immediately after accountForRefactor

**What documentation changes (if any) are needed to support this PR?:**
- DNS Cache documentation should be updated with instruction to add changes to setupVars.conf
- Installation instruction should be updated for unattended installs.
- 01-pihole.conf should be updated with a note about making changes.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

