### PR TITLE
Add missing sed anchors when deleting lines.

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -716,7 +716,7 @@ RemoveCustomDNSAddress() {
     host="${args[3]}"
 
     if valid_ip "${ip}" || valid_ip6 "${ip}" ; then
-        sed -i "/${ip} ${host}/d" "${dnscustomfile}"
+        sed -i "/^${ip} ${host}$/d" "${dnscustomfile}"
     else
         echo -e "  ${CROSS} Invalid IP has been passed"
         exit 1
@@ -748,7 +748,7 @@ RemoveCustomCNAMERecord() {
     if [[ -n "${validDomain}" ]]; then
         validTarget="$(checkDomain "${target}")"
         if [[ -n "${validDomain}" ]]; then
-            sed -i "/cname=${validDomain},${validTarget}/d" "${dnscustomcnamefile}"
+            sed -i "/cname=${validDomain},${validTarget}$/d" "${dnscustomcnamefile}"
         else
             echo "  ${CROSS} Invalid Target Passed!"
             exit 1


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix https://github.com/pi-hole/AdminLTE/issues/1811

**How does this PR accomplish the above?:**

Add missing anchors to `sed`.

Assume the following file content:

> ```
> 1.1.1.1 test
> 1.1.1.1 test.local
> 121.1.1.1 test.local
> 121.1.1.1 test
> ```

Deleting `1.1.1.1 test` would actually remove all entries (matches bold parts):

> **`1.1.1.1 test`**
> **`1.1.1.1 test`** .local
> 12 **`1.1.1.1 test`** .local
> 12 **`1.1.1.1 test`**

while it should only have remove the first one.
We fix this by adding anchors.

Example:
```
$ echo -e "1.1.1.1 test\\n1.1.1.1 test.local\\n121.1.1.1 test.local\\n121.1.1.1 test" | sed "/1.1.1.1 test/d"
```
(empty, all removed)

```
$ echo -e "1.1.1.1 test\\n1.1.1.1 test.local\\n121.1.1.1 test.local\\n121.1.1.1 test" | sed "/^1.1.1.1 test$/d"
1.1.1.1 test.local
121.1.1.1 test.local
121.1.1.1 test
```
(only the first is removed, as expected)

**What documentation changes (if any) are needed to support this PR?:**

None