### PR TITLE
Revert using hardcoded php-intl meta package

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -247,7 +247,7 @@ if is_command apt-get ; then
     PIHOLE_DEPS=(cron curl dnsutils iputils-ping lsof netcat psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data resolvconf libcap2)
     # The Web dashboard has some that also need to be installed
     # It's useful to separate the two since our repos are also setup as "Core" code and "Web" code
-    PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "php-intl")
+    PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-intl")
     # The Web server user,
     LIGHTTPD_USER="www-data"
     # group,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

**Signed-off-by: MichaIng <micha@dietpi.com>**

---
**What does this PR aim to accomplish?:**
Using the meta package causes several issues:
- Install on Debian prior to Stretch and Ubuntu prior to Xenial is broken, since those do not serve the meta packages but php5-* packages instead.
- If $phpVer != "php", then multiple conflicting PHP versions can be installed.
- If "${phpVer}-intl" does not pull the correct package, then inherently "${phpVer}-xml" etc are wrong, too. This is theoretically possible, e.g. if PHP7.4 was installed while the webserver uses a concurrently installed PHP7.3 instance. Then the "php" shell command output can differ from what the webserver uses. This theoretical issue would need a different approach to derive $phpVer, not based on the shell command output but by asking the webserver somehow in the first place. But using $phpVer for some modules and hardcoded meta for the others can only lead to inconsistencies and issues.

**How does this PR accomplish the above?:**
- Revert to $phpVer for PHP intl module