### PR TITLE
Fix gravity optimization order

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -714,6 +714,21 @@ gravity_Trap() {
   trap '{ echo -e "\\n\\n  ${INFO} ${COL_LIGHT_RED}User-abort detected${COL_NC}"; gravity_Cleanup "error"; }' INT
 }
 
+gravity_Optimize() {
+  str="Optimizing domains database"
+  echo -ne "  ${INFO} ${str}..."
+  # Run VACUUM command on database to optimize it
+  output=$( { sqlite3 "${gravityDBfile}" "VACUUM;"; } 2>&1 )
+  status="$?"
+
+  if [[ "${status}" -ne 0 ]]; then
+    echo -e "\\n  ${CROSS} Unable to optimize gravity database ${gravityDBfile}\\n  ${output}"
+    error="error"
+  else
+    echo -e "${OVER}  ${TICK} ${str}"
+  fi
+}
+
 # Clean up after Gravity upon exit or cancellation
 gravity_Cleanup() {
   local error="${1:-}"
@@ -739,21 +754,6 @@ gravity_Cleanup() {
   fi
 
   echo -e "${OVER}  ${TICK} ${str}"
-
-  if ${optimize_database} ; then
-    str="Optimizing domains database"
-    echo -ne "  ${INFO} ${str}..."
-    # Run VACUUM command on database to optimize it
-    output=$( { sqlite3 "${gravityDBfile}" "VACUUM;"; } 2>&1 )
-    status="$?"
-
-    if [[ "${status}" -ne 0 ]]; then
-      echo -e "\\n  ${CROSS} Unable to optimize gravity database ${gravityDBfile}\\n  ${output}"
-      error="error"
-    else
-      echo -e "${OVER}  ${TICK} ${str}"
-    fi
-  fi
 
   # Only restart DNS service if offline
   if ! pgrep pihole-FTL &> /dev/null; then
@@ -830,6 +830,11 @@ chmod g+w "${piholeDir}" "${gravityDBfile}"
 
 # Compute numbers to be displayed
 gravity_ShowCount
+
+# Optimize gravity database if requested
+if ${optimize_database} ; then
+  gravity_Optimize
+fi
 
 # Determine if DNS has been restarted by this instance of gravity
 if [[ -z "${dnsWasOffline:-}" ]]; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix a bug reported on Discourse (see below) where the database got locked by the `pihole -g -o` optimization.

**How does this PR accomplish the above?:**

Optimize gravity database **before** asking FTL to reload to avoid race-collisions on slow(er) devices.

**What documentation changes (if any) are needed to support this PR?:**

None