### PR TITLE
Fix missing change from 3fbb0ac8dde14b8edc1982ae3a2a021f3cf68477 that…

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2310,11 +2310,11 @@ get_binary_name() {
             if [[ -f "/.dockerenv" ]]; then
                 printf "%b  %b Detected ARM architecture in docker\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                binary="pihole-FTL-armel-native"
+                l_binary="pihole-FTL-armel-native"
             else
                 printf "%b  %b Detected ARM architecture\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                binary="pihole-FTL-arm-linux-gnueabi"
+                l_binary="pihole-FTL-arm-linux-gnueabi"
             fi
         fi
     elif [[ "${machine}" == "x86_64" ]]; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*

Fix broken setup process for Pi Zero W. Currently, running the basic-setup.sh prints this output before exiting:

```
--------------------------------------------------------------------------------
  [✓] Enabling lighttpd service to start on reboot...
  [✓] Creating user 'pihole'

  [i] FTL Checks...

  [✓] Detected ARM architecture in docker  [i] Checking for existing FTL binary...
  [i] Downloading and Installing FTL...curl: (3) [globbing] bad range in column 70
  [✗] Downloading and Installing FTL
  Error: URL https://github.com/pi-hole/ftl/releases/latest/download/pihole-FTL
  [✓] Detected ARM architecture in docker not found
  [✗] FTL Engine not installed
```

The strange order of messages is because `get_binary_name()` prints status messages about which architecture was detected but doesn't actually print the binary name. The caller removes everything up to the binary name, but it's missing and nothing is removed from the output.

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

The fix is to rename `binary` to `l_binary` as was done in the rest of the branches in `get_binary_name`. This error appears to be the result of a merge conflict.

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*

None.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
