### PR TITLE
Only check SELinux states if "getenforce" command exists

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1980,9 +1980,9 @@ checkSelinux() {
     local DEFAULT_SELINUX
     local CURRENT_SELINUX
     local SELINUX_ENFORCING=0
-    # Check if a SELinux configuration file exists
-    if [[ -f /etc/selinux/config ]]; then
-        # If a SELinux configuration file was found, check the default SELinux mode.
+    # Check for SELinux configuration file and getenforce command
+    if [[ -f /etc/selinux/config ]] && command -v getenforce &> /dev/null; then
+        # Check the default SELinux mode
         DEFAULT_SELINUX=$(awk -F= '/^SELINUX=/ {print $2}' /etc/selinux/config)
         case "${DEFAULT_SELINUX,,}" in
             enforcing)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish and how does this PR accomplish the above?:**
- Currently, if the SELinux config file exists, installed SELinux is assumed.
- But removing e.g. an APT package via "apt-get remove" leaves config files in place, or they could be present for other reasons.
- If the getenforce command is not present but the config file is, currently the installer exists without error message when calling getenforce due to "set -e".
- With this change, the presence of getenforce command is checked first. If it is not present, selinux-utils is not installed, which is a core part of SELinux, pulled in by selinux-basics as well. So it can be assumed that no SELinux is active if this command is missing.

Related forum error report: https://discourse.pi-hole.net/t/upgrade-to-5-0-failing/32068