### PR TITLE
Tweaks to os-check

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -179,6 +179,7 @@ is_command() {
 }
 
 os_check() {
+<<<<<<< HEAD
     if [ "$PIHOLE_SKIP_OS_CHECK" != true ]; then
         # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
         # and determines whether or not the script is running on one of those systems
@@ -220,6 +221,34 @@ os_check() {
 
         if [ "$valid_os" = true ] && [ "$valid_version" = true ]; then
             display_warning=false
+=======
+    # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
+    # and determines whether or not the script is running on one of those systems
+    local remote_os_domain valid_os valid_version detected_os_pretty detected_os detected_version display_warning
+    remote_os_domain="versions.pi-hole.net"
+
+    detected_os=$(grep "\bID\b" /etc/os-release | cut -d '=' -f2 | tr -d '"')
+    detected_version=$(grep VERSION_ID /etc/os-release | cut -d '=' -f2 | tr -d '"')
+
+    IFS=" " read -r -a supportedOS < <(dig +short -t txt ${remote_os_domain} | tr -d '"')
+
+    for distro_and_versions in "${supportedOS[@]}"
+    do
+        distro_part="${distro_and_versions%%=*}"
+        versions_part="${distro_and_versions##*=}"
+
+        if [[ "${detected_os^^}" =~ ${distro_part^^} ]]; then
+          valid_os=true
+          IFS="," read -r -a supportedVer <<<"${versions_part}"
+          for version in "${supportedVer[@]}"
+          do
+            if [[ "${detected_version}" =~ $version ]];then
+              valid_version=true
+              break
+            fi
+          done
+          break
+>>>>>>> be977287... Reduce subshells, descriptive variable names.
         fi
 
         if [ "$display_warning" = true ]; then
@@ -237,9 +266,24 @@ os_check() {
             printf "      https://discourse.pi-hole.net/c/bugs-problems-issues/community-help/\\n"
             exit 1
 
+<<<<<<< HEAD
         else
             printf "  %b %bSupported OS detected%b\\n" "${TICK}" "${COL_LIGHT_GREEN}" "${COL_NC}"
         fi
+=======
+    if [ "$display_warning" != false ] && [ "$PIHOLE_SKIP_OS_CHECK" != true ]; then
+        printf "  %b %bUnsupported OS detected%b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${COL_NC}"
+        printf "      https://docs.pi-hole.net/main/prerequesites/#supported-operating-systems\\n"
+        printf "\\n"
+        printf "      This check can be skipped by setting the environment variable %bPIHOLE_SKIP_OS_CHECK%b to %btrue%b\\n" "${COL_LIGHT_RED}" "${COL_NC}" "${COL_LIGHT_RED}" "${COL_NC}"
+        printf "      e.g: export PIHOLE_SKIP_OS_CHECK=true\\n"
+        printf "      By setting this variable to true you acknowledge there may be issues with Pi-hole during or after the install\\n"
+        printf "      If that is the case, you can feel free to ask the community on Discourse with the %bCommunity Help%b category:\\n" "${COL_LIGHT_RED}" "${COL_NC}"
+        printf "      https://discourse.pi-hole.net/c/bugs-problems-issues/community-help/\\n"
+        exit 1
+    elif [ "$display_warning" != false ] && [ "$PIHOLE_SKIP_OS_CHECK" = true ]; then
+        printf "  %b %bUnsupported OS detected%b. PIHOLE_SKIP_OS_CHECK env variable set to true - installer will continue\\n" "${INFO}" "${COL_LIGHT_RED}" "${COL_NC}"
+>>>>>>> be977287... Reduce subshells, descriptive variable names.
     else
         printf "  %b %bPIHOLE_SKIP_OS_CHECK env variable set to true - installer will continue%b\\n" "${INFO}" "${COL_LIGHT_GREEN}" "${COL_NC}"
     fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -179,49 +179,6 @@ is_command() {
 }
 
 os_check() {
-<<<<<<< HEAD
-    if [ "$PIHOLE_SKIP_OS_CHECK" != true ]; then
-        # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
-        # and determines whether or not the script is running on one of those systems
-        local remote_os_domain valid_os valid_version detected_os_pretty detected_os detected_version display_warning
-        remote_os_domain="versions.pi-hole.net"
-        valid_os=false
-        valid_version=false
-        display_warning=true
-
-        detected_os_pretty=$(cat /etc/*release | grep PRETTY_NAME | cut -d '=' -f2- | tr -d '"')
-        detected_os="${detected_os_pretty%% *}"
-        detected_version=$(cat /etc/*release | grep VERSION_ID | cut -d '=' -f2- | tr -d '"')
-
-        IFS=" " read -r -a supportedOS < <(dig +short -t txt ${remote_os_domain} @ns1.pi-hole.net | tr -d '"')
-
-        if [ ${#supportedOS[@]} -eq 0 ]; then
-            printf "  %b %bRetrieval of supported OS failed. Please contact support. %b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${COL_NC}"
-            exit 1
-        else
-          for i in "${supportedOS[@]}"
-          do
-              os_part=$(echo "$i" | cut -d '=' -f1)
-              versions_part=$(echo "$i" | cut -d '=' -f2-)
-
-              if [[ "${detected_os}" =~ ${os_part} ]]; then
-                valid_os=true
-                IFS="," read -r -a supportedVer <<<"${versions_part}"
-                for x in "${supportedVer[@]}"
-                do
-                  if [[ "${detected_version}" =~ $x ]];then
-                    valid_version=true
-                    break
-                  fi
-                done
-                break
-              fi
-            done
-          fi
-
-        if [ "$valid_os" = true ] && [ "$valid_version" = true ]; then
-            display_warning=false
-=======
     # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
     # and determines whether or not the script is running on one of those systems
     local remote_os_domain valid_os valid_version detected_os_pretty detected_os detected_version display_warning
@@ -248,29 +205,8 @@ os_check() {
             fi
           done
           break
->>>>>>> be977287... Reduce subshells, descriptive variable names.
         fi
 
-        if [ "$display_warning" = true ]; then
-            printf "  %b %bUnsupported OS detected: %s%b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${detected_os_pretty}" "${COL_NC}"
-            printf "      https://docs.pi-hole.net/main/prerequesites/#supported-operating-systems\\n"
-            printf "\\n"
-            printf "      e.g: If you are seeing this message on a fresh install, you can run:\\n"
-            printf "             'curl -sSL https://install.pi-hole.net | PIHOLE_SKIP_OS_CHECK=true sudo -E bash'\\n"
-            printf "\\n"
-            printf "           If you are seeing this message after having run pihole -up:\\n"
-            printf "             'PIHOLE_SKIP_OS_CHECK=true sudo -E pihole -r'\\n"
-            printf "           (In this case, your previous run of pihole -up will have already updated the local repository)\\n"
-            printf "\\n"
-            printf "      If that is the case, you can feel free to ask the community on Discourse with the %bCommunity Help%b category:\\n" "${COL_LIGHT_RED}" "${COL_NC}"
-            printf "      https://discourse.pi-hole.net/c/bugs-problems-issues/community-help/\\n"
-            exit 1
-
-<<<<<<< HEAD
-        else
-            printf "  %b %bSupported OS detected%b\\n" "${TICK}" "${COL_LIGHT_GREEN}" "${COL_NC}"
-        fi
-=======
     if [ "$display_warning" != false ] && [ "$PIHOLE_SKIP_OS_CHECK" != true ]; then
         printf "  %b %bUnsupported OS detected%b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${COL_NC}"
         printf "      https://docs.pi-hole.net/main/prerequesites/#supported-operating-systems\\n"
@@ -283,7 +219,6 @@ os_check() {
         exit 1
     elif [ "$display_warning" != false ] && [ "$PIHOLE_SKIP_OS_CHECK" = true ]; then
         printf "  %b %bUnsupported OS detected%b. PIHOLE_SKIP_OS_CHECK env variable set to true - installer will continue\\n" "${INFO}" "${COL_LIGHT_RED}" "${COL_NC}"
->>>>>>> be977287... Reduce subshells, descriptive variable names.
     else
         printf "  %b %bPIHOLE_SKIP_OS_CHECK env variable set to true - installer will continue%b\\n" "${INFO}" "${COL_LIGHT_GREEN}" "${COL_NC}"
     fi


### PR DESCRIPTION
A few tweaks to the os-check function.

1. Reduce subshell use where possible.
2. Use descriptive variable names.
3. Remove boolean variables. Bash doesn't have booleans, they are just strings.
4. Check using `/etc/os-release` since all supported distro's use that file.

