### PR TITLE
Add hostname entry with dns suffix to local.list (DHCP enabled)

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -685,7 +685,12 @@ gravity_generateLocalList() {
     return 0
   fi
 
-  echo -e "${hostname}\\npi.hole" > "${localList}.tmp"
+  # Add hostname.suffix entry when DHCP is enabled
+  if [[ "${DHCP_ACTIVE}" == true ]] && [[ -n "${PIHOLE_DOMAIN}" ]]; then
+    echo -e "${hostname}.${PIHOLE_DOMAIN} ${hostname}\\npi.hole" > "${localList}.tmp"
+  else
+    echo -e "${hostname}\\npi.hole" > "${localList}.tmp"
+  fi
 
   # Empty $localList if it already exists, otherwise, create it
   : > "${localList}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

So basically when DHCP server is enabled all hostnames should be resolvable by `hostname.suffix`, Pi-hole is not - no `local.list` entry for it's hostname with suffix.

Before:

```bash
# fails because it looks for pihole.lan under the hood
# there is no lookup for 'pihole' in the query log, only for the suffixed one
>nslookup pihole
Server:  pihole
Address:  192.168.0.2

*** pihole can't find pihole: Non-existent domain


>nslookup pihole.lan
Server:  pihole
Address:  192.168.0.2

*** pihole can't find pihole.lan: Non-existent domain


>nslookup desktop-pc
Server:  pihole
Address:  192.168.0.2

Name:    desktop-pc.lan
Address:  192.168.0.101
```

After:

```bash
>nslookup pihole
Server:  pihole.lan
Address:  192.168.0.2

Name:    pihole.lan
Address:  192.168.0.2


>nslookup pihole.lan
Server:  pihole.lan
Address:  192.168.0.2

Name:    pihole.lan
Address:  192.168.0.2


>nslookup desktop-pc
Server:  pihole.lan
Address:  192.168.0.2

Name:    desktop-pc.lan
Address:  192.168.0.101
```

`pihole` is obviously hostname of the Pi-hole machine.
`avahi-daemon` is disabled.


**How does this PR accomplish the above?:**

Added extra condition to `gravity_generateLocalList()` that inserts `hostname.suffix` entry when DHCP is enabled.


### I'm unsure if this change should also apply to conditional forwarding - I don't have environment to test this

Does `nslookup desktop-pc` gets forwarded with conditional forwarding turned on?


**What documentation changes (if any) are needed to support this PR?:**

I don't think so

---------------------------

**Alternatively probably [this](https://wiki.archlinux.org/index.php/dnsmasq#Adding_a_custom_domain) might accomplish the same (`expand-hosts`).**

15-05-2020 - CI fix
22-05-2020 - merged two entries into one, no point having them separated
30-06-2020 - alternative via dnsmasq config "expand-hosts"