### PR TITLE
Keep old database

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -13,6 +13,7 @@
 # Globals
 piholeDir="/etc/pihole"
 GRAVITYDB="${piholeDir}/gravity.db"
+DBFILE="${piholeDir}/pihole-FTL.db"
 options="$*"
 all=""
 exact=""
@@ -27,6 +28,8 @@ fi
 # Set this only after sourcing pihole-FTL.conf as the gravity database path may
 # have changed
 gravityDBfile="${GRAVITYDB}"
+gravityOLDfile="$(dirname -- "${gravityDBfile}")/gravity_old.db"
+ftlDBfile="${DBFILE}"
 
 colfile="/opt/pihole/COL_TABLE"
 source "${colfile}"
@@ -58,12 +61,70 @@ scanList(){
     esac
 }
 
+# function to count new domain entries since last gravity run
+CountNewDomains() {
+  newdomainentries=$(
+    sqlite3 "/etc/pihole/gravity.db" << EOSQL
+      ATTACH '/etc/pihole/gravity_old.db' AS db2;
+      SELECT count(DISTINCT domain) FROM gravity WHERE domain NOT IN (SELECT domain FROM db2.gravity);
+EOSQL
+      )
+  echo -e "  ${INFO} ${newdomainentries} new domain(s) found."
+  exit 0
+}
+
+# function to find blocked entries in the FTL database,
+# present (new) in the latest (active) gravity database,
+# and NOT present in the old gravity database.
+FindNewBlockedDomains() {
+  # Check if the OLD database exists.
+  if [[ ! -f "${gravityOLDfile}" ]]; then
+    echo -e "  ${CROSS}  Old database ${gravityOLDfile} doesn't exist."
+    exit 1
+  else
+    # Check if the current database is more recent.
+    if [[ $(pihole-FTL "${gravityOLDfile}" "SELECT value FROM info \
+              WHERE property IS 'updated';") \
+        > \
+          $(pihole-FTL "${gravityDBfile}" "SELECT value FROM info \
+              WHERE property IS 'updated';") ]]; then
+      echo -e "  ${CROSS}  Old database ${gravityOLDfile} is more recent."
+      exit 1
+    fi
+    #Run the query
+    resultarray=( $(
+      sqlite3 -separator '  ' "${ftlDBfile}" << EOSQL
+        ATTACH '${gravityDBfile}' AS new;
+        ATTACH '${gravityOLDfile}' AS old;
+        SELECT DISTINCT queries.domain, '(' || adlist.address || ')' FROM queries
+        JOIN gravity ON new.gravity.domain = queries.domain
+        JOIN adlist ON adlist.id = new.gravity.adlist_id
+        WHERE queries.domain NOT IN (SELECT domain FROM old.gravity)
+        AND queries.domain IN (SELECT domain FROM new.gravity)
+        AND queries.status IN (1,9)
+        AND timestamp > (SELECT value FROM new.info WHERE property = 'updated');
+EOSQL
+        ) )
+    if [ ${#resultarray[@]} -eq 0 ]; then
+      echo -e "  ${INFO} No new domains have been blocked yet."
+    else
+      for (( j=0; j<${#resultarray[@]}; j++ )); do
+        echo -e "  ${INFO} Blocked domain: ${resultarray[j]}  (List: ${resultarray[$expr $j + 1]})"
+        j=$(($j + 1))
+      done
+    fi
+  fi
+  exit 0
+}
+
 if [[ "${options}" == "-h" ]] || [[ "${options}" == "--help" ]]; then
     echo "Usage: pihole -q [option] <domain>
 Example: 'pihole -q -exact domain.com'
 Query the adlists for a specified domain
 
 Options:
+  -blocked            List blocked domains since last gravity run
+  -countnew           Count new domain enties since last gravity run
   -exact              Search the block lists for exact domain matches
   -all                Return all query matches within a block list
   -h, --help          Show this help dialog"
@@ -78,6 +139,10 @@ else
     if [[ "${options}" == *"-exact"* ]]; then
         exact="exact"; matchType="exact ${matchType}"
     fi
+    # Count new domain enties since last gravity run
+    [[ "${options}" == *"-countnew"* ]] && CountNewDomains
+    # List blocked domains since last gravity run
+    [[ "${options}" == *"-blocked"* ]] && FindNewBlockedDomains
 fi
 
 # Strip valid options, leaving only the domain and invalid options

--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -64,9 +64,9 @@ scanList(){
 # function to count new domain entries since last gravity run
 CountNewDomains() {
   newdomainentries=$(
-    sqlite3 "/etc/pihole/gravity.db" << EOSQL
-      ATTACH '/etc/pihole/gravity_old.db' AS db2;
-      SELECT count(DISTINCT domain) FROM gravity WHERE domain NOT IN (SELECT domain FROM db2.gravity);
+    sqlite3 "${gravityDBfile}" << EOSQL
+      ATTACH '${gravityOLDfile}' AS old;
+      SELECT count(DISTINCT domain) FROM gravity WHERE domain NOT IN (SELECT domain FROM old.gravity);
 EOSQL
       )
   echo -e "  ${INFO} ${newdomainentries} new domain(s) found."

--- a/gravity.sh
+++ b/gravity.sh
@@ -73,6 +73,7 @@ fi
 # have changed
 gravityDBfile="${GRAVITYDB}"
 gravityTEMPfile="${GRAVITYDB}_temp"
+gravityOLDfile="$(dirname -- "${gravityDBfile}")/gravity_old.db"
 
 if [[ -z "${BLOCKINGMODE}" ]] ; then
   BLOCKINGMODE="NULL"
@@ -123,8 +124,24 @@ gravity_swap_databases() {
   fi
   echo -e "${OVER}  ${TICK} ${str}"
 
-  # Swap databases and remove old database
-  rm "${gravityDBfile}"
+  if [[ -z "${KEEPOLDGRAVITY}" ]] ; then
+    KEEPOLDGRAVITY="true"
+  fi
+
+  # Swap databases and remove or conditionally rename old database
+  # Number of available blocks on disk
+  availableBlocks=$(stat -f --format "%a" $(dirname -- "${gravityDBfile}"))
+  # Number of blocks, used by gravity.db
+  gravityBlocks=$(stat --format "%b" ${gravityDBfile})
+  # Only keep the old database if available disk space is at least twice the size of the existing gravity.db.
+  # Better be safe than sorry...
+  # The variable KEEPOLDGRAVITY in /etc/pihole-FTL.conf can be used to disable this feature.
+  if [ ${availableBlocks} -gt $(expr ${gravityBlocks} \* 2) ] && [ -f "${gravityDBfile}" ] && ${KEEPOLDGRAVITY,,}; then
+    echo -e "  ${TICK} The old database remains available."
+    mv "${gravityDBfile}" "${gravityOLDfile}"
+  else
+    rm "${gravityDBfile}"
+  fi
   mv "${gravityTEMPfile}" "${gravityDBfile}"
 }
 
@@ -872,12 +889,44 @@ gravity_Cleanup() {
   fi
 }
 
+switch_database() {
+  if [[ -f "${gravityOLDfile}" ]]; then
+    gravityOLDversion=$(pihole-FTL "${gravityOLDfile}" "SELECT value FROM info WHERE property IS 'version';")
+    echo -e "  ${TICK}  ${gravityOLDfile} exists."
+  else
+    echo -e "  ${CROSS}  Cannot switch database, ${gravityOLDfile} doesn't exist."
+    exit 1
+  fi
+  if [[ -f "${gravityDBfile}" ]]; then
+    echo -e "  ${TICK}  ${gravityDBfile} exists."
+    if [[ ${gravityOLDversion} -eq $(pihole-FTL "${gravityDBfile}" "SELECT value FROM info WHERE property IS 'version';") ]]; then
+      echo -e "  ${INFO}  Switching database."
+      echo "         current database, updated $(date -d @$(pihole-FTL "${gravityDBfile}" "SELECT value FROM info WHERE property IS 'updated';"))"
+      oldDBdate=$(pihole-FTL "${gravityOLDfile}" "SELECT value FROM info WHERE property IS 'updated';")
+      echo "         old database, updated $(date -d @${oldDBdate})"
+      mv "${gravityOLDfile}" "$(dirname -- "${gravityOLDfile}")/gravity_mv.db"
+      mv "${gravityDBfile}" "${gravityOLDfile}"
+      mv "$(dirname -- "${gravityOLDfile}")/gravity_mv.db" "${gravityDBfile}"
+      "${PIHOLE_COMMAND}" restartdns
+      echo -e "  ${INFO}  database, dated $(date -d @${oldDBdate}) now active"
+      exit 0
+    else
+      echo -e "  ${CROSS}  Cannot switch database, different database version."
+      exit 1
+    fi
+  else
+    echo -e "  ${CROSS}  Cannot switch database, ${gravityDBfile} doesn't exist."
+     exit 1
+  fi
+}
+
 helpFunc() {
   echo "Usage: pihole -g
 Update domains from blocklists specified in adlists.list
 
 Options:
   -f, --force          Force the download of all specified blocklists
+  -s, --switch         Switch to old database
   -h, --help           Show this help dialog"
   exit 0
 }
@@ -886,9 +935,15 @@ for var in "$@"; do
   case "${var}" in
     "-f" | "--force" ) forceDelete=true;;
     "-r" | "--recreate" ) recreate_database=true;;
+    "-s" | "--switch" ) switch_database;;
     "-h" | "--help" ) helpFunc;;
   esac
 done
+
+# Remove OLD (backup) gravity file, if it exists and the command isn't "-s" Or "--switch"
+if [[ -f "${gravityOLDfile}" ]]; then
+  rm "${gravityOLDfile}" 
+fi
 
 # Trap Ctrl-C
 gravity_Trap


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
see feature request https://discourse.pi-hole.net/t/gravity-database/46182

*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*
changes to gravity.sh:
allows (optional - default true) to keep the old database after a gravity run
allows to switch between the old and new database, this to allow the user to determine if a domain was already blocked before the last gravity run or is actually a new entry.
changes to query.sh:
allows the user to check if domains, added due to the last gravity run have already triggered a block event.
allow the user to display the count of new entries since the last run
![image](https://user-images.githubusercontent.com/24669386/118375021-50911b00-b5bf-11eb-8850-fb08c01a0a1c.png)

![image](https://user-images.githubusercontent.com/24669386/118375034-69013580-b5bf-11eb-95f3-ffcd2929ef08.png)

![image](https://user-images.githubusercontent.com/24669386/118375045-79b1ab80-b5bf-11eb-9416-db27ba9fee43.png)

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*
changes to gravity.sh:
doesn't remove the database unconditionally, only removes it during the next gravity run
pihole -g -s switches the database filenames and executes pihole restartdns

![image](https://user-images.githubusercontent.com/24669386/118375253-ec6f5680-b5c0-11eb-8e9c-20658c1c583a.png)

![image](https://user-images.githubusercontent.com/24669386/118375260-05780780-b5c1-11eb-8a2f-85d5fcbc3250.png)

![image](https://user-images.githubusercontent.com/24669386/118375304-3f490e00-b5c1-11eb-979b-9ad275c7e87d.png)

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*
A new switch in setupVars.conf, KEEPOLDGRAVITY=true| false, default true allows the user to disable the keep old database functionality.

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
