### PR TITLE
piholeDebug: Diagnose output if (Web) git directory is not found

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -334,7 +334,17 @@ compare_local_version_to_git_version() {
             return 1
         fi
     else
-        :
+        # There is no git directory so check if the web interface was disabled
+        local setup_vars_web_interface
+        setup_vars_web_interface=$(< ${PIHOLE_SETUP_VARS_FILE} grep ^INSTALL_WEB_INTERFACE | cut -d '=' -f2)
+        if [[ "${pihole_component}" == "Web" ]] && [[ "${setup_vars_web_interface}" == "false" ]]; then
+            log_write "${INFO} ${pihole_component}: Disabled in setupVars.conf via INSTALL_WEB_INTERFACE=false"
+        else
+            # Return an error message
+            log_write "${COL_RED}Directory ${git_dir} doesn't exist${COL_NC}"
+            # and exit with a non zero code
+            return 1
+        fi
     fi
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
If Pi-hole was installed without Web interface the `piholeDebug.sh` currently omits any output in the version check for the "Web" component:
```
*** [ DIAGNOSING ]: Core version                                                                                                                                                                                                                                                                                              
[i] Core: v5.2.1 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249) 
[i] Remotes: origin     https://github.com/pi-hole/pi-hole.git (fetch)                                                                                         
             origin     https://github.com/pi-hole/pi-hole.git (push)                                                                                          
[i] Branch: master                                                                                                                                                                                                                                                                                                            
[i] Commit: v5.2.1-0-g0d8ece1                                                                                                                                  
                                                                                                                                                               
*** [ DIAGNOSING ]: Web version                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                              
*** [ DIAGNOSING ]: FTL version                                                                                                                                
[✓] FTL: v5.3.2 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249)
```
I guess it would be helpful to have more details what's up with the "Web" component.

**How does this PR accomplish the above?:**
I adjusted the code to print a note when the "Web" component has been disabled on purpose:
```
*** [ DIAGNOSING ]: Core version
[i] Core: v5.2.1 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249)
[i] Remotes: origin     https://github.com/pi-hole/pi-hole.git (fetch)
             origin     https://github.com/pi-hole/pi-hole.git (push)
[i] Branch: master                           
[i] Commit: v5.2.1-0-g0d8ece1             

*** [ DIAGNOSING ]: Web version 
[i] Web: Disabled in setupVars.conf via INSTALL_WEB_INTERFACE=false           
                                                                               
*** [ DIAGNOSING ]: FTL version                                      
[✓] FTL: v5.3.2 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249)
```
And I also added a proper error message if the git directory is not found. This works for all the components tested in `compare_local_version_to_git_version()`. Here an example output if `INSTALL_WEB_INTERFACE=true` (or missing) in the `setupVars.conf`:
```
*** [ DIAGNOSING ]: Core version
[i] Core: v5.2.1 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249)
[i] Remotes: origin     https://github.com/pi-hole/pi-hole.git (fetch)
             origin     https://github.com/pi-hole/pi-hole.git (push)
[i] Branch: master
[i] Commit: v5.2.1-0-g0d8ece1

*** [ DIAGNOSING ]: Web version
Directory /var/www/html/admin doesn't exist

*** [ DIAGNOSING ]: FTL version
[✓] FTL: v5.3.2 (https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249)
``` 

**What documentation changes (if any) are needed to support this PR?:**
No changes needed.