### PR TITLE
Support expand-hosts dnsmasq option

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -374,6 +374,10 @@ dhcp-leasefile=/etc/pihole/dhcp.leases
 
     # Sourced from setupVars
     # shellcheck disable=SC2154
+    if [[ "${DHCP_expand_hosts}" == "true" ]]; then
+        echo "expand-hosts" >> "${dhcpconfig}"
+    fi
+
     if [[ "${DHCP_rapid_commit}" == "true" ]]; then
         echo "dhcp-rapid-commit" >> "${dhcpconfig}"
     fi
@@ -403,6 +407,7 @@ EnableDHCP() {
     change_setting "PIHOLE_DOMAIN" "${args[6]}"
     change_setting "DHCP_IPv6" "${args[7]}"
     change_setting "DHCP_rapid_commit" "${args[8]}"
+    change_setting "DHCP_expand_hosts" "${args[9]}"
 
     # Remove possible old setting from file
     delete_dnsmasq_setting "dhcp-"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
- Better solution to minor issue described in https://github.com/pi-hole/pi-hole/pull/3382
- Automatically add DHCP domain to all hosts entries without a period (for example when people add custom hostnames to other devices which have static IP either through **Local DNS Records** or `/etc/hosts`)

**How does this PR accomplish the above?:**
Adds the possibility for the user to add `expand-hosts` option to dnsmasq DHCP config through the web interface.
I've positioned `expand-hosts` option just after `domain` in config file because it makes more sense like this.

**What documentation changes (if any) are needed to support this PR?:**
A mention about this option.

[PR for AdminLTE](https://github.com/pi-hole/AdminLTE/pull/1478)