### PR TITLE
Add tail of pihole.log to debug output

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1325,8 +1325,9 @@ analyze_pihole_log() {
   local pihole_log_head=()
   local pihole_log_tail=()
   local pihole_log_permissions
+  local logging_enabled
 
-  local logging_enabled=$(grep -c "^log-queries" /etc/dnsmasq.d/01-pihole.conf)
+  logging_enabled=$(grep -c "^log-queries" /etc/dnsmasq.d/01-pihole.conf)
   if [[ "${logging_enabled}" == "0" ]]; then
       # Inform user that logging has been disabled and pihole.log does not contain queries
       log_write "${INFO} Query logging is disabled"

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1281,53 +1281,64 @@ analyze_gravity_list() {
     IFS="$OLD_IFS"
 }
 
+obfuscated_pihole_log() {
+  local pihole_log=("$@")
+  local line
+  local error_to_check_for
+  local line_to_obfuscate
+  local obfuscated_line
+  for line in "${pihole_log[@]}"; do
+      # A common error in the pihole.log is when there is a non-hosts formatted file
+      # that the DNS server is attempting to read.  Since it's not formatted
+      # correctly, there will be an entry for "bad address at line n"
+      # So we can check for that here and highlight it in red so the user can see it easily
+      error_to_check_for=$(echo "${line}" | grep 'bad address at')
+      # Some users may not want to have the domains they visit sent to us
+      # To that end, we check for lines in the log that would contain a domain name
+      line_to_obfuscate=$(echo "${line}" | grep ': query\|: forwarded\|: reply')
+      # If the variable contains a value, it found an error in the log
+      if [[ -n ${error_to_check_for} ]]; then
+          # So we can print it in red to make it visible to the user
+          log_write "   ${CROSS} ${COL_RED}${head_line}${COL_NC} (${FAQ_BAD_ADDRESS})"
+      else
+          # If the variable does not a value (the current default behavior), so do not obfuscate anything
+          if [[ -z ${OBFUSCATE} ]]; then
+              log_write "   ${line}"
+          # Othwerise, a flag was passed to this command to obfuscate domains in the log
+          else
+              # So first check if there are domains in the log that should be obfuscated
+              if [[ -n ${line_to_obfuscate} ]]; then
+                  # If there are, we need to use awk to replace only the domain name (the 6th field in the log)
+                  # so we substitute the domain for the placeholder value
+                  obfuscated_line=$(echo "${line_to_obfuscate}" | awk -v placeholder="${OBFUSCATED_PLACEHOLDER}" '{sub($6,placeholder); print $0}')
+                  log_write "   ${obfuscated_line}"
+              else
+                  log_write "   ${line}"
+              fi
+          fi
+      fi
+  done
+}
+
 analyze_pihole_log() {
     echo_current_diagnostic "Pi-hole log"
-    local head_line
+    local pihole_log_head=()
+    local pihole_log_tail=()
+    local pihole_log_permissions
+
     # Put the current Internal Field Separator into another variable so it can be restored later
     OLD_IFS="$IFS"
     # Get the lines that are in the file(s) and store them in an array for parsing later
     IFS=$'\r\n'
-    local pihole_log_permissions
     pihole_log_permissions=$(ls -ld "${PIHOLE_LOG}")
     log_write "${COL_GREEN}${pihole_log_permissions}${COL_NC}"
-    local pihole_log_head=()
     mapfile -t pihole_log_head < <(head -n 20 ${PIHOLE_LOG})
     log_write "   ${COL_CYAN}-----head of $(basename ${PIHOLE_LOG})------${COL_NC}"
-    local error_to_check_for
-    local line_to_obfuscate
-    local obfuscated_line
-    for head_line in "${pihole_log_head[@]}"; do
-        # A common error in the pihole.log is when there is a non-hosts formatted file
-        # that the DNS server is attempting to read.  Since it's not formatted
-        # correctly, there will be an entry for "bad address at line n"
-        # So we can check for that here and highlight it in red so the user can see it easily
-        error_to_check_for=$(echo "${head_line}" | grep 'bad address at')
-        # Some users may not want to have the domains they visit sent to us
-        # To that end, we check for lines in the log that would contain a domain name
-        line_to_obfuscate=$(echo "${head_line}" | grep ': query\|: forwarded\|: reply')
-        # If the variable contains a value, it found an error in the log
-        if [[ -n ${error_to_check_for} ]]; then
-            # So we can print it in red to make it visible to the user
-            log_write "   ${CROSS} ${COL_RED}${head_line}${COL_NC} (${FAQ_BAD_ADDRESS})"
-        else
-            # If the variable does not a value (the current default behavior), so do not obfuscate anything
-            if [[ -z ${OBFUSCATE} ]]; then
-                log_write "   ${head_line}"
-            # Othwerise, a flag was passed to this command to obfuscate domains in the log
-            else
-                # So first check if there are domains in the log that should be obfuscated
-                if [[ -n ${line_to_obfuscate} ]]; then
-                    # If there are, we need to use awk to replace only the domain name (the 6th field in the log)
-                    # so we substitute the domain for the placeholder value
-                    obfuscated_line=$(echo "${line_to_obfuscate}" | awk -v placeholder="${OBFUSCATED_PLACEHOLDER}" '{sub($6,placeholder); print $0}')
-                    log_write "   ${obfuscated_line}"
-                else
-                    log_write "   ${head_line}"
-                fi
-            fi
-        fi
-    done
+    obfuscated_pihole_log "${pihole_log_head[@]}"
+    log_write ""
+    mapfile -t pihole_log_tail < <(tail -n 20 ${PIHOLE_LOG})
+    log_write "   ${COL_CYAN}-----tail of $(basename ${PIHOLE_LOG})------${COL_NC}"
+    obfuscated_pihole_log "${pihole_log_tail[@]}"
     log_write ""
     # Set the IFS back to what it was
     IFS="$OLD_IFS"

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1328,27 +1328,26 @@ analyze_pihole_log() {
 
   local logging_enabled=$(grep -c "^log-queries" /etc/dnsmasq.d/01-pihole.conf)
   if [[ "${logging_enabled}" == "0" ]]; then
-      # No "log-queries" lines are found.
-      # Commented out lines (such as "#log-queries") are ignored
+      # Inform user that logging has been disabled and pihole.log does not contain queries
       log_write "${INFO} Query logging is disabled"
-  else
-      # Put the current Internal Field Separator into another variable so it can be restored later
-      OLD_IFS="$IFS"
-      # Get the lines that are in the file(s) and store them in an array for parsing later
-      IFS=$'\r\n'
-      pihole_log_permissions=$(ls -ld "${PIHOLE_LOG}")
-      log_write "${COL_GREEN}${pihole_log_permissions}${COL_NC}"
-      mapfile -t pihole_log_head < <(head -n 20 ${PIHOLE_LOG})
-      log_write "   ${COL_CYAN}-----head of $(basename ${PIHOLE_LOG})------${COL_NC}"
-      obfuscated_pihole_log "${pihole_log_head[@]}"
       log_write ""
-      mapfile -t pihole_log_tail < <(tail -n 20 ${PIHOLE_LOG})
-      log_write "   ${COL_CYAN}-----tail of $(basename ${PIHOLE_LOG})------${COL_NC}"
-      obfuscated_pihole_log "${pihole_log_tail[@]}"
-      log_write ""
-      # Set the IFS back to what it was
-      IFS="$OLD_IFS"
   fi
+  # Put the current Internal Field Separator into another variable so it can be restored later
+  OLD_IFS="$IFS"
+  # Get the lines that are in the file(s) and store them in an array for parsing later
+  IFS=$'\r\n'
+  pihole_log_permissions=$(ls -ld "${PIHOLE_LOG}")
+  log_write "${COL_GREEN}${pihole_log_permissions}${COL_NC}"
+  mapfile -t pihole_log_head < <(head -n 20 ${PIHOLE_LOG})
+  log_write "   ${COL_CYAN}-----head of $(basename ${PIHOLE_LOG})------${COL_NC}"
+  obfuscated_pihole_log "${pihole_log_head[@]}"
+  log_write ""
+  mapfile -t pihole_log_tail < <(tail -n 20 ${PIHOLE_LOG})
+  log_write "   ${COL_CYAN}-----tail of $(basename ${PIHOLE_LOG})------${COL_NC}"
+  obfuscated_pihole_log "${pihole_log_tail[@]}"
+  log_write ""
+  # Set the IFS back to what it was
+  IFS="$OLD_IFS"
 }
 
 tricorder_use_nc_or_curl() {

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1321,27 +1321,34 @@ obfuscated_pihole_log() {
 }
 
 analyze_pihole_log() {
-    echo_current_diagnostic "Pi-hole log"
-    local pihole_log_head=()
-    local pihole_log_tail=()
-    local pihole_log_permissions
+  echo_current_diagnostic "Pi-hole log"
+  local pihole_log_head=()
+  local pihole_log_tail=()
+  local pihole_log_permissions
 
-    # Put the current Internal Field Separator into another variable so it can be restored later
-    OLD_IFS="$IFS"
-    # Get the lines that are in the file(s) and store them in an array for parsing later
-    IFS=$'\r\n'
-    pihole_log_permissions=$(ls -ld "${PIHOLE_LOG}")
-    log_write "${COL_GREEN}${pihole_log_permissions}${COL_NC}"
-    mapfile -t pihole_log_head < <(head -n 20 ${PIHOLE_LOG})
-    log_write "   ${COL_CYAN}-----head of $(basename ${PIHOLE_LOG})------${COL_NC}"
-    obfuscated_pihole_log "${pihole_log_head[@]}"
-    log_write ""
-    mapfile -t pihole_log_tail < <(tail -n 20 ${PIHOLE_LOG})
-    log_write "   ${COL_CYAN}-----tail of $(basename ${PIHOLE_LOG})------${COL_NC}"
-    obfuscated_pihole_log "${pihole_log_tail[@]}"
-    log_write ""
-    # Set the IFS back to what it was
-    IFS="$OLD_IFS"
+  local logging_enabled=$(grep -c "^log-queries" /etc/dnsmasq.d/01-pihole.conf)
+  if [[ "${logging_enabled}" == "0" ]]; then
+      # No "log-queries" lines are found.
+      # Commented out lines (such as "#log-queries") are ignored
+      log_write "${INFO} Query logging is disabled"
+  else
+      # Put the current Internal Field Separator into another variable so it can be restored later
+      OLD_IFS="$IFS"
+      # Get the lines that are in the file(s) and store them in an array for parsing later
+      IFS=$'\r\n'
+      pihole_log_permissions=$(ls -ld "${PIHOLE_LOG}")
+      log_write "${COL_GREEN}${pihole_log_permissions}${COL_NC}"
+      mapfile -t pihole_log_head < <(head -n 20 ${PIHOLE_LOG})
+      log_write "   ${COL_CYAN}-----head of $(basename ${PIHOLE_LOG})------${COL_NC}"
+      obfuscated_pihole_log "${pihole_log_head[@]}"
+      log_write ""
+      mapfile -t pihole_log_tail < <(tail -n 20 ${PIHOLE_LOG})
+      log_write "   ${COL_CYAN}-----tail of $(basename ${PIHOLE_LOG})------${COL_NC}"
+      obfuscated_pihole_log "${pihole_log_tail[@]}"
+      log_write ""
+      # Set the IFS back to what it was
+      IFS="$OLD_IFS"
+  fi
 }
 
 tricorder_use_nc_or_curl() {


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Adds the tail of `pihole.log` to the debug output. So far only head was used, but sometimes it if necessary to see if `dnsmasq` is still running.


**How does this PR accomplish the above?:**
Takes `obfuscated_pihole_log` function out of `analyze_pihole_log` function and call it once with head and once with tail of `pihole.log`

**What documentation changes (if any) are needed to support this PR?:**
None
