### PR TITLE
Fix chronometer output if web interface is not installed

### DIFF
--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -228,8 +228,14 @@ get_sys_stats() {
         mapfile -t ph_ver_raw < <(pihole -v -c 2> /dev/null | sed -n 's/^.* v/v/p')
         if [[ -n "${ph_ver_raw[0]}" ]]; then
             ph_core_ver="${ph_ver_raw[0]}"
-            ph_lte_ver="${ph_ver_raw[1]}"
-            ph_ftl_ver="${ph_ver_raw[2]}"
+            if [[ ${#ph_ver_raw[@]} -eq 2 ]]; then
+                # AdminLTE not installed
+                ph_lte_ver="n.a."
+                ph_ftl_ver="${ph_ver_raw[1]}"
+            else
+                ph_lte_ver="${ph_ver_raw[1]}"
+                ph_ftl_ver="${ph_ver_raw[2]}"
+            fi
         else
             ph_core_ver="-1"
         fi

--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -230,7 +230,7 @@ get_sys_stats() {
             ph_core_ver="${ph_ver_raw[0]}"
             if [[ ${#ph_ver_raw[@]} -eq 2 ]]; then
                 # AdminLTE not installed
-                ph_lte_ver="n.a."
+                ph_lte_ver="(not installed)"
                 ph_ftl_ver="${ph_ver_raw[1]}"
             else
                 ph_lte_ver="${ph_ver_raw[1]}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Fix wrongly shifted version list in chronometer output if AdminLTE web interface is not installed. Current output:
```
|¯¯¯(¯)_|¯|_  ___|¯|___        Core: v5.2.1.
| ¯_/¯|_| ' \/ _ \ / -_)        Web: v5.3.2.
|_| |_| |_||_\___/_\___|        FTL:
 ——————————————————————————————————————————————————————————
```
Note that the version of FTL is printed on the "Web" line.
Output of `pihole version`:
```
  Pi-hole version is v5.2.1 (Latest: v5.2.1)
  FTL version is v5.3.2 (Latest: v5.3.2)
```

**How does this PR accomplish the above?:**
Set Web version to "n.a." if not reported by `pihole version`:
```
|¯¯¯(¯)_|¯|_  ___|¯|___        Core: v5.2.1.
| ¯_/¯|_| ' \/ _ \ / -_)        Web: n.a.
|_| |_| |_||_\___/_\___|        FTL: v5.3.2.
 ——————————————————————————————————————————————————————————
```


**What documentation changes (if any) are needed to support this PR?:**
Not needed
