### PR TITLE
Allow configuration of dnsmasq log path.

### DIFF
--- a/pihole
+++ b/pihole
@@ -20,6 +20,12 @@ PI_HOLE_BIN_DIR="/usr/local/bin"
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
 
+dnsmasq_log=$(awk 'match($0, /log-facility=(.*)/, a) {print a[1]}' /etc/dnsmasq.d/01-pihole.conf)
+if [ -z "$dnsmasq_log" ]; then
+  # If no config set, use default log location.
+  dnsmasq_log=/var/log/pihole.log
+fi
+
 webpageFunc() {
   source "${PI_HOLE_SCRIPT_DIR}/webpage.sh"
   main "$@"
@@ -220,9 +226,9 @@ Example: 'pihole logging on'
 Specify whether the Pi-hole log should be used
 
 Options:
-  on                  Enable the Pi-hole log at /var/log/pihole.log
-  off                 Disable and flush the Pi-hole log at /var/log/pihole.log
-  off noflush         Disable the Pi-hole log at /var/log/pihole.log"
+  on                  Enable the Pi-hole log at ${dnsmasq_log}
+  off                 Disable and flush the Pi-hole log at ${dnsmasq_log}
+  off noflush         Disable the Pi-hole log at ${dnsmasq_log}"
     exit 0
   elif [[ "${1}" == "off" ]]; then
     # Disable logging
@@ -335,7 +341,7 @@ tailFunc() {
   # Color blocklist/blacklist/wildcard entries as red
   # Color A/AAAA/DHCP strings as white
   # Color everything else as gray
-  tail -f /var/log/pihole.log | sed -E \
+  tail -f ${dnsmasq_log} | sed -E \
     -e "s,($(date +'%b %d ')| dnsmasq\[[0-9]*\]),,g" \
     -e "s,(.*(blacklisted |gravity blocked ).* is (0.0.0.0|::|NXDOMAIN|${IPV4_ADDRESS%/*}|${IPV6_ADDRESS:-NULL}).*),${COL_RED}&${COL_NC}," \
     -e "s,.*(query\\[A|DHCP).*,${COL_NC}&${COL_NC}," \


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
In some setups, dnsmasq may be needed to log out somewhere else than hardcoded /var/log/pihole.log. 


**How does this PR accomplish the above?:**
This commit parses the path from dnsmasq’s configuration file, or defaults to /var/log/pihole.log if no path has been set.


**What documentation changes (if any) are needed to support this PR?:**
- None.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
