### PR TITLE
Update lighttpd.conf.fedora

### DIFF
--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -89,6 +89,23 @@ $HTTP["url"] =~ "^/admin/\.(.*)" {
      url.access-deny = ("")
 }
 
+$HTTP["request-method"] !~ "^(GET|POST|HEAD)$" {
+	url.access-deny = ("")
+}
+
+server.http-parseopts = (
+        "header-strict"            => "enable",
+        "host-strict"              => "enable",
+        "host-normalize"           => "enable",
+        "url-normalize"            => "enable",
+        "url-normalize-unreserved" => "enable",
+        "url-normalize-required"   => "enable",
+        "url-ctrls-reject"         => "enable",
+        "url-path-2f-decode"       => "disable",
+        "url-path-dotseg-remove"   => "enable",
+        "url-query-20-plus"        => "enable"
+)
+
 # Add user chosen options held in external file
 # This uses include_shell instead of an include wildcard for compatibility
 include_shell "cat external.conf 2>/dev/null"


### PR DESCRIPTION
This addresses two issues. 

1) Restricting allowed access methods to just GET, POST and HEAD. Disallow HTTP OPTIONS method. See https://www.rapid7.com/db/vulnerabilities/http-options-method-enabled

2) Explicitly disable "url-path-2f-decode". Flagged as CVE-2019-11072

These popped up during a vulnerability scan.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fix some identified vulnerabilities in lighttpd config


**How does this PR accomplish the above?:**
Added config items to address issues.

**What documentation changes (if any) are needed to support this PR?:**
See https://www.rapid7.com/db/vulnerabilities/http-options-method-enabled and CVE-2019-11072


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
