### PR TITLE
Create custom.list during install/update if it doesn't exist

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1484,7 +1484,7 @@ installConfigs() {
             return 1
         fi
     fi
-    
+
     # If the user chose to install the dashboard,
     if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
         # and if the Web server conf directory does not exist,
@@ -1818,7 +1818,6 @@ installPiholeWeb() {
     chmod 0440 /etc/sudoers.d/pihole
     printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
 }
-
 
 # Installs a cron file
 installCron() {

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -70,6 +70,7 @@ PI_HOLE_BLOCKPAGE_DIR="${webroot}/pihole"
 useUpdateVars=false
 
 adlistFile="/etc/pihole/adlists.list"
+="${PI_HOLE_CONFIG_DIR}/custom.list"
 # Pi-hole needs an IP address; to begin, these variables are empty since we don't know what the IP is until
 # this script can run
 IPV4_ADDRESS=${IPV4_ADDRESS}
@@ -1810,6 +1811,16 @@ installPiholeWeb() {
     printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
 }
 
+# Creates custom DNS file if it does not exist
+installCustomDNSfile() {
+
+    if [[ ! -e "${customDNSfile}" ]]; then
+        touch "${customDNSfile}"
+        chmod 644 "${customDNSfile}"
+    fi
+
+}
+
 # Installs a cron file
 installCron() {
     # Install the cron job
@@ -2036,6 +2047,9 @@ installPihole() {
 
     # install a man page entry for pihole
     install_manpage
+
+    # install custom DNS file if it does not exist
+    installCustomDNSfile
 
     # Update setupvars.conf with any variables that may or may not have been changed during the install
     finalExports

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1479,7 +1479,7 @@ installConfigs() {
 
     # Install empty custom.list file if it does not exist
     if [[ ! -r "${PI_HOLE_CONFIG_DIR}/custom.list" ]]; then
-        if ! install -o root -m 664 /dev/null "${PI_HOLE_CONFIG_DIR}/custom.list" &>/dev/null; then
+        if ! install -o root -m 644 /dev/null "${PI_HOLE_CONFIG_DIR}/custom.list" &>/dev/null; then
             printf "  %bError: Unable to initialize configuration file %s/custom.list\\n" "${COL_LIGHT_RED}" "${PI_HOLE_CONFIG_DIR}"
             return 1
         fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -70,7 +70,6 @@ PI_HOLE_BLOCKPAGE_DIR="${webroot}/pihole"
 useUpdateVars=false
 
 adlistFile="/etc/pihole/adlists.list"
-customDNSfile="${PI_HOLE_CONFIG_DIR}/custom.list"
 # Pi-hole needs an IP address; to begin, these variables are empty since we don't know what the IP is until
 # this script can run
 IPV4_ADDRESS=${IPV4_ADDRESS}
@@ -1477,6 +1476,15 @@ installConfigs() {
             return 1
         fi
     fi
+
+    # Install empty custom.list file if it does not exist
+    if [[ ! -r "${PI_HOLE_CONFIG_DIR}/custom.list" ]]; then
+        if ! install -o root -m 664 /dev/null "${PI_HOLE_CONFIG_DIR}/custom.list" &>/dev/null; then
+            printf "  %bError: Unable to initialize configuration file %s/custom.list\\n" "${COL_LIGHT_RED}" "${PI_HOLE_CONFIG_DIR}"
+            return 1
+        fi
+    fi
+    
     # If the user chose to install the dashboard,
     if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
         # and if the Web server conf directory does not exist,
@@ -1811,15 +1819,6 @@ installPiholeWeb() {
     printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
 }
 
-# Creates custom DNS file if it does not exist
-installCustomDNSfile() {
-
-    if [[ ! -e "${customDNSfile}" ]]; then
-        touch "${customDNSfile}"
-        chmod 644 "${customDNSfile}"
-    fi
-
-}
 
 # Installs a cron file
 installCron() {
@@ -2047,9 +2046,6 @@ installPihole() {
 
     # install a man page entry for pihole
     install_manpage
-
-    # install custom DNS file if it does not exist
-    installCustomDNSfile
 
     # Update setupvars.conf with any variables that may or may not have been changed during the install
     finalExports

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -70,7 +70,7 @@ PI_HOLE_BLOCKPAGE_DIR="${webroot}/pihole"
 useUpdateVars=false
 
 adlistFile="/etc/pihole/adlists.list"
-="${PI_HOLE_CONFIG_DIR}/custom.list"
+customDNSfile="${PI_HOLE_CONFIG_DIR}/custom.list"
 # Pi-hole needs an IP address; to begin, these variables are empty since we don't know what the IP is until
 # this script can run
 IPV4_ADDRESS=${IPV4_ADDRESS}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
`addn-hosts=/etc/pihole/custom.list` is part of `/etc/dnsmasq.d/01-pihole.conf` but the file does not exist until the first "Local DNS Record" is created by `webpage.sh`. Therefore pihole/dnsmasq warns about missing file in log during startup 
`dnsmasq[5249]: failed to load names from /etc/pihole/custom.list: No such file or directory`

This can be prevented by creating the file.

**How does this PR accomplish the above?:**
Creates `custom.list` during installation/update if it does not exist. 


**What documentation changes (if any) are needed to support this PR?:**
No.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.

