### PR TITLE
Don't overwrite existing logrotate

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1954,7 +1954,7 @@ installLogrotate() {
         return 2
     fi
     # Copy the file over from the local repo
-    install -D -m 644 -T ${PI_HOLE_LOCAL_REPO}/advanced/Templates/logrotate ${target}
+    install -D -m 644 -T "${PI_HOLE_LOCAL_REPO}"/advanced/Templates/logrotate ${target}
     # Different operating systems have different user / group
     # settings for logrotate that makes it impossible to create
     # a static logrotate file that will work with e.g.
@@ -1963,7 +1963,7 @@ installLogrotate() {
     # the local properties of the /var/log directory
     logusergroup="$(stat -c '%U %G' /var/log)"
     # If there is a usergroup for log rotation,
-    if [[ ! -z "${logusergroup}" ]]; then
+    if [[ -n "${logusergroup}" ]]; then
         # replace the line in the logrotate script with that usergroup.
         sed -i "s/# su #/su ${logusergroup}/g;" ${target}
     fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1944,9 +1944,17 @@ finalExports() {
 # Install the logrotate script
 installLogrotate() {
     local str="Installing latest logrotate script"
+    local target=/etc/pihole/logrotate
+
     printf "\\n  %b %s..." "${INFO}" "${str}"
+    if [[ -f ${target} ]]; then
+        printf "\\n\\t%b Existing logrotate file found. No changes made.\\n" "${INFO}"
+        # Return value isn't that important, using 2 to indicate that it's not a fatal error but
+        # the function did not complete. 
+        return 2
+    fi
     # Copy the file over from the local repo
-    install -D -m 644 -T ${PI_HOLE_LOCAL_REPO}/advanced/Templates/logrotate /etc/pihole/logrotate
+    install -D -m 644 -T ${PI_HOLE_LOCAL_REPO}/advanced/Templates/logrotate ${target}
     # Different operating systems have different user / group
     # settings for logrotate that makes it impossible to create
     # a static logrotate file that will work with e.g.
@@ -1957,7 +1965,7 @@ installLogrotate() {
     # If there is a usergroup for log rotation,
     if [[ ! -z "${logusergroup}" ]]; then
         # replace the line in the logrotate script with that usergroup.
-        sed -i "s/# su #/su ${logusergroup}/g;" /etc/pihole/logrotate
+        sed -i "s/# su #/su ${logusergroup}/g;" ${target}
     fi
     printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Fixes #3822 

Longstanding bug that would overwrite a users modified logrotate configuration. This would happen on update and is not intended.

**How does this PR accomplish the above?:**

Conditionally checks for file existence before installing the file.

```bash
root@debian-s-1vcpu-1gb-nyc1-01:~# ls -la /etc/pihole/logrotate
ls: cannot access '/etc/pihole/logrotate': No such file or directory

--- Run install script

  [✓] Installing latest logrotate script
root@debian-s-1vcpu-1gb-nyc1-01:~# ls -la /etc/pihole/logrotate
-rw-r--r-- 1 root root 12 Jun 20 18:17 /etc/pihole/logrotate

--- Run install script

  [i] Installing latest logrotate script...
        [i] Existing logrotate file found. No changes made.
```

**What documentation changes (if any) are needed to support this PR?:**

None

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
