### PR TITLE
Fix connection mechanism between Chronometer and FTL

### DIFF
--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -13,6 +13,7 @@ LC_NUMERIC=C
 
 # Retrieve stats from FTL engine
 pihole-FTL() {
+    local ftl_port LINE
     ftl_port=$(cat /run/pihole-FTL.port 2> /dev/null)
     if [[ -n "$ftl_port" ]]; then
         # Open connection to FTL
@@ -20,12 +21,13 @@ pihole-FTL() {
 
         # Test if connection is open
         if { "true" >&3; } 2> /dev/null; then
-            # Send command to FTL
-            echo -e ">$1" >&3
+            # Send command to FTL and ask to quit when finished
+            echo -e ">$1 >quit" >&3
 
-            # Read input
+            # Read input until we received an empty string and the connection is
+            # closed
             read -r -t 1 LINE <&3
-            until [[ ! $? ]] || [[ "$LINE" == *"EOM"* ]]; do
+            until [[ -z "${LINE}" ]] && [[ ! -t 3 ]]; do
                 echo "$LINE" >&1
                 read -r -t 1 LINE <&3
             done


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix connection mechanism between Chronometer and FTL

The existing interaction script between Chronometer (`pihole -c`) and FTL had a few drawbacks:

2. The connection was closed "suddenly" while FTL was waiting for the next query, resulting in a warning in FTL's log.
1. `read` is a `bash`-internal and does not populate. As a result, the existing check for `$?` didn't work and chronometer would have stalled forever if the connection was interrupted midway.

**How does this PR accomplish the above?:**

The two points are addressed with two changes:

1. Send `>whatevercommand > quit` to signal FTL that the pipe is to be closed when done sending the results of the query. This resolves the seen warnings properly.
2. Check for an empty returned value by `read` *and* a closed file descriptor `3`. This is the proper way to check for a terminated connection. Relying on the (non-existing) return value of `read` is removed as well as the check for a string `EOM` in the payload.

**What documentation changes (if any) are needed to support this PR?:**

None

---

These fixes should be applied to PADD as well after they have been evaluated and approved.