### PR TITLE
Add default locations to PATH to assure that all basic commands are available

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -21,6 +21,10 @@
 # instead of continuing the installation with something broken
 set -e
 
+# Set PATH to a usual default to assure that all basic commands are available.
+# When using "su" an uncomplete PATH could be passed: https://github.com/pi-hole/pi-hole/issues/3209
+export PATH+=':/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+
 ######## VARIABLES #########
 # For better maintainability, we store as much information that can change in variables
 # This allows us to make a change in one place that can propagate to all instances of the variable


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
In rare cases, e.g. when the installer is called via `su`, an incomplete/unprivileged PATH could be passed which can make basic commands unavailable, e.g. `usermod` in this example: https://github.com/pi-hole/pi-hole/issues/3209
To avoid larger coding effort to check (and in case search) for each and every basic external (i.e. not bash internal) command before using it, even that it is available in a usual executable location, it is reasonable to make all default locations available via PATH variable.

**How does this PR accomplish the above?:**
Add usual default locations to PATH, which matches by entries (not necessarily order) the `bash` default which is set if no PATH is set, e.g. when using `sudo`.

**What documentation changes (if any) are needed to support this PR?:**
None