### PR TITLE
Log output of pihole -g to pihole_updateGravity.log

### DIFF
--- a/pihole
+++ b/pihole
@@ -70,7 +70,7 @@ reconfigurePiholeFunc() {
 }
 
 updateGravityFunc() {
-  "${PI_HOLE_SCRIPT_DIR}"/gravity.sh "$@"
+  "${PI_HOLE_SCRIPT_DIR}"/gravity.sh "$@" | tee /var/log/pihole_updateGravity.log
   exit $?
 }
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Logs the output of `pihole -g` to `/var/log/pihole_updateGravity.log`.
The cron job already [does log to that file](https://github.com/pi-hole/pi-hole/blob/41bdb741b7e1a70184ecd7dbfc23f3ebcaa5e3bc/advanced/Templates/pihole.cron#L21), but manually running gravity (or via web interface) did not log so far.
