### PR TITLE
Discourage inexperienced users to purge dependencies on uninstall

### DIFF
--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -72,7 +72,7 @@ fi
 
 removeAndPurge() {
     # Purge dependencies
-    echo ""
+    echo -e "  ${INFO} ${COL_YELLOW}We strongly recommend leaving packages installed you are unsure about, as usually required system packages are among them!${COL_NC}"
     for i in "${DEPS[@]}"; do
         if package_check "${i}" > /dev/null; then
             while true; do
@@ -206,11 +206,6 @@ removeNoPurge() {
 }
 
 ######### SCRIPT ###########
-if command -v vcgencmd &> /dev/null; then
-    echo -e "  ${INFO} All dependencies are safe to remove on Raspbian"
-else
-    echo -e "  ${INFO} Be sure to confirm if any dependencies should not be removed"
-fi
 while true; do
     echo -e "  ${INFO} ${COL_YELLOW}The following dependencies may have been added by the Pi-hole install:"
     echo -n "    "
@@ -218,10 +213,10 @@ while true; do
         echo -n "${i} "
     done
     echo "${COL_NC}"
-    read -rp "  ${QST} Do you wish to go through each dependency for removal? (Choosing No will leave all dependencies installed) [Y/n] " yn
+    read -rp "  ${QST} Do you wish to go through each dependency for removal? (Recommended is \"No\" unless you're certain which package you no longer need) [y/N] " yn
     case ${yn} in
         [Yy]* ) removeAndPurge; break;;
         [Nn]* ) removeNoPurge; break;;
-        * ) removeAndPurge; break;;
+        * ) removeNoPurge; break;;
     esac
 done


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
For reference: https://github.com/pi-hole/pi-hole/issues/3929

The ability to loop through packages for removal, and the statement "All dependencies are safe to remove on Raspbian" has been added at a time where a much smaller list of dependencies were installed, all indeed relatively safe to purge. Nowadays this list has grown and includes important system packages, like iproute2, psmisc, sudo, curl and others, which are often again dependencies of other packages, like network stacks (ifupdown) and others, so that inexperienced users, following that statement, may break their systems network capabilities and more.

**How does this PR accomplish the above?:**
The outdated info message has hence been removed, replaced with a recommendation to not remove packages, and the default answer, whether to loop through packages or not, has been changed to "No" accordingly. When "Yes" was still selected, a more prominent "yellow" message is printed to repeat that recommendation for individual packages as well, when the user is uncertain.

**What documentation changes (if any) are needed to support this PR?:**
None


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.