### PR TITLE
Fix debugger stripping content it shouldn't

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -977,7 +977,7 @@ make_array_from_file() {
         # Otherwise, read the file line by line
         while IFS= read -r line;do
             # Othwerise, strip out comments and blank lines
-            new_line=$(echo "${line}" | sed -e 's/#.*$//' -e '/^$/d')
+            new_line=$(echo "${line}" | sed -e 's/^\s*#.*$//' -e '/^$/d')
             # If the line still has content (a non-zero value)
             if [[ -n "${new_line}" ]]; then
                 # Put it into the array


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Strip only lines **starting** with a `#`. Do not silently truncate lines if they have a # somewhere in between (like `server=127.0.0.1#5353`).

**How does this PR accomplish the above?:**

Fix an imprecise `sed` command.

Real content:
```
server=127.0.0.1#5353
```

`pihole -d` now:
```
server=127.0.0.1  <---- [the rest of the line is silently truncated !]
```

`pihole -d` with this fix:
```
server=127.0.0.1#5353
```
Lines starting with `#` ("real comments") are still silently skipped

**What documentation changes (if any) are needed to support this PR?:**

None