### PR TITLE
refactor EnableDHCP for use with -s, seeding it with setupVars config.

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -438,6 +438,19 @@ ra-param=*,0,0
     fi
 }
 
+EnableDHCPSeeded() {
+  case "${args[2]}" in
+    "-s")
+      source "${setupVars}";
+      change_setting "DHCP_ACTIVE" "true";
+      echo EnableDHCP blah "$DHCP_ACTIVE" "$DHCP_START" "$DHCP_END" "$DHCP_ROUTER" "$DHCP_LEASETIME" "$PIHOLE_DOMAIN" "$DHCP_IPv6" "$DHCP_rapid_commit";
+    ;;
+    *)
+      echo EnableDHCP;
+    ;;
+    esac;
+}
+
 EnableDHCP() {
     change_setting "DHCP_ACTIVE" "true"
     change_setting "DHCP_START" "${args[2]}"
@@ -777,7 +790,7 @@ main() {
         "reboot"              ) Reboot;;
         "restartdns"          ) RestartDNS;;
         "setquerylog"         ) SetQueryLogOptions;;
-        "enabledhcp"          ) EnableDHCP;;
+        "enabledhcp"          ) EnableDHCPSeeded "$@";;
         "disabledhcp"         ) DisableDHCP;;
         "layout"              ) SetWebUILayout;;
         "theme"               ) SetWebUITheme;;


### PR DESCRIPTION
Signed-off-by: corbolais <corbolais@gmail.com>

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have tested my proposed changes
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)

---
**What does this PR aim to accomplish?:**
before: enabledhcp would reset DHCP config in setupVars
after: optionally specify "-s" to seed it with DHCP config already set in setupVars

**How does this PR accomplish the above?:**
wrapper around the original EnableDHCP function

**What documentation changes (if any) are needed to support this PR?:**
One could add documentation to helpFunc. EnableDHCP is not documented there yet so the change isn't, either. I ignore whether there is any further documentation on EnableDHCP available, other than the code. If so, information about the "-s" switch can be added.
