### PR TITLE
Fix processing of CONDITIONAL_FORWARDING_REVERSE

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -246,6 +246,9 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
                 4   )   REV_SERVER_CIDR="${arrRev[1]}.${arrRev[0]}.0.0/16";;
                 3   )   REV_SERVER_CIDR="${arrRev[0]}.0.0.0/8";; 
             esac
+        else
+          # Set REV_SERVER_CIDR to whatever value it was set to
+          REV_SERVER_CIDR="$CONDITIONAL_FORWARDING_REVERSE"
         fi
         
         # If REV_SERVER_CIDR is not converted by the above, then use the REV_SERVER_TARGET variable to derive it

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -237,8 +237,7 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
         #          1.168.192.in-addr.arpa to 192.168.1.0/24
         #          168.192.in-addr.arpa to 192.168.0.0/16
         #          192.in-addr.arpa to 192.0.0.0/8
-        search="in-addr.arpa"
-        if [[ "$CONDITIONAL_FORWARDING_REVERSE" == *"$search" ]];then
+        if [[ "${CONDITIONAL_FORWARDING_REVERSE}" == *"in-addr.arpa" ]];then
             arrRev=("${CONDITIONAL_FORWARDING_REVERSE//./ }")        
             case ${#arrRev[@]} in 
                 6   )   REV_SERVER_CIDR="${arrRev[3]}.${arrRev[2]}.${arrRev[1]}.${arrRev[0]}/32";;

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -232,7 +232,7 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
         REV_SERVER_TARGET="${CONDITIONAL_FORWARDING_IP}"
         add_setting "REV_SERVER_TARGET" "${REV_SERVER_TARGET}"
 
-        #Convert CONDITIONAL_FORWARDING_REVERSE if neccasery e.g:
+        #Convert CONDITIONAL_FORWARDING_REVERSE if necessary e.g:
         #          1.1.168.192.in-addr.arpa to 192.168.1.1/32
         #          1.168.192.in-addr.arpa to 192.168.1.0/24
         #          168.192.in-addr.arpa to 192.168.0.0/16

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -239,7 +239,7 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
         #          192.in-addr.arpa to 192.0.0.0/8
         search="in-addr.arpa"
         if [[ "$CONDITIONAL_FORWARDING_REVERSE" == *"$search" ]];then
-            arrRev=(${CONDITIONAL_FORWARDING_REVERSE//./ })        
+            arrRev=("${CONDITIONAL_FORWARDING_REVERSE//./ }")        
             case ${#arrRev[@]} in 
                 6   )   REV_SERVER_CIDR="${arrRev[3]}.${arrRev[2]}.${arrRev[1]}.${arrRev[0]}/32";;
                 5   )   REV_SERVER_CIDR="${arrRev[2]}.${arrRev[1]}.${arrRev[0]}.0/24";;

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -247,7 +247,7 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
             esac
         else
           # Set REV_SERVER_CIDR to whatever value it was set to
-          REV_SERVER_CIDR="$CONDITIONAL_FORWARDING_REVERSE"
+          REV_SERVER_CIDR="${CONDITIONAL_FORWARDING_REVERSE}"
         fi
         
         # If REV_SERVER_CIDR is not converted by the above, then use the REV_SERVER_TARGET variable to derive it


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

This PR attempts to address the issues seen in the most recent release with environment variables/setupvars configs that have been repurposed (be they on purpose or accidentally). See https://github.com/pi-hole/docker-pi-hole/issues/709#issuecomment-735509294

This adds some additional code into the `if [[ "${CONDITIONAL_FORWARDING}" == true ]]; then` condition:
 - delete any existing `REV_SERVER*` settings (this prevents any containers that still have the `CONDITIONAL_FORWARDING*` variables from duplicating the same information every time the container is restarted/rebuilt)
 - Properly transform the `CONDITIONAL_FORWARDING_REVERSE` variable from an `.in-addr.arpa` to CIDR notation
- If `CONDITIONAL_FORWARDING_REVERSE` is not an `in-addr.arpa` value, then leave it as it is. 

Patching in the core repo, rather than the docker `start.sh` makes this solution fit for all (e.g perhaps someone is coming from an older version of Pi-hole on a bare metal install, and therefore renders anything proposed [here](https://github.com/pi-hole/docker-pi-hole/pull/711) moot.

On merging of this PR, the docker `start.sh` and documentation really should be updated to advise the new REV_SERVER variables as env vars, but this maintains backward compatibility


Examples of `setupVars.conf` before:
```
...
CONDITIONAL_FORWARDING=true
CONDITIONAL_FORWARDING_IP=192.168.0.1
CONDITIONAL_FORWARDING_DOMAIN=lan
CONDITIONAL_FORWARDING_REVERSE=0.168.192.in-addr.arpa
...
```

And then after a repair/update:
```
...
REV_SERVER=true
REV_SERVER_DOMAIN=lan
REV_SERVER_TARGET=192.168.0.1
REV_SERVER_CIDR=192.168.0.0/24
...
```

Before:
```
...
CONDITIONAL_FORWARDING=true
CONDITIONAL_FORWARDING_IP=10.251.85.254
CONDITIONAL_FORWARDING_DOMAIN=lan
CONDITIONAL_FORWARDING_REVERSE=251.10.in-addr.arpa
...
```
After:
```
...
REV_SERVER=true
REV_SERVER_DOMAIN=lan
REV_SERVER_TARGET=10.251.85.254
REV_SERVER_CIDR=10.251.0.0/16
...
```

Before:
```
...
CONDITIONAL_FORWARDING=true
CONDITIONAL_FORWARDING_IP=192.168.0.1
CONDITIONAL_FORWARDING_DOMAIN=lan
CONDITIONAL_FORWARDING_REVERSE=192.168.0.0/16
...
```
After:
```
...
REV_SERVER=true
REV_SERVER_DOMAIN=lan
REV_SERVER_TARGET=192.168.0.1
REV_SERVER_CIDR=192.168.0.0/16
...
```