### PR TITLE
Rename default group to ... well ... "Default"

### DIFF
--- a/advanced/Scripts/database_migration/gravity-db.sh
+++ b/advanced/Scripts/database_migration/gravity-db.sh
@@ -104,4 +104,10 @@ upgrade_gravityDB(){
 		sqlite3 "${database}" < "${scriptPath}/10_to_11.sql"
 		version=11
 	fi
+	if [[ "$version" == "11" ]]; then
+		# Rename group 0 from "Unassociated" to "Default"
+		echo -e "  ${INFO} Upgrading gravity database from version 11 to 12"
+		sqlite3 "${database}" < "${scriptPath}/11_to_12.sql"
+		version=12
+	fi
 }

--- a/advanced/Scripts/database_migration/gravity/11_to_12.sql
+++ b/advanced/Scripts/database_migration/gravity/11_to_12.sql
@@ -1,0 +1,19 @@
+.timeout 30000
+
+PRAGMA FOREIGN_KEYS=OFF;
+
+BEGIN TRANSACTION;
+
+UPDATE "group" SET name = 'Default' WHERE id = 0;
+UPDATE "group" SET description = 'The default group' WHERE id = 0;
+
+DROP TRIGGER IF EXISTS tr_group_zero;
+
+CREATE TRIGGER tr_group_zero AFTER DELETE ON "group"
+    BEGIN
+      INSERT OR IGNORE INTO "group" (id,enabled,name,description) VALUES (0,1,'Default','The default group');
+    END;
+
+UPDATE info SET value = 12 WHERE property = 'version';
+
+COMMIT;

--- a/advanced/Templates/gravity.db.sql
+++ b/advanced/Templates/gravity.db.sql
@@ -10,7 +10,7 @@ CREATE TABLE "group"
 	date_modified INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)),
 	description TEXT
 );
-INSERT INTO "group" (id,enabled,name) VALUES (0,1,'Unassociated');
+INSERT INTO "group" (id,enabled,name,description) VALUES (0,1,'Default','The default group');
 
 CREATE TABLE domainlist
 (
@@ -52,7 +52,7 @@ CREATE TABLE info
 	value TEXT NOT NULL
 );
 
-INSERT INTO "info" VALUES('version','11');
+INSERT INTO "info" VALUES('version','12');
 
 CREATE TABLE domain_audit
 (
@@ -167,7 +167,7 @@ CREATE TRIGGER tr_group_update AFTER UPDATE ON "group"
 
 CREATE TRIGGER tr_group_zero AFTER DELETE ON "group"
     BEGIN
-      INSERT OR IGNORE INTO "group" (id,enabled,name) VALUES (0,1,'Unassociated');
+      INSERT OR IGNORE INTO "group" (id,enabled,name) VALUES (0,1,'Default');
     END;
 
 CREATE TRIGGER tr_domainlist_delete AFTER DELETE ON domainlist


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Try to reduce confusion

**How does this PR accomplish the above?:**

Rename the `Unassociated` group to `Default` group and add a comment that this is the default group.

This updates existing databases (users participating in the beta) to version 12 and created new databases already with the new group name.

**What documentation changes (if any) are needed to support this PR?:**

**TODO** The release notes as well as the docs (group management examples) need screnshots to be updated.