### PR TITLE
Use gravity's adlist_id in filename when saving downloaded adlist locally

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -359,9 +359,10 @@ gravity_DownloadBlocklists() {
   for ((i = 0; i < "${#sources[@]}"; i++)); do
     url="${sources[$i]}"
     domain="${sourceDomains[$i]}"
+    id="${sourceIDs[$i]}"
 
     # Save the file as list.#.domain
-    saveLocation="${piholeDir}/list.${i}.${domain}.${domainsExtension}"
+    saveLocation="${piholeDir}/list.${id}.${domain}.${domainsExtension}"
     activeDomains[$i]="${saveLocation}"
 
     # Default user-agent (for Cloudflare's Browser Integrity Check: https://support.cloudflare.com/hc/en-us/articles/200170086-What-does-the-Browser-Integrity-Check-do-)


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Instead of saving downloaded adlists with a filename like `list.3.raw.githubusercontent.com.domains` where the digit is just the number of the counter it saves them as `list.34.raw.githubusercontent.com.domains` where `34` is the adlist_id of the adlist in the `gravity.db`


**How does this PR accomplish the above?:**
Reuses sourceIDs (which contains all adlist_ids gravity is going to download) also for the filename.


**What documentation changes (if any) are needed to support this PR?:**
None.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

