### PR TITLE
fixes #3217 by checking for existing pihole group

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1771,7 +1771,7 @@ create_pihole_user() {
     # If the user pihole exists,
     if id -u pihole &> /dev/null; then
         # if group exists
-        if getent group pihole; then
+        if getent group pihole > /dev/null 2>&1; then
             # just show a success
             printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
         else
@@ -1799,7 +1799,7 @@ create_pihole_user() {
         local str="Creating user 'pihole'"
         printf "%b  %b %s..." "${OVER}" "${INFO}" "${str}"
         # create her with the useradd command
-        if getent group pihole; then
+        if getent group pihole > /dev/null 2>&1; then
             # add primary group pihole as it already exists
             if useradd -r --no-user-group -g pihole -s /usr/sbin/nologin pihole; then
                 printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1770,18 +1770,49 @@ create_pihole_user() {
     printf "  %b %s..." "${INFO}" "${str}"
     # If the user pihole exists,
     if id -u pihole &> /dev/null; then
-        # just show a success
-        printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+        # if group exists
+        if getent group pihole; then
+            # just show a success
+            printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+        else
+            local str="Checking for group 'pihole'"
+            printf "  %b %s..." "${INFO}" "${str}"
+            local str="Creating group 'pihole'"
+            # if group can be created
+            if groupadd pihole; then
+                printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+                local str="Adding user 'pihole' to group 'pihole'"
+                printf "  %b %s..." "${INFO}" "${str}"
+                # if pihole user can be added to group pihole
+                if usermod -g pihole pihole; then
+                    printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+                else
+                    printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+                fi
+            else
+                printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+            fi
+        fi
     # Otherwise,
     else
         printf "%b  %b %s" "${OVER}" "${CROSS}" "${str}"
         local str="Creating user 'pihole'"
         printf "%b  %b %s..." "${OVER}" "${INFO}" "${str}"
         # create her with the useradd command
-        if useradd -r -s /usr/sbin/nologin pihole; then
-          printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+        if getent group pihole; then
+            # add primary group pihole as it already exists
+            if useradd -r --no-user-group -g pihole -s /usr/sbin/nologin pihole; then
+                printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+            else
+                printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+            fi
         else
-          printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+            # add user pihole with default group settings
+            if useradd -r -s /usr/sbin/nologin pihole; then
+                printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+            else
+                printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+            fi
         fi
     fi
 }

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -188,6 +188,14 @@ removeNoPurge() {
             echo -e "  ${CROSS} Unable to remove 'pihole' user"
         fi
     fi
+    # If the pihole group exists, then remove
+    if getent group "pihole" &> /dev/null; then
+        if ${SUDO} groupdel pihole 2> /dev/null; then
+            echo -e "  ${TICK} Removed 'pihole' group"
+        else
+            echo -e "  ${CROSS} Unable to remove 'pihole' group"
+        fi
+    fi
 
     echo -e "\\n   We're sorry to see you go, but thanks for checking out Pi-hole!
        If you need help, reach out to us on Github, Discourse, Reddit or Twitter

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -92,6 +92,47 @@ def test_setupVars_saved_to_file(Pihole):
         assert "{}={}".format(k, v) in output
 
 
+def test_pihole_user_group_creation(Pihole):
+    '''
+    check user creation works if user or group already exist
+    '''
+    # normal situation where neither user or group exist
+    user_create = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    create_pihole_user
+    ''')
+    expected_stdout = tick_box + ' Creating user \'pihole\''
+    assert expected_stdout in user_create.stdout
+    # situation where both user and group already exist
+    user_create = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    create_pihole_user
+    ''')
+    expected_stdout = tick_box + ' Checking for user \'pihole\''
+    assert expected_stdout in user_create.stdout
+    # situation where only group and no user exists
+    Pihole.run('su --shell /bin/bash --command "userdel -r pihole" -p root')
+    user_create = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    create_pihole_user
+    ''')
+    expected_stdout = tick_box + ' Creating user \'pihole\''
+    assert expected_stdout in user_create.stdout
+    # situation where only user and no group exists
+    Pihole.run('su --shell /bin/bash --command "userdel -r pihole" -p root')
+    Pihole.run('su --shell /bin/bash --command "groupdel pihole" -p root')
+    Pihole.run('su --shell /bin/bash --command "groupadd pihole_dummy" -p root')
+    Pihole.run('su --shell /bin/bash --command "useradd -r --no-user-group -g pihole_dummy -s /usr/sbin/nologin pihole" -p root')
+    user_create = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    create_pihole_user
+    ''')
+    expected_stdout = tick_box + ' Creating group \'pihole\''
+    assert expected_stdout in user_create.stdout
+    expected_stdout = tick_box + ' Adding user \'pihole\' to group \'pihole\''
+    assert expected_stdout in user_create.stdout
+
+
 def test_configureFirewall_firewalld_running_no_errors(Pihole):
     '''
     confirms firewalld rules are applied when firewallD is running

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -96,6 +96,7 @@ def test_pihole_user_group_creation(Pihole):
     '''
     check user creation works if user or group already exist
     '''
+    sudo_cmd = 'su --shell /bin/bash --command "{0}" -p root'
     # normal situation where neither user or group exist
     user_create = Pihole.run('''
     source /opt/pihole/basic-install.sh
@@ -111,7 +112,7 @@ def test_pihole_user_group_creation(Pihole):
     expected_stdout = tick_box + ' Checking for user \'pihole\''
     assert expected_stdout in user_create.stdout
     # situation where only group and no user exists
-    Pihole.run('su --shell /bin/bash --command "userdel -r pihole" -p root')
+    Pihole.run(sudo_cmd.format('userdel -r pihole'))
     user_create = Pihole.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -119,10 +120,13 @@ def test_pihole_user_group_creation(Pihole):
     expected_stdout = tick_box + ' Creating user \'pihole\''
     assert expected_stdout in user_create.stdout
     # situation where only user and no group exists
-    Pihole.run('su --shell /bin/bash --command "userdel -r pihole" -p root')
-    Pihole.run('su --shell /bin/bash --command "groupdel pihole" -p root')
-    Pihole.run('su --shell /bin/bash --command "groupadd pihole_dummy" -p root')
-    Pihole.run('su --shell /bin/bash --command "useradd -r --no-user-group -g pihole_dummy -s /usr/sbin/nologin pihole" -p root')
+    Pihole.run(sudo_cmd.format('userdel -r pihole'))
+    Pihole.run(sudo_cmd.format('groupdel pihole'))
+    Pihole.run(sudo_cmd.format('groupadd pihole_dummy'))
+    useradd_dummy = (
+        'useradd -r --no-user-group -g pihole_dummy ' +
+        '-s /usr/sbin/nologin pihole')
+    Pihole.run(sudo_cmd.format(useradd_dummy))
     user_create = Pihole.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user


### PR DESCRIPTION
Signed-off-by: pvogt09 <50047961+pvogt09@users.noreply.github.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fixes installation issues encountered in #3217 by checking if pihole user or group already exist and handling the different cases that might occur accordingly. Also adds a test case for the different situations that might occur:

1. no user and group exist
2. both user and group already exist
3. user exists but group does not
4. group exists but user does not

- [x] During testing I encountered that under Fedora and CentOS deleting the `pihole` user also deletes the group while it remains under Debian which might be the root cause of #3217. Probably something has to be changed in the uninstaller as well depending on the disribution. Or would it be enough to delete the group afer user deletion if it still existed?


**How does this PR accomplish the above?:**
Existance of user and group `pihole` are checked before trying to create one of them.


**What documentation changes (if any) are needed to support this PR?:**
None.