### PR TITLE
Exit installer if directory already exists when trying to clone one of our repos into it

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -528,8 +528,8 @@ make_repo() {
     printf "  %b %s..." "${INFO}" "${str}"
     # If the directory exists,
     if [[ -d "${directory}" ]]; then
-        # delete everything in it so git can clone into it
-        rm -rf "${directory}"
+        # Return with a 1 to exit the installer. We don't want to overwrite what could already be here in case it is not ours
+        return 1
     fi
     # Clone the repo and return the return code from this command
     git clone -q --depth 20 "${remoteRepo}" "${directory}" &> /dev/null || return $?

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -529,6 +529,8 @@ make_repo() {
     # If the directory exists,
     if [[ -d "${directory}" ]]; then
         # Return with a 1 to exit the installer. We don't want to overwrite what could already be here in case it is not ours
+        str="Unable to clone ${remoteRepo} into ${directory}"
+        printf "%b  %b%s\\n" "${OVER}" "${CROSS}" "${str}"
         return 1
     fi
     # Clone the repo and return the return code from this command

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -529,7 +529,7 @@ make_repo() {
     # If the directory exists,
     if [[ -d "${directory}" ]]; then
         # Return with a 1 to exit the installer. We don't want to overwrite what could already be here in case it is not ours
-        str="Unable to clone ${remoteRepo} into ${directory}"
+        str="Unable to clone ${remoteRepo} into ${directory} : Directory already exists"
         printf "%b  %b%s\\n" "${OVER}" "${CROSS}" "${str}"
         return 1
     fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Rather than deleting the directory, return 1 so that the installer knows to throw up the error message and halt the install