### PR TITLE
Add hostname to teleporter backup file if called from cli

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -640,7 +640,7 @@ Teleporter() {
     datetimestamp=$(date "+%Y-%m-%d_%H-%M-%S")
     host=$(hostname)
     host="${host//./_}"
-    php /var/www/html/admin/scripts/pi-hole/php/teleporter.php > "pi-hole-${host}-teleporter_${datetimestamp}.tar.gz"
+    php /var/www/html/admin/scripts/pi-hole/php/teleporter.php > "pi-hole-${host:-noname}-teleporter_${datetimestamp}.tar.gz"
 }
 
 checkDomain()

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -238,18 +238,18 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
         #          168.192.in-addr.arpa to 192.168.0.0/16
         #          192.in-addr.arpa to 192.0.0.0/8
         if [[ "${CONDITIONAL_FORWARDING_REVERSE}" == *"in-addr.arpa" ]];then
-            arrRev=("${CONDITIONAL_FORWARDING_REVERSE//./ }")        
-            case ${#arrRev[@]} in 
+            arrRev=("${CONDITIONAL_FORWARDING_REVERSE//./ }")
+            case ${#arrRev[@]} in
                 6   )   REV_SERVER_CIDR="${arrRev[3]}.${arrRev[2]}.${arrRev[1]}.${arrRev[0]}/32";;
                 5   )   REV_SERVER_CIDR="${arrRev[2]}.${arrRev[1]}.${arrRev[0]}.0/24";;
                 4   )   REV_SERVER_CIDR="${arrRev[1]}.${arrRev[0]}.0.0/16";;
-                3   )   REV_SERVER_CIDR="${arrRev[0]}.0.0.0/8";; 
+                3   )   REV_SERVER_CIDR="${arrRev[0]}.0.0.0/8";;
             esac
         else
           # Set REV_SERVER_CIDR to whatever value it was set to
           REV_SERVER_CIDR="${CONDITIONAL_FORWARDING_REVERSE}"
         fi
-        
+
         # If REV_SERVER_CIDR is not converted by the above, then use the REV_SERVER_TARGET variable to derive it
         if [ -z "${REV_SERVER_CIDR}" ]; then
             # Convert existing input to /24 subnet (preserves legacy behavior)
@@ -636,8 +636,11 @@ Interfaces:
 
 Teleporter() {
     local datetimestamp
+    local host
     datetimestamp=$(date "+%Y-%m-%d_%H-%M-%S")
-    php /var/www/html/admin/scripts/pi-hole/php/teleporter.php > "pi-hole-teleporter_${datetimestamp}.tar.gz"
+    host=$(hostname)
+    host="${host//./_}"
+    php /var/www/html/admin/scripts/pi-hole/php/teleporter.php > "pi-hole-${host}-teleporter_${datetimestamp}.tar.gz"
 }
 
 checkDomain()


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
Add the `hostname` to the teleporter backup file if called via cli (`pihole -a -t`). Same behavior as the web interface

https://github.com/pi-hole/AdminLTE/pull/1417


**How does this PR accomplish the above?:**
Include the hostname in the filename. Replaces all `.` with `_` as in https://github.com/pi-hole/AdminLTE/pull/1517


**What documentation changes (if any) are needed to support this PR?:**
None.

Fixes https://github.com/pi-hole/pi-hole/issues/4048

Before
`-rw-r--r-- 1 root   root   4.8K Feb 11 17:20 pi-hole-teleporter_2021-02-11_17-20-00.tar.gz`

After

`-rw-r--r-- 1 root   root   4.8K Feb 11 19:44 pi-hole-rockpi-4b-teleporter_2021-02-11_19-44-48.tar.gz`

