### PR TITLE
Tweaks to compatibility check output

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -175,59 +175,77 @@ is_command() {
 }
 
 os_check() {
-    # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
-    # and determines whether or not the script is running on one of those systems
-    local remote_os_domain valid_os valid_version detected_os_pretty detected_os detected_version display_warning
-    remote_os_domain="versions.pi-hole.net"
-    valid_os=false
-    valid_version=false
-    display_warning=true
 
-    detected_os_pretty=$(cat /etc/*release | grep PRETTY_NAME | cut -d '=' -f2- | tr -d '"')
-    detected_os="${detected_os_pretty%% *}"
-    detected_version=$(cat /etc/*release | grep VERSION_ID | cut -d '=' -f2- | tr -d '"')
+    if [ "$PIHOLE_SKIP_OS_CHECK" != true ]; then
+        # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
+        # and determines whether or not the script is running on one of those systems
+        local remote_os_domain valid_os valid_version detected_os_pretty detected_os detected_version display_warning
+        remote_os_domain="versions.pi-hole.net"
+        valid_os=false
+        valid_version=false
+        display_warning=true
 
-    IFS=" " read -r -a supportedOS < <(dig +short -t txt ${remote_os_domain} | tr -d '"')
+        detected_os_pretty=$(cat /etc/*release | grep PRETTY_NAME | cut -d '=' -f2- | tr -d '"')
+        detected_os="${detected_os_pretty%% *}"
+        detected_version=$(cat /etc/*release | grep VERSION_ID | cut -d '=' -f2- | tr -d '"')
 
-    for i in "${supportedOS[@]}"
-    do
-        os_part=$(echo "$i" | cut -d '=' -f1)
-        versions_part=$(echo "$i" | cut -d '=' -f2-)
+        IFS=" " read -r -a supportedOS < <(dig +short -t txt ${remote_os_domain} | tr -d '"')
 
-        if [[ "${detected_os}" =~ ${os_part} ]]; then
-          valid_os=true
-          IFS="," read -r -a supportedVer <<<"${versions_part}"
-          for x in "${supportedVer[@]}"
-          do
-            if [[ "${detected_version}" =~ $x ]];then
-              valid_version=true
-              break
+        for i in "${supportedOS[@]}"
+        do
+            os_part=$(echo "$i" | cut -d '=' -f1)
+            versions_part=$(echo "$i" | cut -d '=' -f2-)
+
+            if [[ "${detected_os}" =~ ${os_part} ]]; then
+            valid_os=true
+            IFS="," read -r -a supportedVer <<<"${versions_part}"
+            for x in "${supportedVer[@]}"
+            do
+                if [[ "${detected_version}" =~ $x ]];then
+                valid_version=true
+                break
+                fi
+            done
+            break
             fi
-          done
-          break
+        done
+
+        if [ "$valid_os" = true ] && [ "$valid_version" = true ]; then
+            display_warning=false
         fi
-    done
 
-    if [ "$valid_os" = true ] && [ "$valid_version" = true ]; then
-        display_warning=false
-    fi
+        if [ "$display_warning" = true ]; then
+            printf "  %b %bUnsupported OS detected%b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${COL_NC}"
 
-    if [ "$display_warning" = true ] && [ "$PIHOLE_SKIP_OS_CHECK" != true ]; then
-        printf "  %b %bUnsupported OS detected%b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${COL_NC}"
-        printf "      https://docs.pi-hole.net/main/prerequesites/#supported-operating-systems\\n"
-        printf "\\n"
-        printf "      This check can be skipped by setting the environment variable %bPIHOLE_SKIP_OS_CHECK%b to %btrue%b\\n" "${COL_LIGHT_RED}" "${COL_NC}" "${COL_LIGHT_RED}" "${COL_NC}"
-        printf "      e.g: 'sudo PIHOLE_SKIP_OS_CHECK=true curl -sSL https://install.pi-hole.net | bash'\\n"
-        printf "      or   'sudo PIHOLE_SKIP_OS_CHECK=true pihole -up'\\n"
-        printf "      By setting this variable to true you acknowledge there may be issues with Pi-hole during or after the install\\n"
-        printf "      If that is the case, you can feel free to ask the community on Discourse with the %bCommunity Help%b category:\\n" "${COL_LIGHT_RED}" "${COL_NC}"
-        printf "      https://discourse.pi-hole.net/c/bugs-problems-issues/community-help/\\n"
-        exit 1
-    elif [ "$display_warning" = true ] && [ "$PIHOLE_SKIP_OS_CHECK" = true ]; then
-        printf "  %b %bUnsupported OS detected%b. PIHOLE_SKIP_OS_CHECK env variable set to true - installer will continue\\n" "${INFO}" "${COL_LIGHT_RED}" "${COL_NC}"
+            # Display findings of above test back to the user
+            if [ "$valid_os" = true ]; then
+                printf "  %b Distro: %b%b%b\\n" "${TICK}" "${COL_GREEN}" "${detected_os}" "${COL_NC}"
+                if [ "$valid_version" = true ]; then
+                    printf "  %b Version: %b%b%b\\n" "${TICK}" "${COL_GREEN}" "${detected_version}" "${COL_NC}"
+                else
+                    printf "  %b Version: %b%b%b\\n" "${CROSS}" "${COL_RED}" "${detected_version}" "${COL_NC}"
+                    printf "  %b Error: %b%b is supported but version %b is currently unsupported%b\\n" "${CROSS}" "${COL_RED}" "${detected_os}" "${detected_version}" "${COL_NC}"
+                fi
+            else
+                printf "  %b Distro: %b%b%b\\n" "${CROSS}" "${COL_RED}" "${detected_os}" "${COL_NC}"
+                printf "  %b Error: %b%b is not a supported distro%b\\n" "${CROSS}" "${COL_RED}" "${detected_os}" "${COL_NC}"
+            fi
+            printf "\\n"
+            printf "      https://docs.pi-hole.net/main/prerequesites/#supported-operating-systems\\n\\n"
+            printf "      This check can be skipped by setting the environment variable %bPIHOLE_SKIP_OS_CHECK%b to %btrue%b\\n" "${COL_LIGHT_RED}" "${COL_NC}" "${COL_LIGHT_RED}" "${COL_NC}"
+            printf "      e.g: 'sudo PIHOLE_SKIP_OS_CHECK=true curl -sSL https://install.pi-hole.net | bash'\\n"
+            printf "      or   'sudo PIHOLE_SKIP_OS_CHECK=true pihole -up'\\n\\n"
+            printf "      By setting this variable to true you acknowledge there may be issues with Pi-hole during or after the install\\n"
+            printf "      If that is the case, you can feel free to ask the community on Discourse with the %bCommunity Help%b category:\\n\\n" "${COL_LIGHT_RED}" "${COL_NC}"
+            printf "      https://discourse.pi-hole.net/c/bugs-problems-issues/community-help/\\n\\n"
+            exit 1
+        else
+            printf "  %b %bSupported OS detected%b\\n" "${TICK}" "${COL_LIGHT_GREEN}" "${COL_NC}"
+        fi
     else
-        printf "  %b %bSupported OS detected%b\\n" "${TICK}" "${COL_LIGHT_GREEN}" "${COL_NC}"
+        printf "  %b %bPIHOLE_SKIP_OS_CHECK env variable set to true - installer will continue without checking compatibility%b\\n" "${INFO}" "${COL_LIGHT_RED}" "${COL_NC}"
     fi
+
 }
 
 # Compatibility


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

 - Allows entire check to be bypassed with the ENV var, rather than doing the check first, and then reading in the ENV var.
 - Include information about the detected OS and Version in the error output, e.g if Debian 10 were unsupported it would look like this:

![image](https://user-images.githubusercontent.com/1998970/87878901-1bd42780-c9df-11ea-99b9-ca047db2d33b.png)

This allows for the check to be bypassed entirely in cases like #3578 
