### PR TITLE
Fix pihole status to not rely on a TCP port test

### DIFF
--- a/pihole
+++ b/pihole
@@ -253,35 +253,30 @@ Options:
 analyze_ports() {
   # FTL is listening at least on at least one port when this
   # function is getting called
-  if [[ $(grep -c "IPv4" <<< "${1}") -gt 1 ]] && \
-     [[ $(grep -c "IPv6" <<< "${1}") -gt 1 ]]; then
-    echo -e "  ${TICK} DNS service is listening"
+  echo -e "  ${TICK} DNS service is listening"
+  # Check individual address family/protocol combinations
+  # For a healthy Pi-hole, they should all be up (nothing printed)
+  if grep -q "IPv4.*UDP" <<< "${1}"; then
+      echo -e "     ${TICK} UDP (IPv4)"
   else
-    echo -e "  ${CROSS} DNS service is partially listening"
-    # Check individual address family/protocol combinations
-    # For a healthy Pi-hole, they should all be up (nothing printed)
-    if grep -q "IPv4.*UDP" <<< "${1}"; then
-        echo -e "     ${TICK} UDP (IPv4)"
-    else
-        echo -e "     ${CROSS} UDP (IPv4)"
-    fi
-    if grep -q "IPv4.*TCP" <<< "${1}"; then
-        echo -e "     ${TICK} TCP (IPv4)"
-    else
-        echo -e "     ${CROSS} TCP (IPv4)"
-    fi
-    if grep -q "IPv6.*UDP" <<< "${1}"; then
-        echo -e "     ${TICK} UDP (IPv6)"
-    else
-        echo -e "     ${CROSS} UDP (IPv6)"
-    fi
-    if grep -q "IPv6.*TCP" <<< "${1}"; then
-        echo -e "     ${TICK} TCP (IPv6)"
-    else
-        echo -e "     ${CROSS} TCP (IPv6)"
-    fi
-    echo ""
+      echo -e "     ${CROSS} UDP (IPv4)"
   fi
+  if grep -q "IPv4.*TCP" <<< "${1}"; then
+      echo -e "     ${TICK} TCP (IPv4)"
+  else
+      echo -e "     ${CROSS} TCP (IPv4)"
+  fi
+  if grep -q "IPv6.*UDP" <<< "${1}"; then
+      echo -e "     ${TICK} UDP (IPv6)"
+  else
+      echo -e "     ${CROSS} UDP (IPv6)"
+  fi
+  if grep -q "IPv6.*TCP" <<< "${1}"; then
+      echo -e "     ${TICK} TCP (IPv6)"
+  else
+      echo -e "     ${CROSS} TCP (IPv6)"
+  fi
+  echo ""
 }
 
 statusFunc() {

--- a/pihole
+++ b/pihole
@@ -250,16 +250,52 @@ Options:
   echo -e "${OVER}  ${TICK} ${str}"
 }
 
+analyze_ports() {
+  # FTL is listening at least on at least one port when this
+  # function is getting called
+  if [[ $(grep -c "IPv4" <<< "${1}") -gt 1 ]] && \
+     [[ $(grep -c "IPv6" <<< "${1}") -gt 1 ]]; then
+    echo -e "  ${TICK} DNS service is listening"
+  else
+    echo -e "  ${CROSS} DNS service is partially listening"
+    # Check individual address family/protocol combinations
+    # For a healthy Pi-hole, they should all be up (nothing printed)
+    if grep -q "IPv4.*UDP" <<< "${1}"; then
+        echo -e "     ${TICK} UDP (IPv4)"
+    else
+        echo -e "     ${CROSS} UDP (IPv4)"
+    fi
+    if grep -q "IPv4.*TCP" <<< "${1}"; then
+        echo -e "     ${TICK} TCP (IPv4)"
+    else
+        echo -e "     ${CROSS} TCP (IPv4)"
+    fi
+    if grep -q "IPv6.*UDP" <<< "${1}"; then
+        echo -e "     ${TICK} UDP (IPv6)"
+    else
+        echo -e "     ${CROSS} UDP (IPv6)"
+    fi
+    if grep -q "IPv6.*TCP" <<< "${1}"; then
+        echo -e "     ${TICK} TCP (IPv6)"
+    else
+        echo -e "     ${CROSS} TCP (IPv6)"
+    fi
+    echo ""
+  fi
+}
+
 statusFunc() {
-  # Determine if service is running on port 53 (Cr: https://superuser.com/a/806331)
-  if (echo > /dev/tcp/127.0.0.1/53) >/dev/null 2>&1; then
+  # Determine if there is a pihole service is listening on port 53
+  local listening
+  listening="$(lsof -Pni:53)"
+  if grep -q "pihole" <<< "${listening}"; then
     if [[ "${1}" != "web" ]]; then
-      echo -e "  ${TICK} DNS service is running"
+      analyze_ports "${listening}"
     fi
   else
     case "${1}" in
       "web") echo "-1";;
-      *) echo -e "  ${CROSS} DNS service is NOT running";;
+      *) echo -e "  ${CROSS} DNS service is NOT listening";;
     esac
     return 0
   fi
@@ -269,13 +305,13 @@ statusFunc() {
     # A config is commented out
     case "${1}" in
       "web") echo 0;;
-      *) echo -e "  ${CROSS} Pi-hole blocking is Disabled";;
+      *) echo -e "  ${CROSS} Pi-hole blocking is disabled";;
     esac
   elif grep -q "BLOCKING_ENABLED=true" /etc/pihole/setupVars.conf;  then
     # Configs are set
     case "${1}" in
       "web") echo 1;;
-      *) echo -e "  ${TICK} Pi-hole blocking is Enabled";;
+      *) echo -e "  ${TICK} Pi-hole blocking is enabled";;
     esac
   else
     # No configs were found


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

The current test can fail even when there is no error i case the max. number of TCP workers is reached.

**How does this PR accomplish the above?:**

Actually test if there is a `pihole*` process running on port 53. If so, analyze if we bound to IPv4/6 and UDP/TCP. If all four sockets are accepting/listening, we report that the DNS service is running. If some are missing, we report this, too. If no `pihole*` process is listening on port 53, then this is the new (better) criterion for saying: it is not running

Example for when everything is fine:
```
$ pihole status
  [✓] DNS service is listening
  [✓] Pi-hole blocking is enabled
```

When, e.g., IPv6 is not available:
```
$ pihole status
  [✗] DNS service is partially listening
     [✓] UDP (IPv4)
     [✓] TCP (IPv4)
     [✗] UDP (IPv6)
     [✗] TCP (IPv6)

  [✓] Pi-hole blocking is enabled
```

Or, when FTL is offline:
```
$ pihole status
  [✗] DNS service is NOT listening
```

**What documentation changes (if any) are needed to support this PR?:**

None