### PR TITLE
Pi-hole core v5.1.1

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1264,7 +1264,7 @@ upload_to_tricorder() {
             # If they choose no, just exit out of the script
             *) log_write "    * Log will ${COL_GREEN}NOT${COL_NC} be uploaded to tricorder.\\n    * A local copy of the debug log can be found at: ${COL_CYAN}${PIHOLE_DEBUG_LOG}${COL_NC}\\n";exit;
         esac
-    fi232623
+    fi
     # Check if tricorder.pi-hole.net is reachable and provide token
     # along with some additional useful information
     if [[ -n "${tricorder_token}" ]]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -72,8 +72,8 @@ useUpdateVars=false
 adlistFile="/etc/pihole/adlists.list"
 # Pi-hole needs an IP address; to begin, these variables are empty since we don't know what the IP is until
 # this script can run
-IPV4_ADDRESS=""
-IPV6_ADDRESS=""
+IPV4_ADDRESS=${IPV4_ADDRESS}
+IPV6_ADDRESS=${IPV6_ADDRESS}
 # By default, query logging is enabled and the dashboard is set to be installed
 QUERY_LOGGING=true
 INSTALL_WEB_INTERFACE=true


### PR DESCRIPTION
Cosmetic bug fix for fresh installs. Prevents `IPV4_ADDRESS` and `IPV6_ADDRESS` from being blanked out when the install script calls webpage.sh to set the web password (which in turn re-sources `basic-install.sh` and (currently) resets these two variables)

Edit: Also @PromoFaux broke the debug script, so that too.