### PR TITLE
Read local.list IPs from "ip a" not setupVars.conf

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -47,16 +47,6 @@ domainsExtension="domains"
 setupVars="${piholeDir}/setupVars.conf"
 if [[ -f "${setupVars}" ]];then
   source "${setupVars}"
-
-  # Remove CIDR mask from IPv4/6 addresses
-  IPV4_ADDRESS="${IPV4_ADDRESS%/*}"
-  IPV6_ADDRESS="${IPV6_ADDRESS%/*}"
-
-  # Determine if IPv4/6 addresses exist
-  if [[ -z "${IPV4_ADDRESS}" ]] && [[ -z "${IPV6_ADDRESS}" ]]; then
-    echo -e "  ${COL_LIGHT_RED}No IP addresses found! Please run 'pihole -r' to reconfigure${COL_NC}"
-    exit 1
-  fi
 else
   echo -e "  ${COL_LIGHT_RED}Installation Failure: ${setupVars} does not exist! ${COL_NC}
   Please run 'pihole -r', and choose the 'reconfigure' option to fix."
@@ -564,7 +554,7 @@ compareLists() {
 # Download specified URL and perform checks on HTTP status and file content
 gravity_DownloadBlocklistFromUrl() {
   local url="${1}" cmd_ext="${2}" agent="${3}" adlistID="${4}" saveLocation="${5}" target="${6}" compression="${7}"
-  local heisenbergCompensator="" patternBuffer str httpCode success=""
+  local heisenbergCompensator="" patternBuffer str httpCode success="" ip
 
   # Create temp file to store content on disk instead of RAM
   patternBuffer=$(mktemp -p "/tmp" --suffix=".phgpb")
@@ -582,7 +572,10 @@ gravity_DownloadBlocklistFromUrl() {
   blocked=false
   case $BLOCKINGMODE in
     "IP-NODATA-AAAA"|"IP")
-        if [[ $(dig "${domain}" +short | grep "${IPV4_ADDRESS}" -c) -ge 1 ]]; then
+        # Get IP address of this domain
+        ip="$(dig "${domain}" +short)"
+        # Check if this IP matches any IP of the system
+        if [[ -n "${ip}" && $(grep -Ec "inet(|6) ${ip}" <<< "$(ip a)") -gt 0 ]]; then
           blocked=true
         fi;;
     "NXDOMAIN")
@@ -785,26 +778,11 @@ gravity_ShowCount() {
   gravity_Table_Count "vw_regex_whitelist" "regex whitelist filters"
 }
 
-# Parse list of domains into hosts format
-gravity_ParseDomainsIntoHosts() {
-  awk -v ipv4="$IPV4_ADDRESS" -v ipv6="$IPV6_ADDRESS" '{
-    # Remove windows CR line endings
-    sub(/\r$/, "")
-    # Parse each line as "ipaddr domain"
-    if(ipv6 && ipv4) {
-      print ipv4" "$0"\n"ipv6" "$0
-    } else if(!ipv6) {
-      print ipv4" "$0
-    } else {
-      print ipv6" "$0
-    }
-  }' >> "${2}" < "${1}"
-}
-
-# Create "localhost" entries into hosts format
+# Add additional LAN hosts provided by OpenVPN (if available)
 gravity_generateLocalList() {
-  local hostname
+  local addresses hostname
 
+  # Get hostname of this system
   if [[ -s "/etc/hostname" ]]; then
     hostname=$(< "/etc/hostname")
   elif command -v hostname &> /dev/null; then
@@ -814,13 +792,25 @@ gravity_generateLocalList() {
     return 0
   fi
 
-  echo -e "${hostname}\\npi.hole" > "${localList}.tmp"
-
   # Empty $localList if it already exists, otherwise, create it
   : > "${localList}"
   chmod 644 "${localList}"
+  echo "### Do not modify this file, it will be overwritten by pihole -g" > "${localList}"
 
-  gravity_ParseDomainsIntoHosts "${localList}.tmp" "${localList}"
+  # Get addresses of currently active interfaces
+  # sed logic breakdown:
+  #     /inet(|6) /!d;
+  #          Removes all lines from ip a that do not contain either "inet " or "inet6 "
+  #     s/^.*inet(|6) //g;
+  #          Removes all leading whitespace as well as the "inet " or "inet6 " string
+  #     s/\/.*$//g;
+  #          Removes CIDR and everything thereafter (e.g., scope properties)
+  addresses="$(sed -r '/inet(|6) /!d;s/^.*inet(|6) //g;s/\/.*$//g;' <<< "$(ip a)")"
+
+  while IFS= read -r addr ; do
+    echo "${addr} ${hostname}" >> "${localList}";
+    echo "${addr} pi.hole" >> "${localList}";
+  done <<< "${addresses}"
 
   # Add additional LAN hosts provided by OpenVPN (if available)
   if [[ -f "${VPNList}" ]]; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix a bug reported on Discourse (see below).

**How does this PR accomplish the above?:**

Instead of relying on the correct IP address being in `setupVars.conf`, we should add all available addresses to `local.list`. FTL uses the option `localise-queries` that will pick the most appropriate one (arriving interface dependent) for the requesting client.

**What documentation changes (if any) are needed to support this PR?:**

None