### PR TITLE
Enable PHP8 support for Debian/Ubuntu

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -360,7 +360,11 @@ if is_command apt-get ; then
     PIHOLE_DEPS=(cron curl iputils-ping lsof netcat psmisc sudo unzip wget idn2 sqlite3 libcap2-bin dns-root-data libcap2)
     # Packages required for the Web admin interface (stored as an array)
     # It's useful to separate this from Pi-hole, since the two repos are also setup separately
-    PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-json" "${phpVer}-intl")
+    PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-intl")
+    # Prior to PHP8.0, JSON functionality is provided as dedicated module, required by Pi-hole AdminLTE: https://www.php.net/manual/json.installation.php
+    if [[ "${phpInsNewer}" != true || "${phpInsMajor}" -lt 8 ]]; then
+        PIHOLE_WEB_DEPS+=("${phpVer}-json")
+    fi
     # The Web server user,
     LIGHTTPD_USER="www-data"
     # group,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Since PHP8.0, the JSON extension is a core PHP extension and hence the php8.0-json package does not exist and is not required:
- https://www.php.net/manual/json.installation.php
- https://packages.debian.org/php8.0-json

Solves: https://discourse.pi-hole.net/t/php-8-packages-not-found/46286

**How does this PR accomplish the above?:**
If an installed PHP version has been detected and it's major version is 8 or higher, the JSON module package is not added to web dependencies.

This only affects Debian/Ubuntu installs. On RPM-based distributions no pre-installed PHP versions are detected, instead conditional dependencies are done based on distro and version. E.g. until CentOS 7, the JSON module was compiled into the PHP core package as implementation peculiarity, changed with CentOS 8: https://github.com/pi-hole/pi-hole/pull/3066

This does not effect the case where stable Debian or Ubuntu releases use PHP8. Debian Bullseye however uses PHP7.4 and is in version freeze already and all current Ubuntu versions do aas well, especially the current LTS focal. It is assumed that Pi-hole v6 will be released long before a Debian release or Ubuntu LTS will ship PHP8 or higher, making a long-term PHP8-compatibility obsolete.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.