### PR TITLE
Report and exit if dig supportedOS returns nothing

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -190,7 +190,7 @@ os_check() {
 
         IFS=" " read -r -a supportedOS < <(dig +short -t txt ${remote_os_domain} @ns1.pi-hole.net | tr -d '"')
 
-        if [ -z "$supportedOS" ]; then
+        if [ ${#supportedOS[@]} -eq 0 ]; then
             printf "  %b %bRetrieval of supported OS failed. Please contact support. %b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${COL_NC}"
             exit 1
         else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -190,24 +190,29 @@ os_check() {
 
         IFS=" " read -r -a supportedOS < <(dig +short -t txt ${remote_os_domain} @ns1.pi-hole.net | tr -d '"')
 
-        for i in "${supportedOS[@]}"
-        do
-            os_part=$(echo "$i" | cut -d '=' -f1)
-            versions_part=$(echo "$i" | cut -d '=' -f2-)
+        if [ -z "$supportedOS" ]; then
+            printf "  %b %bRetrieval of supported OS failed. Please contact support. %b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${COL_NC}"
+            exit 1
+        else
+          for i in "${supportedOS[@]}"
+          do
+              os_part=$(echo "$i" | cut -d '=' -f1)
+              versions_part=$(echo "$i" | cut -d '=' -f2-)
 
-            if [[ "${detected_os}" =~ ${os_part} ]]; then
-            valid_os=true
-            IFS="," read -r -a supportedVer <<<"${versions_part}"
-            for x in "${supportedVer[@]}"
-            do
-                if [[ "${detected_version}" =~ $x ]];then
-                valid_version=true
+              if [[ "${detected_os}" =~ ${os_part} ]]; then
+                valid_os=true
+                IFS="," read -r -a supportedVer <<<"${versions_part}"
+                for x in "${supportedVer[@]}"
+                do
+                  if [[ "${detected_version}" =~ $x ]];then
+                    valid_version=true
+                    break
+                  fi
+                done
                 break
-                fi
+              fi
             done
-            break
-            fi
-        done
+          fi
 
         if [ "$valid_os" = true ] && [ "$valid_version" = true ]; then
             display_warning=false


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))


---
**What does this PR aim to accomplish?:**
If `dig` for supportedOS does not return any value (e.g. due to misconfigured upstream DNS servers) it should report an appropriate error and exit the script


**How does this PR accomplish the above?:**
Check if `supportedOS` is an empty array.


**What documentation changes (if any) are needed to support this PR?:**
No changes required

