### PR TITLE
Remove 19036 trust anchor

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -179,7 +179,6 @@ ProcessDNSSettings() {
 
     if [[ "${DNSSEC}" == true ]]; then
         echo "dnssec
-trust-anchor=.,19036,8,2,49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5
 trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D
 " >> "${dnsmasqconfig}"
     fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Remove expired DNSSEC root key

See ICANN announcement here: https://www.icann.org/news/announcement-2018-10-15-en
`dnsmasq` upstream removed the trust anchor on March 17: http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=63e21bdea37a5fec18c339c9a1fd104f11974752

**How does this PR accomplish the above?:**

Remove automatically added trust anchor

**What documentation changes (if any) are needed to support this PR?:**

None