### PR TITLE
Add native ARMv4T, ARMv5TE and ARMv8-A support

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2395,7 +2395,7 @@ get_binary_name() {
 
     local l_binary
 
-    local str="Detecting architecture"
+    local str="Detecting processor"
     printf "  %b %s..." "${INFO}" "${str}"
     # If the machine is arm or aarch
     if [[ "${machine}" == "arm"* || "${machine}" == *"aarch"* ]]; then
@@ -2408,48 +2408,58 @@ get_binary_name() {
         lib=$(ldd /bin/ls | grep -E '^\s*/lib' | awk '{ print $1 }')
         #
         if [[ "${lib}" == "/lib/ld-linux-aarch64.so.1" ]]; then
-            printf "%b  %b Detected ARM-aarch64 architecture\\n" "${OVER}" "${TICK}"
+            printf "%b  %b Detected AArch64 (64 Bit ARM) processor\\n" "${OVER}" "${TICK}"
             # set the binary to be used
             l_binary="pihole-FTL-aarch64-linux-gnu"
         #
         elif [[ "${lib}" == "/lib/ld-linux-armhf.so.3" ]]; then
-            #
-            if [[ "${rev}" -gt 6 ]]; then
-                printf "%b  %b Detected ARM-hf architecture (armv7+)\\n" "${OVER}" "${TICK}"
+            # Hard-float available: Use gnueabihf binaries
+            # If ARMv8 or higher is found (e.g., BCM2837 as found in Raspberry Pi Model 3B)
+            if [[ "${rev}" -gt 7 ]]; then
+                printf "%b  %b Detected ARMv8 (or newer) processor\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                l_binary="pihole-FTL-arm-linux-gnueabihf"
-            # Otherwise,
+                l_binary="pihole-FTL-armv8-linux-gnueabihf"
+            # Otherwise, if ARMv7 is found (e.g., BCM2836 as found in Raspberry Pi Model 2)
+            elif [[ "${rev}" -eq 7 ]]; then
+                printf "%b  %b Detected ARMv7 processor (with hard-float support)\\n" "${OVER}" "${TICK}"
+                # set the binary to be used
+                l_binary="pihole-FTL-armv7-linux-gnueabihf"
+            # Otherwise, use the ARMv6 binary (e.g., BCM2835 as found in Raspberry Pi Zero and Model 1)
             else
-                printf "%b  %b Detected ARM-hf architecture (armv6 or lower) Using ARM binary\\n" "${OVER}" "${TICK}"
+                printf "%b  %b Detected ARMv6 processor (with hard-float support)\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                l_binary="pihole-FTL-arm-linux-gnueabi"
+                l_binary="pihole-FTL-armv6-linux-gnueabihf"
             fi
         else
-            if [[ -f "/.dockerenv" ]]; then
-                printf "%b  %b Detected ARM architecture in docker\\n" "${OVER}" "${TICK}"
+            # No hard-float support found: Use gnueabi binaries
+            # Use the ARMv4-compliant binary only if we detected an ARMv4T core
+            if [[ "${rev}" -eq 4 ]]; then
+                printf "%b  %b Detected ARMv4 processor\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                l_binary="pihole-FTL-armel-native"
+                l_binary="pihole-FTL-armv4-linux-gnueabi"
+            # Otherwise, use the ARMv5 binary. To date (end of 2020), all modern ARM processors
+            # are backwards-compatible to the ARMv5
             else
-                printf "%b  %b Detected ARM architecture\\n" "${OVER}" "${TICK}"
+                printf "%b  %b Detected ARMv5 (or newer) processor\\n" "${OVER}" "${TICK}"
                 # set the binary to be used
-                l_binary="pihole-FTL-arm-linux-gnueabi"
+                l_binary="pihole-FTL-armv5-linux-gnueabi"
             fi
         fi
     elif [[ "${machine}" == "x86_64" ]]; then
-        # This gives the architecture of packages dpkg installs (for example, "i386")
+        # This gives the processor of packages dpkg installs (for example, "i386")
         local dpkgarch
-        dpkgarch=$(dpkg --print-architecture 2> /dev/null || true)
+        dpkgarch=$(dpkg --print-processor 2> /dev/null || true)
 
         # Special case: This is a 32 bit OS, installed on a 64 bit machine
-        # -> change machine architecture to download the 32 bit executable
+        # -> change machine processor to download the 32 bit executable
         # We only check this for Debian-based systems as this has been an issue
         # in the past (see https://github.com/pi-hole/pi-hole/pull/2004)
         if [[ "${dpkgarch}" == "i386" ]]; then
-            printf "%b  %b Detected 32bit (i686) architecture\\n" "${OVER}" "${TICK}"
+            printf "%b  %b Detected 32bit (i686) processor\\n" "${OVER}" "${TICK}"
             l_binary="pihole-FTL-linux-x86_32"
         else
             # 64bit
-            printf "%b  %b Detected x86_64 architecture\\n" "${OVER}" "${TICK}"
+            printf "%b  %b Detected x86_64 processor\\n" "${OVER}" "${TICK}"
             # set the binary to be used
             l_binary="pihole-FTL-linux-x86_64"
         fi
@@ -2457,10 +2467,10 @@ get_binary_name() {
         # Something else - we try to use 32bit executable and warn the user
         if [[ ! "${machine}" == "i686" ]]; then
             printf "%b  %b %s...\\n" "${OVER}" "${CROSS}" "${str}"
-            printf "  %b %bNot able to detect architecture (unknown: %s), trying 32bit executable%b\\n" "${INFO}" "${COL_LIGHT_RED}" "${machine}" "${COL_NC}"
+            printf "  %b %bNot able to detect processor (unknown: %s), trying x86 (32bit) executable%b\\n" "${INFO}" "${COL_LIGHT_RED}" "${machine}" "${COL_NC}"
             printf "  %b Contact Pi-hole Support if you experience issues (e.g: FTL not running)\\n" "${INFO}"
         else
-            printf "%b  %b Detected 32bit (i686) architecture\\n" "${OVER}" "${TICK}"
+            printf "%b  %b Detected 32bit (i686) processor\\n" "${OVER}" "${TICK}"
         fi
         l_binary="pihole-FTL-linux-x86_32"
     fi

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -187,7 +187,55 @@ def test_FTL_detect_aarch64_no_errors(Pihole):
     ''')
     expected_stdout = info_box + ' FTL Checks...'
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + ' Detected ARM-aarch64 architecture'
+    expected_stdout = tick_box + ' Detected AArch64 (64 Bit ARM) processor'
+    assert expected_stdout in detectPlatform.stdout
+    expected_stdout = tick_box + ' Downloading and Installing FTL'
+    assert expected_stdout in detectPlatform.stdout
+
+
+def test_FTL_detect_armv4t_no_errors(Pihole):
+    '''
+    confirms only armv4t package is downloaded for FTL engine
+    '''
+    # mock uname to return armv4t platform
+    mock_command('uname', {'-m': ('armv4t', '0')}, Pihole)
+    # mock ldd to respond with ld-linux shared library
+    mock_command('ldd', {'/bin/ls': ('/lib/ld-linux.so.3', '0')}, Pihole)
+    detectPlatform = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    create_pihole_user
+    funcOutput=$(get_binary_name)
+    binary="pihole-FTL${funcOutput##*pihole-FTL}"
+    theRest="${funcOutput%pihole-FTL*}"
+    FTLdetect "${binary}" "${theRest}"
+    ''')
+    expected_stdout = info_box + ' FTL Checks...'
+    assert expected_stdout in detectPlatform.stdout
+    expected_stdout = tick_box + (' Detected ARMv4 processor')
+    assert expected_stdout in detectPlatform.stdout
+    expected_stdout = tick_box + ' Downloading and Installing FTL'
+    assert expected_stdout in detectPlatform.stdout
+
+
+def test_FTL_detect_armv5te_no_errors(Pihole):
+    '''
+    confirms only armv5te package is downloaded for FTL engine
+    '''
+    # mock uname to return armv5te platform
+    mock_command('uname', {'-m': ('armv5te', '0')}, Pihole)
+    # mock ldd to respond with ld-linux shared library
+    mock_command('ldd', {'/bin/ls': ('/lib/ld-linux.so.3', '0')}, Pihole)
+    detectPlatform = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    create_pihole_user
+    funcOutput=$(get_binary_name)
+    binary="pihole-FTL${funcOutput##*pihole-FTL}"
+    theRest="${funcOutput%pihole-FTL*}"
+    FTLdetect "${binary}" "${theRest}"
+    ''')
+    expected_stdout = info_box + ' FTL Checks...'
+    assert expected_stdout in detectPlatform.stdout
+    expected_stdout = tick_box + (' Detected ARMv5 (or newer) processor')
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in detectPlatform.stdout
@@ -199,7 +247,7 @@ def test_FTL_detect_armv6l_no_errors(Pihole):
     '''
     # mock uname to return armv6l platform
     mock_command('uname', {'-m': ('armv6l', '0')}, Pihole)
-    # mock ldd to respond with aarch64 shared library
+    # mock ldd to respond with ld-linux-armhf shared library
     mock_command('ldd', {'/bin/ls': ('/lib/ld-linux-armhf.so.3', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
@@ -211,8 +259,8 @@ def test_FTL_detect_armv6l_no_errors(Pihole):
     ''')
     expected_stdout = info_box + ' FTL Checks...'
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + (' Detected ARM-hf architecture '
-                                  '(armv6 or lower)')
+    expected_stdout = tick_box + (' Detected ARMv6 processor '
+                                  '(with hard-float support)')
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in detectPlatform.stdout
@@ -224,7 +272,7 @@ def test_FTL_detect_armv7l_no_errors(Pihole):
     '''
     # mock uname to return armv7l platform
     mock_command('uname', {'-m': ('armv7l', '0')}, Pihole)
-    # mock ldd to respond with aarch64 shared library
+    # mock ldd to respond with ld-linux-armhf shared library
     mock_command('ldd', {'/bin/ls': ('/lib/ld-linux-armhf.so.3', '0')}, Pihole)
     detectPlatform = Pihole.run('''
     source /opt/pihole/basic-install.sh
@@ -236,7 +284,32 @@ def test_FTL_detect_armv7l_no_errors(Pihole):
     ''')
     expected_stdout = info_box + ' FTL Checks...'
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + ' Detected ARM-hf architecture (armv7+)'
+    expected_stdout = tick_box + (' Detected ARMv7 processor '
+                                  '(with hard-float support)')
+    assert expected_stdout in detectPlatform.stdout
+    expected_stdout = tick_box + ' Downloading and Installing FTL'
+    assert expected_stdout in detectPlatform.stdout
+
+
+def test_FTL_detect_armv8a_no_errors(Pihole):
+    '''
+    confirms only armv8a package is downloaded for FTL engine
+    '''
+    # mock uname to return armv8a platform
+    mock_command('uname', {'-m': ('armv8a', '0')}, Pihole)
+    # mock ldd to respond with ld-linux-armhf shared library
+    mock_command('ldd', {'/bin/ls': ('/lib/ld-linux-armhf.so.3', '0')}, Pihole)
+    detectPlatform = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    create_pihole_user
+    funcOutput=$(get_binary_name)
+    binary="pihole-FTL${funcOutput##*pihole-FTL}"
+    theRest="${funcOutput%pihole-FTL*}"
+    FTLdetect "${binary}" "${theRest}"
+    ''')
+    expected_stdout = info_box + ' FTL Checks...'
+    assert expected_stdout in detectPlatform.stdout
+    expected_stdout = tick_box + ' Detected ARMv8 (or newer) processor'
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in detectPlatform.stdout
@@ -256,7 +329,7 @@ def test_FTL_detect_x86_64_no_errors(Pihole):
     ''')
     expected_stdout = info_box + ' FTL Checks...'
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + ' Detected x86_64 architecture'
+    expected_stdout = tick_box + ' Detected x86_64 processor'
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + ' Downloading and Installing FTL'
     assert expected_stdout in detectPlatform.stdout
@@ -274,7 +347,7 @@ def test_FTL_detect_unknown_no_errors(Pihole):
     theRest="${funcOutput%pihole-FTL*}"
     FTLdetect "${binary}" "${theRest}"
     ''')
-    expected_stdout = 'Not able to detect architecture (unknown: mips)'
+    expected_stdout = 'Not able to detect processor (unknown: mips)'
     assert expected_stdout in detectPlatform.stdout
 
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Add support for pre-compiled ARMv4R, ARMv5TE and ARMv8-A FTL binaries

**How does this PR accomplish the above?:**

Improve detection and add new criteria

**Dependencies of this PR**

This PR depends on https://github.com/pi-hole/docker-base-images/pull/31 (:heavy_check_mark:) and should be merged at the same time as https://github.com/pi-hole/FTL/pull/903 (already approved)
**What documentation changes (if any) are needed to support this PR?:**

None