### PR TITLE
Fixed potential security issue with $landPage receiving variables

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -55,7 +55,16 @@ if ($serverName === "pi.hole"
     // Redirect to Web Interface
     exit(header("Location: /admin"));
 } elseif (filter_var($serverName, FILTER_VALIDATE_IP) || in_array($serverName, $authorizedHosts)) {
-    // Set Splash Page output
+    // When directly browsing via IP or authorized hostname
+    // Render splash/landing page based off presence of $landPage file
+    // If $landPage file is present
+    if (is_file(getcwd()."/$landPage")) {
+        //Unset variables so as to not be included in $landPage
+        unset($serverName, $svPasswd, $svEmail, $authorizedHosts, $validExtTypes, $currentUrlExt, $viewPort);
+        include $landPage;
+        exit();
+    }
+    // If $landPage file was not present, Set Splash Page output
     $splashPage = "
     <!doctype html>
     <html lang='en'>
@@ -74,15 +83,7 @@ if ($serverName === "pi.hole"
         </body>
     </html>
     ";
-
-    // Set splash/landing page based off presence of $landPage
-    $renderPage = is_file(getcwd()."/$landPage") ? include $landPage : "$splashPage";
-
-    // Unset variables so as to not be included in $landPage
-    unset($serverName, $svPasswd, $svEmail, $authorizedHosts, $validExtTypes, $currentUrlExt, $viewPort);
-
-    // Render splash/landing page when directly browsing via IP or authorized hostname
-    exit($renderPage);
+    exit($splashPage);
 } elseif ($currentUrlExt === "js") {
     // Serve Pi-hole JavaScript for blocked domains requesting JS
     exit(setHeader("js").'var x = "Pi-hole: A black hole for Internet advertisements."');

--- a/advanced/index.php
+++ b/advanced/index.php
@@ -57,10 +57,10 @@ if ($serverName === "pi.hole"
 } elseif (filter_var($serverName, FILTER_VALIDATE_IP) || in_array($serverName, $authorizedHosts)) {
     // When directly browsing via IP or authorized hostname
     // Render splash/landing page based off presence of $landPage file
+    // Unset variables so as to not be included in $landPage or $splashPage
+    unset($serverName, $svPasswd, $svEmail, $authorizedHosts, $validExtTypes, $currentUrlExt, $viewPort);
     // If $landPage file is present
     if (is_file(getcwd()."/$landPage")) {
-        //Unset variables so as to not be included in $landPage
-        unset($serverName, $svPasswd, $svEmail, $authorizedHosts, $validExtTypes, $currentUrlExt, $viewPort);
         include $landPage;
         exit();
     }


### PR DESCRIPTION
Signed-off-by: craigmayhew <craig@mayhew.io>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [ ] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Possible security fix involving variables being passed to a landing page that should not be passed to the landing page.


**How does this PR accomplish the above?:**
Re-order and tidy of of code. Unset now occurs before $landPage is included. Also noticed $splashPage is set regardless if it is used - this has been fixed by moving the $landPage check above the setting of $splashPage.


**What documentation changes (if any) are needed to support this PR?:**
Genuinely unsure.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
