### PR TITLE
Further failsafe check for available APT packages

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -85,6 +85,8 @@ QUERY_LOGGING=true
 INSTALL_WEB_INTERFACE=true
 PRIVACY_LEVEL=0
 CACHE_SIZE=10000
+# Placeholder variable for the list of available APT packages to be parsed subsequently
+APT_PACKAGE_LIST=""
 
 if [ -z "${USER}" ]; then
   USER="$(id -un)"
@@ -177,6 +179,19 @@ is_command() {
     local check_command="$1"
 
     command -v "${check_command}" >/dev/null 2>&1
+}
+
+is_apt_package(){
+    # Checks whether a package, or one that provides it, is available in
+    # the installed APT repository lists.
+    local check_package=$1
+
+    # Obtain the list of available packages once
+    if [[ -z $APT_PACKAGE_LIST ]]; then
+        APT_PACKAGE_LIST=$(apt-cache dumpavail | grep -E '^P(ackage|rovides):')
+    fi
+
+    grep -qE " $check_package(,|$)" <<< "$APT_PACKAGE_LIST"
 }
 
 os_check() {
@@ -303,10 +318,10 @@ if is_command apt-get ; then
     # Update package cache. This is required already here to assure apt-cache calls have package lists available.
     update_package_cache || exit 1
     # Debian 7 doesn't have iproute2 so check if it's available first
-    if apt-cache show iproute2 > /dev/null 2>&1; then
+    if is_apt_package iproute2; then
         iproute_pkg="iproute2"
     # Otherwise, check if iproute is available
-    elif apt-cache show iproute > /dev/null 2>&1; then
+    elif is_apt_package iproute; then
         iproute_pkg="iproute"
     # Else print error and exit
     else
@@ -326,10 +341,10 @@ if is_command apt-get ; then
     # Check if installed php is v 7.0, or newer to determine packages to install
     if [[ "$phpInsNewer" != true ]]; then
         # Prefer the php metapackage if it's there
-        if apt-cache show php > /dev/null 2>&1; then
+        if is_apt_package php; then
             phpVer="php"
         # Else fall back on the php5 package if it's there
-        elif apt-cache show php5 > /dev/null 2>&1; then
+        elif is_apt_package php5; then
             phpVer="php5"
         # Else print error and exit
         else
@@ -341,9 +356,9 @@ if is_command apt-get ; then
         phpVer="php$phpInsMajor.$phpInsMinor"
     fi
     # We also need the correct version for `php-sqlite` (which differs across distros)
-    if apt-cache show "${phpVer}-sqlite3" > /dev/null 2>&1; then
+    if is_apt_package "${phpVer}-sqlite3"; then
         phpSqlite="sqlite3"
-    elif apt-cache show "${phpVer}-sqlite" > /dev/null 2>&1; then
+    elif is_apt_package "${phpVer}-sqlite"; then
         phpSqlite="sqlite"
     else
         printf "  %b Aborting installation: No SQLite PHP module was found in APT repository.\\n" "${CROSS}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Signed-off-by: MichaIng <micha@dietpi.com>

---
**What does this PR aim to accomplish?:**
- "apt-cache show _package_" succeeds as well if _package_ is only listed as (optional) dependency or conflict by another installed package, while it may not be actually present in any repository, hence this is no 100% reliable check.
- There is no command which explicitly checks if a package/name can be effectively selected by apt-get for install. An install simulation/dry-run is possible as it was before Pi-hole v5.1, or the whole package cache can be scraped, which is still the less time consuming solution.

**How does this PR accomplish the above?:**
- Scrape `apt-cache dumpavail` for effectively available packages.
- As well allow to succeed if another package "provides" it, like "php7.3-apcu" is provided by "php-apcu" or "awk" is provided by "mawk" and "gawk", in which case the actual (non-virtual) package is selected automatically by apt-get.

For reference: https://github.com/MichaIng/DietPi/pull/3657/commits/066b89fa410ff568f57ad31fa8f50ec72c97796d

**What documentation changes (if any) are needed to support this PR?:**
- None