### PR TITLE
Change OS Detection in debug script

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -405,7 +405,7 @@ os_check() {
     detected_os="${detected_os_pretty%% *}"
     detected_version=$(cat /etc/*release | grep VERSION_ID | cut -d '=' -f2- | tr -d '"')
 
-    mapfile -t supportedOS < <(dig +short -t txt ${remote_os_domain} | tr -d '"' | tr ' ' '\n')
+    IFS=" "; read -r -a supportedOS < <(dig +short -t txt ${remote_os_domain} | tr -d '"')
 
     for i in "${supportedOS[@]}"
     do
@@ -414,7 +414,7 @@ os_check() {
 
         if [[ "${detected_os}" =~ ${os_part} ]]; then
           valid_os=true
-          mapfile -t supportedVer < <(echo "${versions_part}" | tr ',' '\n')
+          IFS=","; read -r -a supportedVer <<<"${versions_part}"
           for x in "${supportedVer[@]}"
           do
             if [[ "${detected_version}" =~ $x ]];then

--- a/supportedos.txt
+++ b/supportedos.txt
@@ -1,0 +1,5 @@
+Raspbian=9,10
+Ubuntu=16,18
+Debian=9,10
+Fedora=31,32
+CentOS=7,8


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Currently the supported/unsupported OS detection is based on the distro name being one of 5 set values, this is fine, but then we also need to check further. For example Raspbian <9 is not supported.

This PR adds that check.  I'd like to get a similar output into the installer if it fails, however I am starting to think that maybe the installer should prompt user to run and _read_ the debug log if an update fails.  Though obviously that won't necessarily work on a fresh install.

Examples using a Debian 10 (Buster) system:
`supportedos.txt` contains:
```
Raspbian=9,10
Ubuntu=16,18
Debian=9,10
Fedora=31,32
CentOS=7,8
```
Debug output:
![image](https://user-images.githubusercontent.com/1998970/82756698-a0d20480-9dd3-11ea-9115-a79c4c2a4fc8.png)

`supportedos.txt` contains:
```
Raspbian=9,10
Ubuntu=16,18
Debian=9
Fedora=31,32
CentOS=7,8
```
Debug Output:
![image](https://user-images.githubusercontent.com/1998970/82758783-8a7e7580-9de0-11ea-9510-4ee8587ae945.png)


`supportedos.txt` contains:
```
Raspbian=9,10
Ubuntu=16,18
Fedora=31,32
CentOS=7,8
```
Debug Output:
![image](https://user-images.githubusercontent.com/1998970/82758791-99fdbe80-9de0-11ea-9437-2ddce3978928.png)



