### PR TITLE
Do not add pihole user to web server group

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1933,8 +1933,6 @@ installPihole() {
             # Repair permissions if /var/www/html is not world readable
             chmod a+rx /var/www
             chmod a+rx /var/www/html
-            # Give pihole access to the Web server group
-            usermod -a -G ${LIGHTTPD_GROUP} pihole
             # Give lighttpd access to the pihole group so the web interface can
             # manage the gravity.db database
             usermod -a -G pihole ${LIGHTTPD_USER}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Signed-off-by: MichaIng <micha@dietpi.com>

---
**What does this PR aim to accomplish?:**
- **Cleanup + security**
- The `pihole` user is currently added to `www-data` webserver group.
- This is and was never required: https://github.com/pi-hole/pi-hole/pull/2900#issuecomment-597228202
  - As can be seen, after a fresh Pi-hole install with official v5 installer, the only three items with group = `www-data` + user != `dietpi` + higher group mode than "others" mode are `/var/cache/lighttpd/compress/`, `/var/cache/lighttpd/uploads/`, both with 750 modes, and `/var/www/html` with 775 mode. Hence as long as Pi-hole does not directly read one of the first two directories or writes to `/var/www/html` (excluding subdirs!), in fact the `www-data` group does not add any other permissions. I could not find any hint for both cases.
- Furthermore I tracked down the Git blame to when this `usermod` was actually added, to probably find some explanation: https://github.com/pi-hole/pi-hole/pull/2900#issuecomment-597260630
  - It was added with the very first automated installer commit as part of the webserver install. At that time the user `pi` was added to `www-data` as a regular step to enable the default RPi login user administrating the webroot. The `pihole` user did not exist at that time and no service/process ran as `pi` user. The `pihole` was first introduced as fallback if the user `pi` does not exist, to have a similar pseudo-admin user on non-RPi devices. Full transition to pihole user was done later, using it as actual run user for services/processes again later. Adding it to `www-data` group was migrated over the years while the initial reason, to give the default login user some website admin capabilities, is not valid anymore.

**How does this PR accomplish the above?:**
- Remove obsolete `usermod -a -G www-data pihole`.