### PR TITLE
Do not add php5-xml to webserver dependencies

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -258,7 +258,11 @@ if is_command apt-get ; then
     PIHOLE_DEPS=(cron curl dnsutils iputils-ping lsof netcat psmisc sudo unzip wget idn2 sqlite3 libcap2-bin dns-root-data libcap2)
     # The Web dashboard has some that also need to be installed
     # It's useful to separate the two since our repos are also setup as "Core" code and "Web" code
-    PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-intl")
+    PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-intl")
+    # - Do not add php5-xml, which does not exist and is compiled into php5-cgi on Debian and Ubuntu
+    if [[ ${phpVer} != 'php5' ]]; then
+        PIHOLE_WEB_DEPS+=("${phpVer}-xml")
+    fi
     # The Web server user,
     LIGHTTPD_USER="www-data"
     # group,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
php5-xml does not exist and is compiled into php5-cgi on Debian and Ubuntu:
- https://packages.debian.org/php5-xml
- https://packages.debian.org/php5-cgi
- http://archive.ubuntu.com/ubuntu/pool/main/p/php5/
- http://raspbian.raspberrypi.org/raspbian/pool/main/p/php5/

The package must hence not be added to the dependencies array to prevent APT errors.

**How does this PR accomplish the above?:**
The `phpVer` variable is checked against "php5" and only it it does not match, the `${phpVer}-xml` package is added to the dependencies array.