### PR TITLE
Add systemctl status --full --no-pager pihole-FTL.service to the debug log

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -946,7 +946,7 @@ process_status(){
     done
 }
 
-pihole-FTL_full_status(){
+ftl_full_status(){
     # if using systemd print the full status of pihole-FTL
     echo_current_diagnostic "Pi-hole-FTL full status"
     local FTL_status
@@ -1389,7 +1389,7 @@ check_networking
 check_name_resolution
 check_dhcp_servers
 process_status
-pihole-FTL_full_status
+ftl_full_status
 parse_setup_vars
 check_x_headers
 analyze_gravity_list

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -953,6 +953,8 @@ ftl_full_status(){
     if command -v systemctl &> /dev/null; then
       FTL_status=$(systemctl status --full --no-pager pihole-FTL.service)
       log_write "   ${FTL_status}"
+    else
+      log_write "${INFO} systemctl:  command not found"
     fi
 }
 

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -946,6 +946,16 @@ process_status(){
     done
 }
 
+pihole-FTL_full_status(){
+    # if using systemd print the full status of pihole-FTL
+    echo_current_diagnostic "Pi-hole-FTL full status"
+    local FTL_status
+    if command -v systemctl &> /dev/null; then
+      FTL_status=$(systemctl status --full --no-pager pihole-FTL.service)
+      log_write "   ${FTL_status}"
+    fi
+}
+
 make_array_from_file() {
     local filename="${1}"
     # The second argument can put a limit on how many line should be read from the file
@@ -1379,6 +1389,7 @@ check_networking
 check_name_resolution
 check_dhcp_servers
 process_status
+pihole-FTL_full_status
 parse_setup_vars
 check_x_headers
 analyze_gravity_list


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Adds the output of `systemctl status --full --no-pager pihole-FTL.service` to the debug log. This is a usual follow up question during support in case FTL is not running.

```
*** [ DIAGNOSING ]: Pi-hole processes
[✓] lighttpd daemon is active
[✓] pihole-FTL daemon is active

*** [ DIAGNOSING ]: Pi-hole-FTL full status
   ● pihole-FTL.service - LSB: pihole-FTL daemon
   Loaded: loaded (/etc/init.d/pihole-FTL; generated)
   Active: active (exited) since Thu 2020-11-19 12:30:07 CET; 4 days ago
     Docs: man:systemd-sysv-generator(8)
  Process: 23694 ExecStart=/etc/init.d/pihole-FTL start (code=exited, status=0/SUCCESS)

Warning: Journal has been rotated since unit was started. Log output is incomplete or unavailable.

*** [ DIAGNOSING ]: Setup variables
    CONDITIONAL_FORWARDING=false
    TEMPERATUREUNIT=C
    DHCP_START=192.168.1.20

```
