### PR TITLE
set permission of /var/cache if it did not exist

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1428,7 +1428,13 @@ installConfigs() {
         # Make the directories if they do not exist and set the owners
         mkdir -p /var/run/lighttpd
         chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /var/run/lighttpd
+        test -d /var/cache
+        local varcache=$?
         mkdir -p /var/cache/lighttpd/compress
+        if [[ ! "${varcache}" -eq 0 ]]; then
+            chmod a+rx /var/cache
+        fi
+        chmod a+rx /var/cache/lighttpd
         chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /var/cache/lighttpd/compress
         mkdir -p /var/cache/lighttpd/uploads
         chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /var/cache/lighttpd/uploads


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Sets the permission of `/var/cache/lighttpd` if `/var/cache` did not exist prior to run of installation script. This might only happen in reduced container-based systems like the ones used in the Travis-CI tests as seen [here](https://github.com/pi-hole/pi-hole/pull/3191#issuecomment-602899410). A similar, maybe related problem was encountered [here](https://discourse.pi-hole.net/t/lighttpd-permission-denied-var-cache-lighttpd-compress/20553).
The change is also partly contained in #3191, but that might not make its way to the development branch any time soon.


**How does this PR accomplish the above?:**
Existance of `/var/cache` is checked before `mkdir` and permission are set accordingly.


**What documentation changes (if any) are needed to support this PR?:**
None.