### PR TITLE
piholeDebug: Fix warning if lighttpd/php are not installed

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -371,9 +371,9 @@ get_program_version() {
     echo_current_diagnostic "${program_name} version"
     # Evalutate the program we are checking, if it is any of the ones below, show the version
     case "${program_name}" in
-        "lighttpd") program_version="$(${program_name} -v |& head -n1 | cut -d '/' -f2 | cut -d ' ' -f1)"
+        "lighttpd") program_version="$(${program_name} -v 2> /dev/null | head -n1 | cut -d '/' -f2 | cut -d ' ' -f1)"
                     ;;
-        "php") program_version="$(${program_name} -v |& head -n1 | cut -d '-' -f1 | cut -d ' ' -f2)"
+        "php") program_version="$(${program_name} -v 2> /dev/null | head -n1 | cut -d '-' -f1 | cut -d ' ' -f2)"
                 ;;
         # If a match is not found, show an error
         *) echo "Unrecognized program";


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
If the installation is done without web interface lighttpd and php are typically missing on the system. The `piholeDebug.sh` script tries to detect that but fails to do so properly. The current output looks like this:
```
*** [ DIAGNOSING ]: FTL version                                                                                                                                
[✓] FTL: v5.3.2 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249)  
                                                                                                                                                               
*** [ DIAGNOSING ]: lighttpd version                                                                                                                           
[i] opt                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                              
*** [ DIAGNOSING ]: php version                                                                                                                                                                                                                                                                                               
[i] line 
```
This is fixed by adjusting the commands to retrieve the versions of lighttpd and php.

**How does this PR accomplish the above?:**
This is a bit a tricky one as I have to admit that I don't fully understand what's going wrong here and that it might even be something that is depending on the version of bash. I observed this behaviour on CentOS 8 with `bash-4.4.19-10.el8` and on Gentoo with `bash-5.0_p18`.

When running the section in debug mode the output (e.g. for the lighttpd) check shows:
```
*** [ DIAGNOSING ]: lighttpd version                                  
+ case "${program_name}" in                      
++ head -n1
++ lighttpd -v
++ cut -d / -f2
++ cut -d ' ' -f1
+ program_version=opt
+ set +x
[i] opt
```
Lightthpd obviously is not installed so a plain version check would result in the following output (on stderr):
```
# lighttpd -v
-bash: lighttpd: command not found
```
It looks like the pipefail option that is globally set doesn't play well with the merging of stdout/stderr `|&`. It looks like bash is not stopping when the lighttpd command failed and continues parsing some mysterious strings. I didn't figure out where these 'opt' and 'line' strings which will be assigned to the `program_version` variable are coming from. They are certainly not leaking from any previous code as the variable is only defined above and local to the function.

The simplest change that was fixing the issue for me was to simply get rid of the output merging and suppress stderr (the "command not found" message). lighttpd as well as php print the version information to stdout on the systems that I tested. With the proposed patch the behaviour looks again as intended:
```
*** [ DIAGNOSING ]: lighttpd version                                                                                                                                                                                                                                                                                          
+ case "${program_name}" in                      
++ cut -d / -f2                                                       
++ head -n1                  
++ lighttpd -v                                                                 
++ cut -d ' ' -f1                                                                                                                                                                                                                                                                                                             
+ program_version=                                                                                                                                             
+ set +x   
[✗] lighttpd version could not be detected.
```

Eventually the version check output then looks as following:
```
*** [ DIAGNOSING ]: FTL version                                                                                                                                
[✓] FTL: v5.3.2                                                                                                                                                
                                                                               
*** [ DIAGNOSING ]: lighttpd version                                                                                                                           
[✗] lighttpd version could not be detected.                                    
                                                                               
*** [ DIAGNOSING ]: php version         
[✗] php version could not be detected. 
```

I don't assume that there are lighttpd/php versions that are printing their version to stderr so I'm asking for feedback. If there would be, this change would obviously introduce a regression for those systems which won't be able to detect a properly installed lighttpd or php version anymore. 

Alternatively I could just rewrite the version check logic to only be executed if the command exists.

**What documentation changes (if any) are needed to support this PR?:**
None