### PR TITLE
read REV_SERVER_CIDR from environment

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -224,17 +224,20 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
         REV_SERVER_TARGET="${CONDITIONAL_FORWARDING_IP}"
         add_setting "REV_SERVER_TARGET" "${REV_SERVER_TARGET}"
 
+        REV_SERVER_CIDR="${CONDITIONAL_FORWARDING_REVERSE}"
+        if [ -z "${REV_SERVER_CIDR}" ]; then
+            # Convert existing input to /24 subnet (preserves legacy behavior)
+            # This sed converts "192.168.1.2" to "192.168.1.0/24"
+            # shellcheck disable=2001
+            REV_SERVER_CIDR="$(sed "s+\\.[0-9]*$+\\.0/24+" <<< "${REV_SERVER_TARGET}")"
+        fi
+        add_setting "REV_SERVER_CIDR" "${REV_SERVER_CIDR}"
+
         # Remove obsolete settings from setupVars.conf
         delete_setting "CONDITIONAL_FORWARDING"
         delete_setting "CONDITIONAL_FORWARDING_REVERSE"
         delete_setting "CONDITIONAL_FORWARDING_DOMAIN"
         delete_setting "CONDITIONAL_FORWARDING_IP"
-
-        # Convert existing input to /24 subnet (preserves legacy behavior)
-        # This sed converts "192.168.1.2" to "192.168.1.0/24"
-        # shellcheck disable=2001
-        REV_SERVER_CIDR="$(sed "s+\\.[0-9]*$+\\.0/24+" <<< "${REV_SERVER_TARGET}")"
-        add_setting "REV_SERVER_CIDR" "${REV_SERVER_CIDR}"
     fi
 
     if [[ "${REV_SERVER}" == true ]]; then


### PR DESCRIPTION
Signed-off-by: Sebastian Gmeiner <sebastian@gmeiners.net>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*
Setting ```REV_SERVER_CIDR``` cannot be persisted as long as the environment variable ```CONDITIONAL_FORWARING=true``` exists (probably most common in Docker compose setups). This PR reactivates the existing (but unused) ```CONDITIONAL_FORWARDING_REVERSE``` variable to set the value of ```REV_SERVER_CIDR```. In the absence of ```CONDITIONAL_FORWARDING_REVERSE``` the original behaviour is kept as fallback.

This fixes issue https://github.com/pi-hole/docker-pi-hole/issues/680 which cannot be addressed in the downstream project.


**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*
Adding the code to populate the setting from the environment variable in file advanced/Scripts/webpage.sh plus a simple check (empty string) to activate the fallback.


**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*
```CONDITIONAL_FORWARDING_REVERSE``` originally contained the name of the reverse DNS zone. With this PR the documentation (over at https://github.com/pi-hole/docker-pi-hole, particularly https://github.com/pi-hole/docker-pi-hole/blob/master/README.md#environment-variables) should be updated to show an example value of ```192.168.0.0/24``` (or any other network address in CIDR notation) instead of ```0.168.192.in-addr.arpa```.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
