### PR TITLE
Update basic-install.sh check existing /etc/dnsmasq.d/01-pihole.conf

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1382,26 +1382,27 @@ version_check_dnsmasq() {
         install -d -m 755 "/etc/dnsmasq.d"
     fi
     # Copy the new Pi-hole DNS config file into the dnsmasq.d directory
-    install -D -m 644 -T "${dnsmasq_pihole_01_snippet}" "${dnsmasq_pihole_01_location}"
-    printf "%b  %b Copying 01-pihole.conf to /etc/dnsmasq.d/01-pihole.conf\\n" "${OVER}"  "${TICK}"
-    # Replace our placeholder values with the GLOBAL DNS variables that we populated earlier
-    # First, swap in the interface to listen on
-    sed -i "s/@INT@/$PIHOLE_INTERFACE/" "${dnsmasq_pihole_01_location}"
-    if [[ "${PIHOLE_DNS_1}" != "" ]]; then
-        # Then swap in the primary DNS server
-        sed -i "s/@DNS1@/$PIHOLE_DNS_1/" "${dnsmasq_pihole_01_location}"
-    else
-        #
-        sed -i '/^server=@DNS1@/d' "${dnsmasq_pihole_01_location}"
+    if [[ ! -f "${dnsmasq_pihole_01_location} ]]; then
+        install -D -m 644 -T "${dnsmasq_pihole_01_snippet}" "${dnsmasq_pihole_01_location}"
+        printf "%b  %b Copying 01-pihole.conf to /etc/dnsmasq.d/01-pihole.conf\\n" "${OVER}"  "${TICK}"
+        # Replace our placeholder values with the GLOBAL DNS variables that we populated earlier
+        # First, swap in the interface to listen on
+        sed -i "s/@INT@/$PIHOLE_INTERFACE/" "${dnsmasq_pihole_01_location}"
+        if [[ "${PIHOLE_DNS_1}" != "" ]]; then
+            # Then swap in the primary DNS server
+            sed -i "s/@DNS1@/$PIHOLE_DNS_1/" "${dnsmasq_pihole_01_location}"
+        else
+            #
+            sed -i '/^server=@DNS1@/d' "${dnsmasq_pihole_01_location}"
+        fi
+        if [[ "${PIHOLE_DNS_2}" != "" ]]; then
+            # Then swap in the primary DNS server
+            sed -i "s/@DNS2@/$PIHOLE_DNS_2/" "${dnsmasq_pihole_01_location}"
+        else
+            #
+            sed -i '/^server=@DNS2@/d' "${dnsmasq_pihole_01_location}"
+        fi
     fi
-    if [[ "${PIHOLE_DNS_2}" != "" ]]; then
-        # Then swap in the primary DNS server
-        sed -i "s/@DNS2@/$PIHOLE_DNS_2/" "${dnsmasq_pihole_01_location}"
-    else
-        #
-        sed -i '/^server=@DNS2@/d' "${dnsmasq_pihole_01_location}"
-    fi
-
     #
     sed -i 's/^#conf-dir=\/etc\/dnsmasq.d$/conf-dir=\/etc\/dnsmasq.d/' "${dnsmasq_conf}"
 


### PR DESCRIPTION
Update script to check if /etc/dnsmasq.d/01-pihole.conf already exists.  If it doesn't exist then create from local repo.  

This change allows for configuration managed outside of pihole container to "pre-populate" the config on startup of a new container.  Examples would be a mounted Docker volume or Kubernetes ConfigMap.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Allow for the pre-population of config file for containers with ephemeral storage.  In may case I use Kubernetes ConfigMaps to generate config files for my PiHole container so that I don't require persistent storage.

**How does this PR accomplish the above?:**
Check for existence of /etc/dnsmasq.d/01-pihole.conf.  Create if it doesn't exist. 

**What documentation changes (if any) are needed to support this PR?:**
None


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
