### PR TITLE
Removes broken youtube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 The Pi-hole® is a [DNS sinkhole](https://en.wikipedia.org/wiki/DNS_Sinkhole) that protects your devices from unwanted content, without installing any client-side software.
 
-- **Easy-to-install**: our versatile installer walks you through the process, and [takes less than ten minutes](https://www.youtube.com/watch?v=vKWjx1AQYgs)
+- **Easy-to-install**: our versatile installer walks you through the process, and takes less than ten minutes
 - **Resolute**: content is blocked in _non-browser locations_, such as ad-laden mobile apps and smart TVs
 - **Responsive**: seamlessly speeds up the feel of everyday browsing by caching DNS queries
 - **Lightweight**: runs smoothly with [minimal hardware and software requirements](https://docs.pi-hole.net/main/prerequisites/)


### PR DESCRIPTION
Fixes https://github.com/pi-hole/docs/issues/357 by deleting the broken link to youtube.

Should go together with https://github.com/pi-hole/docs/pull/358