### PR TITLE
Ensure critical config lines have trailing newlines before appending new content

### DIFF
--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Pi-hole: A black hole for Internet advertisements
+# (c) 2020 Pi-hole, LLC (https://pi-hole.net)
+# Network-wide ad blocking via your own hardware.
+#
+# Controller for all pihole scripts and functions.
+#
+# This file is copyright under the latest version of the EUPL.
+# Please see LICENSE file for your rights under this license.
+
+# Ensure there is a newline at the end of the file passed as argument
+ensure_newline() {
+  # Check if the last line of the passed file is empty, if not, append a newline
+  # to the file to ensure we can append new content safely using echo "" >>
+  # later on
+  [ -n "$(tail -c1 "${1}")" ] && printf '\n' >> "${1}"
+  # There was also the suggestion of using a sed-magic call here, however, this
+  # had the drawback to updating all the file timestamps whenever the sed was
+  # run. This solution only updates the timestamp when actually appending a
+  # newline
+}

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -49,6 +49,7 @@ Options:
 }
 
 add_setting() {
+    ensure_newline "${setupVars}"
     echo "${1}=${2}" >> "${setupVars}"
 }
 
@@ -62,6 +63,7 @@ change_setting() {
 }
 
 addFTLsetting() {
+    ensure_newline "${FTLconf}"
     echo "${1}=${2}" >> "${FTLconf}"
 }
 
