### PR TITLE
Revert "Ensure that adlistFile is created before chmodding"

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1299,7 +1299,6 @@ chooseBlocklists() {
     do
         appendToListsFile "${choice}"
     done
-    touch "${adlistFile}"
     chmod 644 "${adlistFile}"
 }
 


### PR DESCRIPTION
This reverts commit 7934a9bcb4936aaa5218dbe967ad57b70b19f5bc.

With v5.1 https://github.com/pi-hole/pi-hole/pull/3463 and https://github.com/pi-hole/pi-hole/pull/3388 fixed the same issue in slightly different ways. Both have been merged and v5.1 contains two ways to create an empty adlist file if users don't select any adlist on install.

This PR reverts the **newer** of the two PRs mentioned above (https://github.com/pi-hole/pi-hole/pull/3463)

Fixes https://github.com/pi-hole/pi-hole/issues/3551