### PR TITLE
Fix for pihole -w --nuke displaying help info even if command is exec…

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -222,6 +222,7 @@ Displaylist() {
 
 NukeList() {
     sqlite3 "${gravityDBfile}" "DELETE FROM domainlist WHERE type = ${typeId};"
+    exit 0;
 }
 
 for var in "$@"; do


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
In the latest release version (5.0), doing a `pihole -w --nuke` to nuke the whitelist works, but the standard syntax help information was still displayed (the output you get when you do `pihole -w --help`).

This gives the user the impression that the syntax was wrong and the nuke did not go through. This could be confusing.

example:

```
pi@pihole:~ $ pihole -w --nuke
Usage: pihole -w [options] <domain> <domain2 ...>
Example: 'pihole -w site.com', or 'pihole -w site1.com site2.com'
Whitelist one or more domains

Options:
  -d, --delmode       Remove domain(s) from the whitelist
  -nr, --noreload     Update whitelist without reloading the DNS server
  -q, --quiet         Make output less verbose
  -h, --help          Show this help dialog
  -l, --list          Display all your whitelistlisted domains
  --nuke              Removes all entries in a list
```

This PR rectifies this behaviour

**How does this PR accomplish the above?:**
By making sure the call to NukeList() exits, like any other function in the same module. (For example, Displaylist() )

**Possible additional improvement** is to output the exit code of the sqlite3 command, but that's not done in other functions here, so I left that out.

**What documentation changes (if any) are needed to support this PR?:**
None.
