### PR TITLE
Update "About Pi-hole" link on "Website Blocked" page

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -305,7 +305,7 @@ setHeader();
       </p>
     </div>
     <div class="aboutLink">
-      <a class="linkPH" href="https://github.com/pi-hole/pi-hole/wiki/What-is-Pi-hole%3F-A-simple-explanation"><?php //About PH ?></a>
+      <a class="linkPH" href="https://docs.pi-hole.net/"><?php //About PH ?></a>
       <?php if (!empty($svEmail)) echo '<a class="linkEmail" href="mailto:'.$svEmail.'"></a>'; ?>
     </div>
   </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**

Updates the **About Pi-hole** link found on the **Website Blocked** page:

<img width="1309" alt="Screen Shot 2020-08-01 at 7 55 35 PM" src="https://user-images.githubusercontent.com/1638631/89113090-dd545900-d431-11ea-8774-509f7193e9a8.png">

Currently, this link points to https://github.com/pi-hole/pi-hole/wiki/What-is-Pi-hole%3F-A-simple-explanation, which redirects to https://github.com/pi-hole/pi-hole/wiki, which instructs the user to instead visit https://docs.pi-hole.net/.

This PR updates the link to point directly to https://docs.pi-hole.net/.

**How does this PR accomplish the above?:**

Updates the hard-coded **About Pi-hole** link in `advanced/index.php`.

**What documentation changes (if any) are needed to support this PR?:**

None.
