### PR TITLE
Fix for gravity cronjob

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -12,19 +12,8 @@
 FTLUSER=pihole
 PIDFILE=/run/pihole-FTL.pid
 
-get_pid() {
-    # First, try to obtain PID from PIDFILE
-    if [ -s "${PIDFILE}" ]; then
-        cat "${PIDFILE}"
-        return
-    fi
-
-    # If the PIDFILE is empty or not available, obtain the PID using pidof
-    pidof "pihole-FTL" | awk '{print $(NF)}'
-}
-
 is_running() {
-    ps "$(get_pid)" > /dev/null 2>&1
+    pgrep -o "pihole-FTL" > /dev/null 2>&1
 }
 
 
@@ -63,7 +52,7 @@ start() {
 # Stop the service
 stop() {
   if is_running; then
-    kill "$(get_pid)"
+    pkill -o pihole-FTL
     for i in {1..5}; do
       if ! is_running; then
         break
@@ -76,7 +65,7 @@ stop() {
 
     if is_running; then
       echo "Not stopped; may still be shutting down or shutdown may have failed, killing now"
-      kill -9 "$(get_pid)"
+      pkill -o -9 pihole-FTL
       exit 1
     else
       echo "Stopped"

--- a/advanced/Templates/pihole.cron
+++ b/advanced/Templates/pihole.cron
@@ -18,19 +18,19 @@
 #          early morning. Download any updates from the adlists
 #          Squash output to log, then splat the log to stdout on error to allow for
 #          standard crontab job error handling.
-59 1    * * 7   root    PATH="$PATH:/usr/local/bin/" pihole updateGravity >/var/log/pihole_updateGravity.log || cat /var/log/pihole_updateGravity.log
+59 1    * * 7   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole_updateGravity.log || cat /var/log/pihole_updateGravity.log
 
 # Pi-hole: Flush the log daily at 00:00
 #          The flush script will use logrotate if available
 #          parameter "once": logrotate only once (default is twice)
 #          parameter "quiet": don't print messages
-00 00   * * *   root    PATH="$PATH:/usr/local/bin/" pihole flush once quiet
+00 00   * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole flush once quiet
 
 @reboot root /usr/sbin/logrotate /etc/pihole/logrotate
 
 # Pi-hole: Grab local version and branch every 10 minutes
-*/10 *  * * *   root    PATH="$PATH:/usr/local/bin/" pihole updatechecker local
+*/10 *  * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker local
 
 # Pi-hole: Grab remote version every 24 hours
-59 17  * * *   root    PATH="$PATH:/usr/local/bin/" pihole updatechecker remote
-@reboot root    PATH="$PATH:/usr/local/bin/" pihole updatechecker remote reboot
+59 17  * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker remote
+@reboot root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker remote reboot

--- a/gravity.sh
+++ b/gravity.sh
@@ -43,8 +43,6 @@ optimize_database=false
 
 domainsExtension="domains"
 
-resolver="pihole-FTL"
-
 # Source setupVars from install script
 setupVars="${piholeDir}/setupVars.conf"
 if [[ -f "${setupVars}" ]];then
@@ -284,7 +282,7 @@ gravity_CheckDNSResolutionAvailable() {
   fi
 
   # Determine error output message
-  if pidof ${resolver} &> /dev/null; then
+  if pgrep pihole-FTL &> /dev/null; then
     echo -e "  ${CROSS} DNS resolution is currently unavailable"
   else
     echo -e "  ${CROSS} DNS service is not running"
@@ -746,7 +744,7 @@ gravity_Cleanup() {
   fi
 
   # Only restart DNS service if offline
-  if ! pidof ${resolver} &> /dev/null; then
+  if ! pgrep pihole-FTL &> /dev/null; then
     "${PIHOLE_COMMAND}" restartdns
     dnsWasOffline=true
   fi

--- a/pihole
+++ b/pihole
@@ -20,8 +20,6 @@ PI_HOLE_BIN_DIR="/usr/local/bin"
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
 
-resolver="pihole-FTL"
-
 webpageFunc() {
   source "${PI_HOLE_SCRIPT_DIR}/webpage.sh"
   main "$@"
@@ -107,19 +105,19 @@ restartDNS() {
   # Determine if we should reload or restart
   if [[ "${svcOption}" =~ "reload-lists" ]]; then
     # Reloading of the lists has been requested
-    # Note: This will NOT re-read any *.conf files
+    # Note 1: This will NOT re-read any *.conf files
     # Note 2: We cannot use killall here as it does
     #         not know about real-time signals
-    svc="kill -SIGRTMIN $(pidof ${resolver})"
+    svc="pkill -RTMIN pihole-FTL"
     str="Reloading DNS lists"
   elif [[ "${svcOption}" =~ "reload" ]]; then
     # Reloading of the DNS cache has been requested
     # Note: This will NOT re-read any *.conf files
-    svc="killall -s SIGHUP ${resolver}"
+    svc="pkill -HUP pihole-FTL"
     str="Flushing DNS cache"
   else
     # A full restart has been requested
-    svc="service ${resolver} restart"
+    svc="service pihole-FTL restart"
     str="Restarting DNS server"
   fi
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

1. Fix gravity cronjob path
2. `pidof` does not always find `pihole-FTL` even when it is running

**How does this PR accomplish the above?:**

1. `/usr/sbin` is missing so `service` cannot be found, add `/usr/sbin` to `PATH`
2. Switch from `killall + pidof` to `pkill` and `pgrep`

**What documentation changes (if any) are needed to support this PR?:**

None