### PR TITLE
web server question enhancements

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1177,8 +1177,8 @@ setAdminFlag() {
     esac
 
     # Request user to install web server, if --disable-install-webserver has not been used (INSTALL_WEB_SERVER=true is default).
-    if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
-        WebToggleCommand=(whiptail --separate-output --radiolist "Do you wish to install the web server (lighttpd)?\\n\\nNB: If you disable this, and, do not have an existing webserver installed, the web interface will not function." "${r}" "${c}" 6)
+    if [[ "${INSTALL_WEB_INTERFACE}" == true && "${INSTALL_WEB_SERVER}" == true ]]; then
+        WebToggleCommand=(whiptail --separate-output --radiolist "Do you wish to install the web server (lighttpd) and required PHP modules?\\n\\nNB: If you disable this, and, do not have an existing webserver with required PHP modules installed, the web interface will not function.\nRequired PHP modules are: xml sqlite intl json\nAdditionally the web server needs to be member of the \"pihole\" group for full functionality." "${r}" "${c}" 6)
         # with the default being enabled
         WebChooseOptions=("On (Recommended)" "" on
             Off "" off)
@@ -1932,7 +1932,7 @@ installPihole() {
             chmod 0775 ${webroot}
             # Repair permissions if /var/www/html is not world readable
             chmod a+rx /var/www
-            chmod a+rx /var/www/html
+            chmod a+rx ${webroot}
             # Give pihole access to the Web server group
             usermod -a -G ${LIGHTTPD_GROUP} pihole
             # Give lighttpd access to the pihole group so the web interface can

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1173,11 +1173,13 @@ setAdminFlag() {
             printf "  %b Web Interface Off\\n" "${INFO}"
             # or false
             INSTALL_WEB_INTERFACE=false
+            # Deselect the web server as well, since it is obsolete then
+            INSTALL_WEB_SERVER=false
             ;;
     esac
 
-    # Request user to install web server, if --disable-install-webserver has not been used (INSTALL_WEB_SERVER=true is default).
-    if [[ "${INSTALL_WEB_INTERFACE}" == true && "${INSTALL_WEB_SERVER}" == true ]]; then
+    # Request user to install web server, if it has not been deselected before (INSTALL_WEB_SERVER=true is default).
+    if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
         WebToggleCommand=(whiptail --separate-output --radiolist "Do you wish to install the web server (lighttpd) and required PHP modules?\\n\\nNB: If you disable this, and, do not have an existing webserver with required PHP modules installed, the web interface will not function.\nRequired PHP modules are: xml sqlite intl json\nAdditionally the web server needs to be member of the \"pihole\" group for full functionality." "${r}" "${c}" 6)
         # with the default being enabled
         WebChooseOptions=("On (Recommended)" "" on


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

**Signed-off-by: MichaIng <micha@dietpi.com>**

---
**What does this PR aim to accomplish?:**
- When the web interface is not wanted, the web server install is obsolete, hence the question to install it not required.
- When the web server is deselected during install, required PHP modules are not installed as well and the web server user is not added to the `pihole` group for database access through web UI. This needs to be instead done/assured manually by the user.

**How does this PR accomplish the above?:**
+ Do not ask to install the web server, if the web interface has been deselected before.
+ Add additional info, that PHP modules need to be installed manually, when web server is deselected and the web server user needs to be member of the "pihole" group.