### PR TITLE
Improve IP validation function

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -22,6 +22,7 @@ readonly gravityDBfile="/etc/pihole/gravity.db"
 
 # Source install script for ${setupVars}, ${PI_HOLE_BIN_DIR} and valid_ip()
 readonly PI_HOLE_FILES_DIR="/etc/.pihole"
+# shellcheck disable=SC2034  # used in basic-install
 PH_TEST="true"
 source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1018,7 +1018,7 @@ valid_ip() {
     local stat=1
 
     # If the IP matches the format xxx.xxx.xxx.xxx (optional port of range #0-65536), also ensure string ends with 0-9
-    if [[ "${ip}" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}#{0,1}[0-9]{0,5}$ && "${ip}" =~ ^.*[0-9]$ ]]; then
+    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(#[0-9]{1,5})?$ ]]; then
         # Save the old Internal Field Separator in a variable
         OIFS=$IFS
         # and set the new one to a dot (period)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1017,30 +1017,16 @@ valid_ip() {
     local ip=${1}
     local stat=1
 
-    # If the IP matches the format xxx.xxx.xxx.xxx (optional port of range #0-65536), also ensure string ends with 0-9
-    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(#[0-9]{1,5})?$ ]]; then
-        # Save the old Internal Field Separator in a variable
-        OIFS=$IFS
-        # and set the new one to a dot (period)
-        IFS='.#'
-        # Put the IP into an array
-        read -r -a ip <<< "${ip}"
-        # Restore the IFS to what it was
-        IFS=${OIFS}
+    # One IPv4 element is 8bit: 0 - 256
+    local ipv4elem="(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]?|0)";
+    # optional port number starting '#' with range of 1-65536
+    local portelem="(#([1-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9]|[1-8][0-9]{3}|9[0-8][0-9]{2}|99[0-8][0-9]|999[0-9]|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-6]))?"
+    # build a full regex string from the above parts
+    local regex="^${ipv4elem}\.${ipv4elem}\.${ipv4elem}\.${ipv4elem}${portelem}$"
 
-        ## Evaluate each octet by checking if it's less than or equal to 255 (the max for each octet)
-        [[ "${ip[0]}" -le 255 && "${ip[1]}" -le 255 && "${ip[2]}" -le 255 && "${ip[3]}" -le 255 ]]
-        # Save the exit code
-        stat=$?
+    [[ $ip =~ ${regex} ]]
 
-        # If there is a 5th part to the array, then it is a port number - check it is between 1 and 65536
-        if [[ "${ip[4]}" ]]; then
-            [[ "${ip[4]}" -ge 1 && "${ip[4]}" -le 65536 ]]
-            # Save the exit code
-            stat=$?
-        fi
-
-    fi
+    stat=$?
     # Return the exit code
     return "${stat}"
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

This PR is two-fold:

My first aim was to fix a potential exploit reported by validating the IP used in `pihole -a setdns`. This is done by sourcing the install script in `webpage.sh` and using the `valid_ip()` function.

Secondly, a "whilst I'm in here" - I have expanded the valid_ip() function to accept custom IP addresses with a port number (i.e 1.1.1.1#5353)

Exemplary output from testing the function:

```
[adam@ADAM-PC ~]# ./valid_ip.sh 
4.2.2.2             : good
a.b.c.d             : bad
192.168.1.1         : good
0.0.0.0             : good
255.255.255.255     : good
255.255.255.256     : bad
192.168.0.1         : good
192.168.0           : bad
1234.123.123.123    : bad
192.168.0.119#5353  : good
1.1.1.1#65536       : good
1.1.1.1#65537       : bad
1.1.1.1#12345       : good
1.1.1.1#00000       : bad
1.1.1.1#0           : bad
1.1.1.1#            : bad
```
