### PR TITLE
Remove false statement about dependency removal on Raspbian

### DIFF
--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -206,11 +206,7 @@ removeNoPurge() {
 }
 
 ######### SCRIPT ###########
-if command -v vcgencmd &> /dev/null; then
-    echo -e "  ${INFO} All dependencies are safe to remove on Raspbian"
-else
-    echo -e "  ${INFO} Be sure to confirm if any dependencies should not be removed"
-fi
+echo -e "  ${INFO} Be sure to confirm if any dependencies should not be removed"
 while true; do
     echo -e "  ${INFO} ${COL_YELLOW}The following dependencies may have been added by the Pi-hole install:"
     echo -n "    "


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
The statement "All dependencies are safe to remove on Raspbian" has been added at a time where a much smaller list of dependencies were installed, all indeed relatively safe to purge. Nowadays this list has grown and includes important system packages, like iproute2, psmisc, sudo, curl and others, which are often again dependencies of other packages, like network stacks (ifupdown) and others, so that inexperienced users, following that statement, may break their systems network capabilities and more.

**How does this PR accomplish the above?:**
This message has hence been removed.


**What documentation changes (if any) are needed to support this PR?:**
None

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.