### PR TITLE
Ensure x86_64 processor architecture is listed as supported

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -560,7 +560,7 @@ processor_check() {
     else
         # Check if the architecture is currently supported for FTL
         case "${PROCESSOR}" in
-            "amd64") log_write "${TICK} ${COL_GREEN}${PROCESSOR}${COL_NC}"
+            "amd64" | "x86_64") log_write "${TICK} ${COL_GREEN}${PROCESSOR}${COL_NC}"
                 ;;
             "armv6l") log_write "${TICK} ${COL_GREEN}${PROCESSOR}${COL_NC}"
                 ;;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Currently the Pi-hole debug script running on a regular 64bit Intel/AMD processor doesn't display the architecture as supported:
```
*** [ DIAGNOSING ]: Processor                                                                                                                                  
[i] x86_64
```

**How does this PR accomplish the above?:**
Ensure that the usual output of `uname -m` for Intel-compatible 64bit processors is recognized as supported. With my change:
```
*** [ DIAGNOSING ]: Processor                                                                                                                                  
[✓] x86_64
```
I even think that the already defined value `amd64` is invalid and never returned by `uname` or `lscpu`. But maybe there are somewhere some exotic kernel builds so I don't dare to break anything existing that might work. 


**What documentation changes (if any) are needed to support this PR?:**
None


---