### PR TITLE
Obtain FTL's PID from the PID file

### DIFF
--- a/pihole
+++ b/pihole
@@ -108,25 +108,14 @@ getFTLPID() {
     pid="$(<"$FTL_PID_FILE")"
     # Verify that the value read from the file is numeric
     if [[ "$pid" =~ [^[:digit:]] ]]; then
-      # If no, unset the variable so we use pgrep in the next step
+      # Exploit prevention: unset the variable if there is malicious content
       pid=
     fi
   fi
 
-  # If no PID file is available, try to get a PID from pgrep
-  if [ -z "$pid" ]; then
-    # Use --oldest to get the main process of FTL (all TCP workers are created
-    # after the main process has been started)
-    pid="$(pgrep --oldest pihole-FTL)"
-  fi
-
-  # If we still have no PID, FTL is not running, substitute negative PID to
-  # signal this to the caller
-  if [ -z "$pid" ]; then
-    pid="-1"
-  fi
-
-  echo "$pid"
+  # If FTL is not running, or the PID file contains malicious stuff, substitute
+  # negative PID to signal this to the caller
+  echo "${pid:=-1}"
 }
 
 restartDNS() {

--- a/pihole
+++ b/pihole
@@ -16,6 +16,7 @@ readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 # error due to modifying a readonly variable.
 setupVars="/etc/pihole/setupVars.conf"
 PI_HOLE_BIN_DIR="/usr/local/bin"
+readonly FTL_PID="/run/pihole-FTL.pid"
 
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
@@ -98,8 +99,38 @@ versionFunc() {
   exit 0
 }
 
+# Get PID of main pihole-FTL process
+getFTLPID() {
+  local pid
+
+  if [ -s "${FTL_PID}" ]; then
+    # -s: FILE exists and has a size greater than zero
+    pid="$(<"$FTL_PID")"
+    # Verify that the value read from the file is numeric
+    if [[ "$pid" =~ [^[:digit:]] ]]; then
+      # If no, unset the variable so we use pgrep in the next step
+      pid=
+    fi
+  fi
+
+  # If no PID file is available, try to get a PID from pgrep
+  if [ -z "$pid" ]; then
+    # Use --oldest to get the main process of FTL (all TCP workers are created
+    # after the main process has been started)
+    pid="$(pgrep --oldest pihole-FTL)"
+  fi
+
+  # If we still have no PID, FTL is not running, substitute negative PID to
+  # signal this to the caller
+  if [ -z "$pid" ]; then
+    pid="-1"
+  fi
+
+  echo "$pid"
+}
+
 restartDNS() {
-  local svcOption svc str output status
+  local svcOption svc str output status pid icon
   svcOption="${1:-restart}"
 
   # Determine if we should reload or restart
@@ -108,17 +139,34 @@ restartDNS() {
     # Note 1: This will NOT re-read any *.conf files
     # Note 2: We cannot use killall here as it does
     #         not know about real-time signals
-    svc="pkill -RTMIN pihole-FTL"
-    str="Reloading DNS lists"
+    pid="$(getFTLPID)"
+    if [[ "$pid" -eq "-1" ]]; then
+      svc="true"
+      str="FTL is not running"
+      icon="${INFO}"
+    else
+      svc="kill -RTMIN ${pid}"
+      str="Reloading DNS lists"
+      icon="${TICK}"
+    fi
   elif [[ "${svcOption}" =~ "reload" ]]; then
     # Reloading of the DNS cache has been requested
     # Note: This will NOT re-read any *.conf files
-    svc="pkill -HUP pihole-FTL"
-    str="Flushing DNS cache"
+    pid="$(getFTLPID)"
+    if [[ "$pid" -eq "-1" ]]; then
+      svc="true"
+      str="FTL is not running"
+      icon="${INFO}"
+    else
+      svc="kill -HUP ${pid}"
+      str="Flushing DNS cache"
+      icon="${TICK}"
+    fi
   else
     # A full restart has been requested
     svc="service pihole-FTL restart"
     str="Restarting DNS server"
+    icon="${TICK}"
   fi
 
   # Print output to Terminal, but not to Web Admin
@@ -128,7 +176,7 @@ restartDNS() {
   status="$?"
 
   if [[ "${status}" -eq 0 ]]; then
-    [[ -t 1 ]] && echo -e "${OVER}  ${TICK} ${str}"
+    [[ -t 1 ]] && echo -e "${OVER}  ${icon} ${str}"
     return 0
   else
     [[ ! -t 1 ]] && local OVER=""

--- a/pihole
+++ b/pihole
@@ -16,7 +16,7 @@ readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 # error due to modifying a readonly variable.
 setupVars="/etc/pihole/setupVars.conf"
 PI_HOLE_BIN_DIR="/usr/local/bin"
-readonly FTL_PID="/run/pihole-FTL.pid"
+readonly FTL_PID_FILE="/run/pihole-FTL.pid"
 
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 source "${colfile}"
@@ -103,9 +103,9 @@ versionFunc() {
 getFTLPID() {
   local pid
 
-  if [ -s "${FTL_PID}" ]; then
+  if [ -s "${FTL_PID_FILE}" ]; then
     # -s: FILE exists and has a size greater than zero
-    pid="$(<"$FTL_PID")"
+    pid="$(<"$FTL_PID_FILE")"
     # Verify that the value read from the file is numeric
     if [[ "$pid" =~ [^[:digit:]] ]]; then
       # If no, unset the variable so we use pgrep in the next step

--- a/pihole
+++ b/pihole
@@ -108,7 +108,7 @@ getFTLPID() {
     pid="$(<"$FTL_PID_FILE")"
     # Exploit prevention: unset the variable if there is malicious content
     # Verify that the value read from the file is numeric
-    [[ "$pid" =~ [^[:digit:]] ]] && pid=
+    [[ "$pid" =~ [^[:digit:]] ]] && unset pid
   fi
 
   # If FTL is not running, or the PID file contains malicious stuff, substitute

--- a/pihole
+++ b/pihole
@@ -106,11 +106,9 @@ getFTLPID() {
   if [ -s "${FTL_PID_FILE}" ]; then
     # -s: FILE exists and has a size greater than zero
     pid="$(<"$FTL_PID_FILE")"
+    # Exploit prevention: unset the variable if there is malicious content
     # Verify that the value read from the file is numeric
-    if [[ "$pid" =~ [^[:digit:]] ]]; then
-      # Exploit prevention: unset the variable if there is malicious content
-      pid=
-    fi
+    [[ "$pid" =~ [^[:digit:]] ]] && pid=
   fi
 
   # If FTL is not running, or the PID file contains malicious stuff, substitute


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Obtain FTL's PID from the PID file instead of relying on `pkill` finding the right process by itself. This allows the script to work in even when FTL is running inside the memory checker `valgrind`.

**How does this PR accomplish the above?:**

Try to obtain FTL's PID from the PID file. If this fails, try to identify the main process using `pgrep --oldest`. If this fails as well, we can safely assume FTL is not running and should show a hint instead of throwing an error.

**What documentation changes (if any) are needed to support this PR?:**

None