### PR TITLE
Revert "fix #3336 by creating adlist file even if no list was selecte…

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1292,9 +1292,7 @@ chooseBlocklists() {
 
     # In a variable, show the choices available; exit if Cancel is selected
     choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty) || { printf "  %bCancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"; rm "${adlistFile}" ;exit 1; }
-    # create empty adlist file if no list was selected
-    : > "${adlistFile}"
-    # For each choice available
+    # For each choice available,
     for choice in ${choices}
     do
         appendToListsFile "${choice}"


### PR DESCRIPTION
This reverts commit 3c6ea26

With v5.1 https://github.com/pi-hole/pi-hole/pull/3463 and https://github.com/pi-hole/pi-hole/pull/3388 fixed the same issue in slightly different ways. Both have been merged and v5.1 contains two ways to create an empty adlist file if users don't select any adlist on install.

This PR reverts  https://github.com/pi-hole/pi-hole/pull/3388 
Fixes https://github.com/pi-hole/pi-hole/issues/3551