### PR TITLE
Security enhancement for the "never forward non-FQDNs" feature

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -167,9 +167,11 @@ ProcessDNSSettings() {
     fi
 
     delete_dnsmasq_setting "domain-needed"
+    delete_dnsmasq_setting "expand-hosts"
 
     if [[ "${DNS_FQDN_REQUIRED}" == true ]]; then
         add_dnsmasq_setting "domain-needed"
+        add_dnsmasq_setting "expand-hosts"
     fi
 
     delete_dnsmasq_setting "bogus-priv"
@@ -370,6 +372,7 @@ dhcp-leasefile=/etc/pihole/dhcp.leases
 
     if [[ "${PIHOLE_DOMAIN}" != "none" ]]; then
         echo "domain=${PIHOLE_DOMAIN}" >> "${dhcpconfig}"
+        echo "local=/${PIHOLE_DOMAIN}/" >> "${dhcpconfig}"
     fi
 
     # Sourced from setupVars

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -372,7 +372,9 @@ dhcp-leasefile=/etc/pihole/dhcp.leases
 
     if [[ "${PIHOLE_DOMAIN}" != "none" ]]; then
         echo "domain=${PIHOLE_DOMAIN}" >> "${dhcpconfig}"
-        echo "local=/${PIHOLE_DOMAIN}/" >> "${dhcpconfig}"
+        if  [[ "${DNS_FQDN_REQUIRED}" == true ]]; then
+          echo "local=/${PIHOLE_DOMAIN}/" >> "${dhcpconfig}"
+        fi
     fi
 
     # Sourced from setupVars


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Security enhancement for the "never forward non-FQDNs" feature

**How does this PR accomplish the above?:**

This should prevent all local queries from being forwarded (will show up as blocked by regex) as well as any hostname without a domain (for example one word searches from the address bar in browsers). This fixes issue #3303 where this improvement was suggested by @jacklul.

### Tests
(:green_circle: = not forwarded, :red_circle: = forwarded, domain = `lan`)

#### Before this PR:

- `localhost` :green_circle: (IP)
- `localhost.lan` :red_circle: (forwarded, came back as NXDOMAIN)
- `dhcphost` :green_circle: (IP)
- `dhcphost.lan` :green_circle: (IP)
- `nonexistinghost` :green_circle: (NODATA)
- `nonexistinghost.lan` :red_circle: (forwarded, came back as NXDOMAIN)

#### After this PR:

- `localhost` :green_circle: (IP)
- `localhost.lan` :green_circle: (IP)
- `dhcphost` :green_circle: (IP)
- `dhcphost.lan` :green_circle: (IP)
- `nonexistinghost` :green_circle: (NODATA)
- `nonexistinghost.lan` :green_circle: (NXDOMAIN)

**What documentation changes (if any) are needed to support this PR?:**

None