### PR TITLE
Delete Firefox canary gravity from gravity table

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -104,6 +104,23 @@ gravity_swap_databases() {
   fi
   echo -e "${OVER}  ${TICK} ${str}"
 
+  # Deleting the canary domain from the gravity table is fast after having created the INDEX above
+  # This prevens Firefox from automatically switching over to DNS-over-HTTPS
+  # This follows https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https
+  # (sourced 7th September 2019)
+  str="Post-processing gravity table"
+  echo -ne "  ${INFO} ${str}..."
+
+  output=$( { sqlite3 "${gravityTEMPfile}" "DELETE FROM gravity WHERE domain = 'use-application-dns.net'"; } 2>&1 )
+  status="$?"
+
+  # We still continue on error here, it is not fatal
+  if [[ "${status}" -ne 0 ]]; then
+    echo -e "\\n  ${CROSS} Unable to post-process gravity table in ${gravityTEMPfile}\\n  ${output}"
+  else
+    echo -e "${OVER}  ${TICK} ${str}"
+  fi
+
   str="Swapping databases"
   echo -ne "  ${INFO} ${str}..."
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Prevent blocking lists from being able to re-enable DoH for Firefox.

**How does this PR accomplish the above?:**

I do consider this a bug fix.

Remove canary domain `use-application-dns.net` from gravity list when one of the adlists contain it. This ensures DoH blocking works by default and that it can still be re-enabled by blacklisting the domain explicitly.

**What documentation changes (if any) are needed to support this PR?:**

None