### PR TITLE
Wait for system to be time-synced before starting pihole-FTL

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 ### BEGIN INIT INFO
 # Provides:          pihole-FTL
-# Required-Start:    $remote_fs $syslog $network
+# Required-Start:    $remote_fs $syslog $network $time
 # Required-Stop:     $remote_fs $syslog $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*
When starting Pi-hole on Fedora 32 (and potentially other systems) on an RPi without a Real-Time Clock (RTC), the system time is usually incorrect. If Pi-hole is started before the system achieves time sync, the query graphs don't work and `/var/log/pihole-FTL.log` contains many lines line

```
[2020-06-04 10:47:42.921 628] WARN: getOverTimeID(1591231500): 9262 is too large: 1585674300
[2020-06-04 10:50:45.110 628] WARN: getOverTimeID(1591232100): 9263 is too large: 1585674300
[2020-06-04 10:50:45.115 628] WARN: getOverTimeID(1591232100): 9263 is too large: 1585674300
[2020-06-04 10:50:45.116 628] WARN: getOverTimeID(1591232100): 9263 is too large: 1585674300
```
This PR fixes the above issue by delaying start of the pihole-FTL engine until the system has achieved time sync.

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*
A simple adjustment to the init script will be used either by LSB init wrappers or systemd to require that time-sync has been achieved before starting the pihole-FTL service.

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*
I don't think there are any documentation changes required

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