@@ -75,6 +77,7 @@ changeFTLsetting() {
 }
 
 add_dnsmasq_setting() {
+    ensure_newline "${dnsmasqconfig}"
     if [[ "${2}" != "" ]]; then
         echo "${1}=${2}" >> "${dnsmasqconfig}"
     else
@@ -146,6 +149,7 @@ SetWebPassword() {
 ProcessDNSSettings() {
     source "${setupVars}"
 
+    ensure_newline "${dnsmasqconfig}"
     delete_dnsmasq_setting "server"
 
     COUNTER=1
@@ -392,6 +396,7 @@ ProcessDHCPSettings() {
     fi
 
     # Write settings to file
+    # We do not need to ensure a newline here as the entire file is re-written
     echo "###############################################################################
 #  DHCP SERVER CONFIG FILE AUTOMATICALLY POPULATED BY PI-HOLE WEB INTERFACE.  #
 #            ANY CHANGES MADE TO THIS FILE WILL BE LOST ON CHANGE             #
@@ -545,6 +550,7 @@ AddDHCPStaticAddress() {
     ip="${args[3]}"
     host="${args[4]}"
 
+    ensure_newline "${dhcpstaticconfig}"
     if [[ "${ip}" == "noip" ]]; then
         # Static host name
         echo "dhcp-host=${mac},${host}" >> "${dhcpstaticconfig}"
@@ -689,6 +695,7 @@ AddCustomDNSAddress() {
 
     ip="${args[2]}"
     host="${args[3]}"
+    ensure_newline "${dnscustomfile}"
 	echo "${ip} ${host}" >> "${dnscustomfile}"
 
     # Restart dnsmasq to load new custom DNS entries
@@ -711,6 +718,7 @@ AddCustomCNAMERecord() {
 
     domain="${args[2]}"
     target="${args[3]}"
+    ensure_newline "${dnscustomcnamefile}"
     echo "cname=${domain},${target}" >> "${dnscustomcnamefile}"
 
     # Restart dnsmasq to load new custom CNAME records

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -26,6 +26,9 @@ readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 PH_TEST="true"
 source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
 
+# ensure_newline()
+source "utils.sh"
+
 coltable="/opt/pihole/COL_TABLE"
 if [[ -f ${coltable} ]]; then
     source ${coltable}

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -22,16 +22,21 @@ readonly gravityDBfile="/etc/pihole/gravity.db"
 
 # Source install script for ${setupVars}, ${PI_HOLE_BIN_DIR} and valid_ip()
 readonly PI_HOLE_FILES_DIR="/etc/.pihole"
+setupVars=""
+DHCP_IPv6=false
 # shellcheck disable=SC2034  # used in basic-install
 PH_TEST="true"
 source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
 
 # ensure_newline()
-source "utils.sh"
+readonly utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
+# shellcheck source=./utils.sh
+source "${utilsfile}"
 
-coltable="/opt/pihole/COL_TABLE"
+readonly coltable="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 if [[ -f ${coltable} ]]; then
-    source ${coltable}
+  # shellcheck source=./COL_TABLE
+  source "${coltable}"
 fi
 
 helpFunc() {

--- a/pihole
+++ b/pihole
@@ -20,17 +20,8 @@ PI_HOLE_BIN_DIR="/usr/local/bin"
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
 
-# Ensure there is a newline at the end of the file passed as argument
-ensure_newline() {
-  # Check if the last line of the passed file is empty, if not, append a newline
-  # to the file to ensure we can append new content safely using echo "" >>
-  # later on
-  [ -n "$(tail -c1 "${1}")" ] && printf '\n' >> "${1}"
-  # There was also the suggestion of using a sed-magic call here, however, this
-  # had the drawback to updating all the file timestamps whenever the sed was
-  # run. This solution only updates the timestamp when actually appending a
-  # newline
-}
+# ensure_newline()
+source "utils.sh"
 
 webpageFunc() {
   source "${PI_HOLE_SCRIPT_DIR}/webpage.sh"

--- a/pihole
+++ b/pihole
@@ -18,12 +18,16 @@ setupVars="/etc/pihole/setupVars.conf"
 PI_HOLE_BIN_DIR="/usr/local/bin"
 
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
+# shellcheck source=./advanced/Scripts/COL_TABLE
 source "${colfile}"
 
 # ensure_newline()
-source "utils.sh"
+readonly utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
+# shellcheck source=./advanced/Scripts/utils.sh
+source "${utilsfile}"
 
 webpageFunc() {
+  # shellcheck source=./advanced/Scripts/webpage.sh
   source "${PI_HOLE_SCRIPT_DIR}/webpage.sh"
   main "$@"
   exit 0
@@ -40,9 +44,13 @@ debugFunc() {
 
   # Pull off the `debug` leaving passed call augmentation flags in $1
   shift
+  # We do not want to be warned about implicit concatenation of array in [[ ]]
+  # as this is exactly what we want here
+  # shellcheck disable=SC2199
   if [[ "$@" == *"-a"* ]]; then
     automated="true"
   fi
+  # shellcheck disable=SC2199
   if [[ "$@" == *"-w"* ]]; then
     web="true"
   fi
@@ -157,7 +165,7 @@ Time:
       echo -e "  ${INFO} Blocking already disabled, nothing to do"
       exit 0
     fi
-    if [[ $# > 1 ]]; then
+    if [[ $# -gt 1 ]]; then
       local error=false
       if [[ "${2}" == *"s" ]]; then
         tt=${2%"s"}
@@ -165,7 +173,7 @@ Time:
           local str="Disabling blocking for ${tt} seconds"
           echo -e "  ${INFO} ${str}..."
           local str="Blocking will be re-enabled in ${tt} seconds"
-          nohup "${PI_HOLE_SCRIPT_DIR}"/pihole-reenable.sh ${tt} </dev/null &>/dev/null &
+          nohup "${PI_HOLE_SCRIPT_DIR}/pihole-reenable.sh" "${tt}" </dev/null &>/dev/null &
         else
           local error=true
         fi
@@ -175,8 +183,8 @@ Time:
           local str="Disabling blocking for ${tt} minutes"
           echo -e "  ${INFO} ${str}..."
           local str="Blocking will be re-enabled in ${tt} minutes"
-          tt=$((${tt}*60))
-          nohup "${PI_HOLE_SCRIPT_DIR}"/pihole-reenable.sh ${tt} </dev/null &>/dev/null &
+          tt=$((tt*60))
+          nohup "${PI_HOLE_SCRIPT_DIR}/pihole-reenable.sh" "${tt}" </dev/null &>/dev/null &
         else
           local error=true
         fi
@@ -325,7 +333,8 @@ statusFunc() {
 
 tailFunc() {
   # Warn user if Pi-hole's logging is disabled
-  local logging_enabled=$(grep -c "^log-queries" /etc/dnsmasq.d/01-pihole.conf)
+  local logging_enabled
+  logging_enabled=$(grep -c "^log-queries" /etc/dnsmasq.d/01-pihole.conf)
   if [[ "${logging_enabled}" == "0" ]]; then
     # No "log-queries" lines are found.
     # Commented out lines (such as "#log-queries") are ignored
@@ -366,6 +375,7 @@ Branches:
     exit 0
   fi
 
+  # shellcheck source=./advanced/Scripts/piholeCheckout.sh
   source "${PI_HOLE_SCRIPT_DIR}"/piholeCheckout.sh
   shift
   checkout "$@"

--- a/pihole
+++ b/pihole
@@ -20,6 +20,18 @@ PI_HOLE_BIN_DIR="/usr/local/bin"
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
 
+# Ensure there is a newline at the end of the file passed as argument
+ensure_newline() {
+  # Check if the last line of the passed file is empty, if not, append a newline
+  # to the file to ensure we can append new content safely using echo "" >>
+  # later on
+  [ -n "$(tail -c1 "${1}")" ] && printf '\n' >> "${1}"
+  # There was also the suggestion of using a sed-magic call here, however, this
+  # had the drawback to updating all the file timestamps whenever the sed was
+  # run. This solution only updates the timestamp when actually appending a
+  # newline
+}
+
 webpageFunc() {
   source "${PI_HOLE_SCRIPT_DIR}/webpage.sh"
   main "$@"
@@ -191,6 +203,7 @@ Time:
 
       local str="Pi-hole Disabled"
       sed -i "/BLOCKING_ENABLED=/d" "${setupVars}"
+      ensure_newline "${setupVars}"
       echo "BLOCKING_ENABLED=false" >> "${setupVars}"
     fi
   else
@@ -204,6 +217,7 @@ Time:
     local str="Pi-hole Enabled"
 
     sed -i "/BLOCKING_ENABLED=/d" "${setupVars}"
+    ensure_newline "${setupVars}"
     echo "BLOCKING_ENABLED=true" >> "${setupVars}"
   fi
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Ensure critical config lines have trailing newlines before appending new content. This is guaranteed by our scripts, however, it is not guaranteed any longer when users manually edited config files themselves.

**How does this PR accomplish the above?:**

Ensure the files are okay to work with before adding anything to them by checking them with:
``` bash
[ -n "$(tail -c1 "${1}")" ] && printf '\n' >> "${1}"
```

**What documentation changes (if any) are needed to support this PR?:**

None