### PR TITLE
use debian stretch image for test cases

### DIFF
--- a/test/debian.Dockerfile
+++ b/test/debian.Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:jessie-scm
+FROM buildpack-deps:stretch-scm
 
 ENV GITDIR /etc/.pihole
 ENV SCRIPTDIR /opt/pihole


### PR DESCRIPTION
Signed-off-by: pvogt09 <50047961+pvogt09@users.noreply.github.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
This PR changes the debian image used for the test cases from jessie to stretch because jessie is not [officially](https://docs.pi-hole.net/main/prerequesites/) suported.


**How does this PR accomplish the above?:**
When trying to run a full install of pi-hole in the test, for the debian image the following errors occur during installation of the dependencies:
```
debconf: delaying package configuration, since apt-utils is not installed
E: Unable to locate package php5-xml
E: Unable to locate package php-intl
```
This is due to the fact, that a jessie image is used for the tests and the package `php-intl` is available as `php5-intl` in [jessie](https://packages.debian.org/jessie/php5-intl) and the `php5-xml` package is not available at all. (This might also indicate an error in the php version logic as in #3204 although jessie is not supported.) Therefore the image is changed to stretch.


**What documentation changes (if any) are needed to support this PR?:**
None

