### PR TITLE
Include lighttpd-mod-deflate since it is no longer provided by default in Bullsye

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -360,7 +360,7 @@ if is_command apt-get ; then
     PIHOLE_DEPS=(cron curl iputils-ping lsof netcat psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2)
     # Packages required for the Web admin interface (stored as an array)
     # It's useful to separate this from Pi-hole, since the two repos are also setup separately
-    PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-intl")
+    PIHOLE_WEB_DEPS=(lighttpd lighttpd-mod-deflate "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-intl")
     # Prior to PHP8.0, JSON functionality is provided as dedicated module, required by Pi-hole AdminLTE: https://www.php.net/manual/json.installation.php
     if [[ "${phpInsNewer}" != true || "${phpInsMajor}" -lt 8 ]]; then
         PIHOLE_WEB_DEPS+=("${phpVer}-json")


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*

Right now, Pihole fails on Debian Bullseye due to the missing deflate module for lighttpd. This PR includes the module as a dependency to correct that failure. Another possible option is to remove the use of the module - but that might be a bit tricky for system migrations that already have the lighttpd configuration created. Also, compression is good.

Failure:

> 2021-06-30 22:36:39: plugin.c.195) dlopen() failed for: /usr/lib/lighttpd/mod_deflate.so /usr/lib/lighttpd/mod_deflate.so: cannot open shared object file: No such file or directory
> 2021-06-30 22:36:39: server.c.1238) loading plugins finally failed
> Stopping lighttpd
> lighttpd: no process found

Debian Bullseye is in 'Hard Freeze' status, with a 'Full Freeze' status planned for 2021-07-17. As far as I can determine, this is the only required change to get things working on Bullseye. I did testing of this change through Docker using the down-stream docker-pihole project.

Interesting enough, if you search for the error message, you'll come across the Pihole discourse, talking about the same error, except with the Kali distribution. Which of course is unsupported, but shares the same solution:

* [Installation aborts at lighttpd restart](https://discourse.pi-hole.net/t/installation-aborts-at-lighttpd-restart/45912/2)
* [Mod_deflate.so module is missing from lighttpd?](https://discourse.pi-hole.net/t/mod-deflate-so-module-is-missing-from-lighttpd/42781/3)

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

Include `lighttpd-mod-deflate` as a dependency for Pihole Web.

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*
 
None that I know of? As far as I can tell, the uninstall script sources from this same variable, so it should work fine I believe?

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
