### PR TITLE
Fix release check for centos stream

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -408,7 +408,7 @@ elif is_command rpm ; then
         SUPPORTED_CENTOS_VERSION=7
         SUPPORTED_CENTOS_PHP_VERSION=7
         # Check current CentOS major release version
-        CURRENT_CENTOS_VERSION=$(grep -oP '(?<= )[0-9]+(?=\.)' /etc/redhat-release)
+        CURRENT_CENTOS_VERSION=$(grep -oP '(?<= )[0-9]+(?=\.?)' /etc/redhat-release)
         # Check if CentOS version is supported
         if [[ $CURRENT_CENTOS_VERSION -lt $SUPPORTED_CENTOS_VERSION ]]; then
             printf "  %b CentOS %s is not supported.\\n" "${CROSS}" "${CURRENT_CENTOS_VERSION}"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
---
**What does this PR aim to accomplish?:**
Ensure `CURRENT_CENTOS_VERSION` variable is populated when installed on CentOS Stream

**How does this PR accomplish the above?:**
Add conditional for `.` on the lookback anchor.

**What documentation changes (if any) are needed to support this PR?:**
N/A

Test Examples:

old:
```
[root@localhost ~]# cat /etc/redhat-release 
CentOS Stream release 8
[root@localhost ~]# grep -oP '(?<= )[0-9]+(?=\.)' /etc/redhat-release
[root@localhost ~]# 
```

new:
```
[root@localhost ~]# cat /etc/redhat-release 
CentOS Stream release 8
[root@localhost ~]# grep -oP '(?<= )[0-9]+(?=\.?)' /etc/redhat-release
8
[root@localhost ~]#
```

CentOS 8.x regression check:
```
[root@centos8 ~]# cat /etc/redhat-release
CentOS Linux release 8.2.2004 (Core) 
[root@centos8 ~]# grep -oP '(?<= )[0-9]+(?=\.?)' /etc/redhat-release
8
[root@centos8 ~]#
```