### PR TITLE
Be explicit in IPv6 RA values.

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -426,7 +426,7 @@ dhcp-leasefile=/etc/pihole/dhcp.leases
         echo "#quiet-dhcp6
 #enable-ra
 dhcp-option=option6:dns-server,[::]
-dhcp-range=::100,::1ff,constructor:${interface},ra-names,slaac,${leasetime}
+dhcp-range=::100,::1ff,constructor:${interface},ra-names,slaac,64,3600
 ra-param=*,0,0
 " >> "${dhcpconfig}"
     fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Fixes #4142 

Be explicit in the values for the IPv6 RA packets. 

The format for the range statement is: (from https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html)

`--dhcp-range=[tag:<tag>[,tag:<tag>],][set:<tag>,]<start-IPv6addr>[,<end-IPv6addr>|constructor:<interface>][,<mode>][,<prefix-len>][,<lease time>]`

We set the prefix length and hard code in a lease time. Previously we used the lease time variable that was used for IPv4 addressing. Because of other issues it was possible for a misinterpreted short lease time to be seen as a prefix length and cause `pihole-FTL`/`dnsmasq` to fail to start. 

The intention of the RA is to advertise the DNS capabilities. We do not intend to be a stateful IPv6 DHCP server. I think the hard code value for lease time is okay since there shouldn't ever be an actual lease generated. 


**How does this PR accomplish the above?:**

Be as explicit as possible for all values that should not vary.

**What documentation changes (if any) are needed to support this PR?:**

None
