### PR TITLE
Improve man pihole restartdns section

### DIFF
--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -257,14 +257,14 @@ Available commands and options:
 
 \fBrestartdns\fR [options]
 .br
-    Full restart Pi-hole subsystems
+    Full restart Pi-hole subsystems. Without any options (see below) a full restart causes config file parsing and history re-reading
 .br
 
     (restart options):
 .br
-      reload            Updates the lists and flushes DNS cache
+      reload            Updates the lists (incl. HOSTS files) and flushes DNS cache. Does not reparse config files
 .br
-      reload-lists      Updates the lists WITHOUT flushing the DNS cache
+      reload-lists      Updates the lists (excl. HOSTS files) WITHOUT flushing the DNS cache. Does not reparse config files
 .br
 
 \fBcheckout\fR [repo] [branch]


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Further clarify `man pihole` -> `restartdns` section

**How does this PR accomplish the above?:**

Add more description as discussed in https://discourse.pi-hole.net/t/pihole-ftl-not-sure-there-is-a-problem-requesting-clarification/31728

**What documentation changes (if any) are needed to support this PR?:**

None