### PR TITLE
Filter pihole -t

### DIFF
--- a/pihole
+++ b/pihole
@@ -370,7 +370,7 @@ tailFunc() {
   # Color blocklist/blacklist/wildcard entries as red
   # Color A/AAAA/DHCP strings as white
   # Color everything else as gray
-  tail -f /var/log/pihole.log | sed -E \
+  tail -f /var/log/pihole.log | grep --line-buffered "${1}" | sed -E \
     -e "s,($(date +'%b %d ')| dnsmasq\[[0-9]*\]),,g" \
     -e "s,(.*(blacklisted |gravity blocked ).* is (0.0.0.0|::|NXDOMAIN|${IPV4_ADDRESS%/*}|${IPV6_ADDRESS:-NULL}).*),${COL_RED}&${COL_NC}," \
     -e "s,.*(query\\[A|DHCP).*,${COL_NC}&${COL_NC}," \
@@ -456,7 +456,10 @@ Debugging Options:
                         Add '-a' to automatically upload the log to tricorder.pi-hole.net
   -f, flush           Flush the Pi-hole log
   -r, reconfigure     Reconfigure or Repair Pi-hole subsystems
-  -t, tail            View the live output of the Pi-hole log
+  -t, tail [arg]      View the live output of the Pi-hole log.
+                      Add an optional argument to filter the log
+                      (regular expressions are supported)
+
 
 Options:
   -a, admin           Web interface options
@@ -530,7 +533,7 @@ case "${1}" in
   "status"                      ) statusFunc "$2";;
   "restartdns"                  ) restartDNS "$2";;
   "-a" | "admin"                ) webpageFunc "$@";;
-  "-t" | "tail"                 ) tailFunc;;
+  "-t" | "tail"                 ) tailFunc "$2";;
   "checkout"                    ) piholeCheckoutFunc "$@";;
   "tricorder"                   ) tricorderFunc;;
   "updatechecker"               ) updateCheckFunc "$@";;


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Adds the ability to filter the output of `pihole -t` (by simple grep). Compared to only tailing `pihole.log` this preserves the coloring of `pihole -t`


**How does this PR accomplish the above?:**
`grep` before doing the coloring.

**What documentation changes (if any) are needed to support this PR?:**
None.

```
rockpi@rockpi-4b:~$ ./pihole -t 10.0.1.31
  [i] Press Ctrl-C to exit
Jun  4 22:07:22: query[A] content-autofill.googleapis.com from 10.0.1.31
Jun  4 22:07:28: query[A] signaler-pa.clients6.google.com from 10.0.1.31
Jun  4 22:07:58: query[A] beacons.gcp.gvt2.com from 10.0.1.31
Jun  4 22:07:58: query[A] beacons.gcp.gvt2.com.fritz.box from 10.0.1.31


rockpi@rockpi-4b:~$ ./pihole -t google
  [i] Press Ctrl-C to exit
Jun  4 22:08:46: query[A] play.google.com from 10.0.1.31
Jun  4 22:08:46: cached play.google.com is 172.217.20.238
Jun  4 22:08:58: query[A] clients2.google.com from 10.0.1.31
Jun  4 22:08:58: forwarded clients2.google.com to 127.0.0.1
Jun  4 22:08:58: reply clients2.google.com is <CNAME>
Jun  4 22:08:58: reply clients.l.google.com is 172.217.23.78


```
