### PR TITLE
Revert "Enable DNS forwarding loop detection"

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -32,8 +32,6 @@ no-resolv
 server=@DNS1@
 server=@DNS2@
 
-dns-loop-detect
-
 interface=@INT@
 
 cache-size=@CACHE_SIZE@


### PR DESCRIPTION
Reverts pi-hole/pi-hole#3810

We discussed this internally, some of the thoughts are already [expressed by @Bucking-Horn](https://github.com/pi-hole/pi-hole/pull/3810#issuecomment-731861662). The main reasons for reverting it is that this feature unnecessarily sends queries to upstream servers. If such a feature is to be enabled by default in Pi-hole, we'll likely have to invent our own test (and, maybe, only query network-internal servers).

Or we just implement such a test *without* any active probing queries by just watching if queries incoming from some clients are always repeated by one and the same client. Only time will tell :-)