### PR TITLE
Revert "Include lighttpd-mod-deflate since it is no longer provided by default in Bullsye"

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -360,7 +360,7 @@ if is_command apt-get ; then
     PIHOLE_DEPS=(cron curl iputils-ping lsof netcat psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2)
     # Packages required for the Web admin interface (stored as an array)
     # It's useful to separate this from Pi-hole, since the two repos are also setup separately
-    PIHOLE_WEB_DEPS=(lighttpd lighttpd-mod-deflate "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-intl")
+    PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-intl")
     # Prior to PHP8.0, JSON functionality is provided as dedicated module, required by Pi-hole AdminLTE: https://www.php.net/manual/json.installation.php
     if [[ "${phpInsNewer}" != true || "${phpInsMajor}" -lt 8 ]]; then
         PIHOLE_WEB_DEPS+=("${phpVer}-json")


### PR DESCRIPTION
Reverts pi-hole/pi-hole#4212

A little premature. See comments on #4212