### PR TITLE
Remove creation of unused dir /var/log/pihole

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -27,8 +27,7 @@ start() {
     touch /run/pihole-FTL.pid /run/pihole-FTL.port
     touch /etc/pihole/dhcp.leases
     mkdir -p /run/pihole
-    mkdir -p /var/log/pihole
-    chown pihole:pihole /run/pihole /var/log/pihole
+    chown pihole:pihole /run/pihole
     # Remove possible leftovers from previous pihole-FTL processes
     rm -f /dev/shm/FTL-* 2> /dev/null
     rm /run/pihole/FTL.sock 2> /dev/null


### PR DESCRIPTION
Don't create directory `/var/log/pihole` on start of `pihole-FTL.service` as it is never used for logging (all happens on `/var/log`).

Fixes https://github.com/pi-hole/pi-hole/issues/3728 and https://github.com/pi-hole/pi-hole/issues/3629