### PR TITLE
Return lighttpd access log format to default

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -35,7 +35,7 @@ server.username             = "www-data"
 server.groupname            = "www-data"
 server.port                 = 80
 accesslog.filename          = "/var/log/lighttpd/access.log"
-accesslog.format            = "%{%s}t|%V|%r|%s|%b"
+accesslog.format            = "%h %V %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\""
 
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny             = ( "~", ".inc", ".md", ".yml", ".ini" )

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -36,7 +36,7 @@ server.username             = "lighttpd"
 server.groupname            = "lighttpd"
 server.port                 = 80
 accesslog.filename          = "/var/log/lighttpd/access.log"
-accesslog.format            = "%{%s}t|%V|%r|%s|%b"
+accesslog.format            = "%h %V %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\""
 
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny             = ( "~", ".inc", ".md", ".yml", ".ini" )


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Returns the lighttpd access log format to its default, as that is most compatible with other programs and cannot be overridden in external.conf. 
Further discussion in #4110


**How does this PR accomplish the above?:**
Changes the format config from "%{%s}t|%V|%r|%s|%b" (old format, only compatible with Logstalgia) to "%h %V %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" (default format, compatible with just about everything, including Logstalgia) in both lighttpd.conf files.


**What documentation changes (if any) are needed to support this PR?:**
No anticipated changes, Logstalgia (the original reason of implementation) handles the default format fine now.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
