### PR TITLE
Reduce apt-get install verbosity

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -184,7 +184,7 @@ if is_command apt-get ; then
     # A variable to store the command used to update the package cache
     UPDATE_PKG_CACHE="${PKG_MANAGER} update"
     # An array for something...
-    PKG_INSTALL=("${PKG_MANAGER}" --yes --no-install-recommends install)
+    PKG_INSTALL=("${PKG_MANAGER}" -qq --no-install-recommends install)
     # grep -c will return 1 retVal on 0 matches, block this throwing the set -e with an OR TRUE
     PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
     # Some distros vary slightly so these fixes for dependencies may apply


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

**Signed-off-by: MichaIng <micha@dietpi.com>**

---
**What does this PR aim to accomplish?:**
The new version of the installer moved from debconf-apt-progress to raw apt-get output on installs to solve issues with interactive config file choices. This lead to a largely increases amount of output lines of the installer. To reduce the apt-get output to a minimum, while sustaining interactive input in case of config files, the "-qq" option can be used, which inherits "--yes": 
- https://manpages.debian.org/buster/apt/apt-get.8.en.html#OPTIONS
- https://manpages.ubuntu.com/manpages/bionic/man8/apt-get.8.html#options

**How does this PR accomplish the above?:**
Replacing `--yes` with `-qq` for apt-get installs
________________
#### Before
```
  [i] Processing apt-get install(s) for: dhcpcd5 git, please wait...
--------------------------------------------------------------------------------
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  git-man libcurl3-gnutls liberror-perl libexpat1 libgdbm-compat4 libgdbm6 libperl5.28 perl perl-modules-5.28
Suggested packages:
  dhcpcd-gtk git-daemon-run | git-daemon-sysvinit git-doc git-el git-email git-gui gitk gitweb git-cvs git-mediawiki git-svn gdbm-l10n perl-doc
  libterm-readline-gnu-perl | libterm-readline-perl-perl make libb-debug-perl liblocale-codes-perl
Recommended packages:
  openresolv | resolvconf patch less ssh-client netbase
The following NEW packages will be installed:
  dhcpcd5 git git-man libcurl3-gnutls liberror-perl libexpat1 libgdbm-compat4 libgdbm6 libperl5.28 perl perl-modules-5.28
0 upgraded, 11 newly installed, 0 to remove and 0 not upgraded.
Need to get 14.9 MB of archives.
After this operation, 86.6 MB of additional disk space will be used.
Get:1 https://deb.debian.org/debian buster/main amd64 perl-modules-5.28 all 5.28.1-6 [2,873 kB]
Get:2 https://deb.debian.org/debian buster/main amd64 libgdbm6 amd64 1.18.1-4 [64.7 kB]
Get:3 https://deb.debian.org/debian buster/main amd64 libgdbm-compat4 amd64 1.18.1-4 [44.1 kB]
Get:4 https://deb.debian.org/debian buster/main amd64 libperl5.28 amd64 5.28.1-6 [3,883 kB]
Get:5 https://deb.debian.org/debian buster/main amd64 perl amd64 5.28.1-6 [204 kB]
Get:6 https://deb.debian.org/debian buster/main amd64 dhcpcd5 amd64 7.1.0-2 [163 kB]
Get:7 https://deb.debian.org/debian-security buster/updates/main amd64 libcurl3-gnutls amd64 7.64.0-4+deb10u1 [330 kB]
Get:8 https://deb.debian.org/debian buster/main amd64 libexpat1 amd64 2.2.6-2+deb10u1 [106 kB]
Get:9 https://deb.debian.org/debian buster/main amd64 liberror-perl all 0.17027-2 [30.9 kB]
Get:10 https://deb.debian.org/debian buster/main amd64 git-man all 1:2.20.1-2+deb10u1 [1,620 kB]
Get:11 https://deb.debian.org/debian buster/main amd64 git amd64 1:2.20.1-2+deb10u1 [5,620 kB]
Fetched 14.9 MB in 4s (3,548 kB/s)
Selecting previously unselected package perl-modules-5.28.
(Reading database ... 15879 files and directories currently installed.)
Preparing to unpack .../00-perl-modules-5.28_5.28.1-6_all.deb ...
Unpacking perl-modules-5.28 (5.28.1-6) ...
Selecting previously unselected package libgdbm6:amd64.
Preparing to unpack .../01-libgdbm6_1.18.1-4_amd64.deb ...
Unpacking libgdbm6:amd64 (1.18.1-4) ...
Selecting previously unselected package libgdbm-compat4:amd64.
Preparing to unpack .../02-libgdbm-compat4_1.18.1-4_amd64.deb ...
Unpacking libgdbm-compat4:amd64 (1.18.1-4) ...
Selecting previously unselected package libperl5.28:amd64.
Preparing to unpack .../03-libperl5.28_5.28.1-6_amd64.deb ...
Unpacking libperl5.28:amd64 (5.28.1-6) ...
Selecting previously unselected package perl.
Preparing to unpack .../04-perl_5.28.1-6_amd64.deb ...
Unpacking perl (5.28.1-6) ...
Selecting previously unselected package dhcpcd5.
Preparing to unpack .../05-dhcpcd5_7.1.0-2_amd64.deb ...
Unpacking dhcpcd5 (7.1.0-2) ...
Selecting previously unselected package libcurl3-gnutls:amd64.
Preparing to unpack .../06-libcurl3-gnutls_7.64.0-4+deb10u1_amd64.deb ...
Unpacking libcurl3-gnutls:amd64 (7.64.0-4+deb10u1) ...
Selecting previously unselected package libexpat1:amd64.
Preparing to unpack .../07-libexpat1_2.2.6-2+deb10u1_amd64.deb ...
Unpacking libexpat1:amd64 (2.2.6-2+deb10u1) ...
Selecting previously unselected package liberror-perl.
Preparing to unpack .../08-liberror-perl_0.17027-2_all.deb ...
Unpacking liberror-perl (0.17027-2) ...
Selecting previously unselected package git-man.
Preparing to unpack .../09-git-man_1%3a2.20.1-2+deb10u1_all.deb ...
Unpacking git-man (1:2.20.1-2+deb10u1) ...
Selecting previously unselected package git.
Preparing to unpack .../10-git_1%3a2.20.1-2+deb10u1_amd64.deb ...
Unpacking git (1:2.20.1-2+deb10u1) ...
Setting up perl-modules-5.28 (5.28.1-6) ...
Setting up libexpat1:amd64 (2.2.6-2+deb10u1) ...
Setting up dhcpcd5 (7.1.0-2) ...
Created symlink /etc/systemd/system/multi-user.target.wants/dhcpcd.service → /lib/systemd/system/dhcpcd.service.
Setting up libcurl3-gnutls:amd64 (7.64.0-4+deb10u1) ...
Setting up git-man (1:2.20.1-2+deb10u1) ...
Setting up libgdbm6:amd64 (1.18.1-4) ...
Setting up libgdbm-compat4:amd64 (1.18.1-4) ...
Setting up libperl5.28:amd64 (5.28.1-6) ...
Setting up perl (5.28.1-6) ...
Setting up liberror-perl (0.17027-2) ...
Setting up git (1:2.20.1-2+deb10u1) ...
Processing triggers for systemd (241-7~deb10u3) ...
Processing triggers for libc-bin (2.28-10) ...
--------------------------------------------------------------------------------
```
#### After
```
  [i] Processing apt-get install(s) for: dhcpcd5 git, please wait...
--------------------------------------------------------------------------------
Selecting previously unselected package perl-modules-5.28.
(Reading database ... 15879 files and directories currently installed.)
Preparing to unpack .../00-perl-modules-5.28_5.28.1-6_all.deb ...
Unpacking perl-modules-5.28 (5.28.1-6) ...
Selecting previously unselected package libgdbm6:amd64.
Preparing to unpack .../01-libgdbm6_1.18.1-4_amd64.deb ...
Unpacking libgdbm6:amd64 (1.18.1-4) ...
Selecting previously unselected package libgdbm-compat4:amd64.
Preparing to unpack .../02-libgdbm-compat4_1.18.1-4_amd64.deb ...
Unpacking libgdbm-compat4:amd64 (1.18.1-4) ...
Selecting previously unselected package libperl5.28:amd64.
Preparing to unpack .../03-libperl5.28_5.28.1-6_amd64.deb ...
Unpacking libperl5.28:amd64 (5.28.1-6) ...
Selecting previously unselected package perl.
Preparing to unpack .../04-perl_5.28.1-6_amd64.deb ...
Unpacking perl (5.28.1-6) ...
Selecting previously unselected package dhcpcd5.
Preparing to unpack .../05-dhcpcd5_7.1.0-2_amd64.deb ...
Unpacking dhcpcd5 (7.1.0-2) ...
Selecting previously unselected package libcurl3-gnutls:amd64.
Preparing to unpack .../06-libcurl3-gnutls_7.64.0-4+deb10u1_amd64.deb ...
Unpacking libcurl3-gnutls:amd64 (7.64.0-4+deb10u1) ...
Selecting previously unselected package libexpat1:amd64.
Preparing to unpack .../07-libexpat1_2.2.6-2+deb10u1_amd64.deb ...
Unpacking libexpat1:amd64 (2.2.6-2+deb10u1) ...
Selecting previously unselected package liberror-perl.
Preparing to unpack .../08-liberror-perl_0.17027-2_all.deb ...
Unpacking liberror-perl (0.17027-2) ...
Selecting previously unselected package git-man.
Preparing to unpack .../09-git-man_1%3a2.20.1-2+deb10u1_all.deb ...
Unpacking git-man (1:2.20.1-2+deb10u1) ...
Selecting previously unselected package git.
Preparing to unpack .../10-git_1%3a2.20.1-2+deb10u1_amd64.deb ...
Unpacking git (1:2.20.1-2+deb10u1) ...
Setting up perl-modules-5.28 (5.28.1-6) ...
Setting up libexpat1:amd64 (2.2.6-2+deb10u1) ...
Setting up dhcpcd5 (7.1.0-2) ...
Created symlink /etc/systemd/system/multi-user.target.wants/dhcpcd.service → /lib/systemd/system/dhcpcd.service.
Setting up libcurl3-gnutls:amd64 (7.64.0-4+deb10u1) ...
Setting up git-man (1:2.20.1-2+deb10u1) ...
Setting up libgdbm6:amd64 (1.18.1-4) ...
Setting up libgdbm-compat4:amd64 (1.18.1-4) ...
Setting up libperl5.28:amd64 (5.28.1-6) ...
Setting up perl (5.28.1-6) ...
Setting up liberror-perl (0.17027-2) ...
Setting up git (1:2.20.1-2+deb10u1) ...
Processing triggers for systemd (241-7~deb10u3) ...
Processing triggers for libc-bin (2.28-10) ...
--------------------------------------------------------------------------------
```