### PR TITLE
Fix GitHub capitalisation

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -3,7 +3,7 @@
 # (c) 2017 Pi-hole, LLC (https://pi-hole.net)
 # Network-wide ad blocking via your own hardware.
 #
-# Switch Pi-hole subsystems to a different Github branch.
+# Switch Pi-hole subsystems to a different GitHub branch.
 #
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -88,7 +88,7 @@ getRemoteVersion(){
     local arrCache
     cachedVersions="/etc/pihole/GitHubVersions"
 
-    #If the above file exists, then we can read from that. Prevents overuse of Github API
+    #If the above file exists, then we can read from that. Prevents overuse of GitHub API
     if [[ -f "$cachedVersions" ]]; then
         IFS=' ' read -r -a arrCache < "$cachedVersions"
         case $daemon in
@@ -203,7 +203,7 @@ Repositories:
 Options:
   -c, --current        Return the current version
   -l, --latest         Return the latest version
-  --hash               Return the Github hash from your local repositories
+  --hash               Return the GitHub hash from your local repositories
   -h, --help           Show this help dialog"
   exit 0
 }

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -190,7 +190,7 @@ removeNoPurge() {
     fi
 
     echo -e "\\n   We're sorry to see you go, but thanks for checking out Pi-hole!
-       If you need help, reach out to us on Github, Discourse, Reddit or Twitter
+       If you need help, reach out to us on GitHub, Discourse, Reddit or Twitter
        Reinstall at any time: ${COL_WHITE}curl -sSL https://install.pi-hole.net | bash${COL_NC}
 
       ${COL_LIGHT_RED}Please reset the DNS on your router/clients to restore internet connectivity

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -224,7 +224,7 @@ Available commands and options:
 .br
       -l, --latest      Return the latest version
 .br
-      --hash            Return the Github hash from your local
+      --hash            Return the GitHub hash from your local
                         repositories
 .br
 
@@ -269,7 +269,7 @@ Available commands and options:
 
 \fBcheckout\fR [repo] [branch]
 .br
-    Switch Pi-hole subsystems to a different Github branch
+    Switch Pi-hole subsystems to a different GitHub branch
 .br
 
     (repo options):

--- a/pihole
+++ b/pihole
@@ -317,7 +317,7 @@ piholeCheckoutFunc() {
   if [[ "$2" == "-h" ]] || [[ "$2" == "--help" ]]; then
     echo "Usage: pihole checkout [repo] [branch]
 Example: 'pihole checkout master' or 'pihole checkout core dev'
-Switch Pi-hole subsystems to a different Github branch
+Switch Pi-hole subsystems to a different GitHub branch
 
 Repositories:
   core [branch]       Change the branch of Pi-hole's core subsystem
@@ -416,7 +416,7 @@ Options:
   restartdns          Full restart Pi-hole subsystems
                         Add 'reload' to update the lists and flush the cache without restarting the DNS server
                         Add 'reload-lists' to only update the lists WITHOUT flushing the cache or restarting the DNS server
-  checkout            Switch Pi-hole subsystems to a different Github branch
+  checkout            Switch Pi-hole subsystems to a different GitHub branch
                         Add '-h' for more info on checkout usage
   arpflush            Flush information stored in Pi-hole's network tables";
   exit 0


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [ ] I give this submission freely and claim no ownership.
- [ ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
This pull request standardises the capitalisation of "GitHub".