### PR TITLE
Add new tests to ensure dependencies are available to the OS

### DIFF
--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -597,3 +597,43 @@ def test_os_check_passes(Pihole):
     ''')
     expected_stdout = 'Supported OS detected'
     assert expected_stdout in detectOS.stdout
+
+
+def test_package_manager_has_installer_deps(Pihole):
+    ''' Confirms OS is able to install the required packages for the installer'''
+    mock_command('whiptail', {'*': ('', '0')}, Pihole)
+    output = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    distro_check
+    install_dependent_packages ${INSTALLER_DEPS[@]}
+    ''')
+
+    assert 'No package' not in output.stdout #centos7 still exits 0...
+    assert output.rc == 0
+
+
+def test_package_manager_has_pihole_deps(Pihole):
+    ''' Confirms OS is able to install the required packages for Pi-hole '''
+    mock_command('whiptail', {'*': ('', '0')}, Pihole)
+    output = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    distro_check
+    install_dependent_packages ${PIHOLE_DEPS[@]}
+    ''')
+
+    assert 'No package' not in output.stdout #centos7 still exits 0...
+    assert output.rc == 0
+
+
+def test_package_manager_has_web_deps(Pihole):
+    ''' Confirms OS is able to install the required packages for web '''
+    mock_command('whiptail', {'*': ('', '0')}, Pihole)
+    output = Pihole.run('''
+    source /opt/pihole/basic-install.sh
+    distro_check
+    install_dependent_packages ${PIHOLE_WEB_DEPS[@]}
+    ''')
+
+    assert 'No package' not in output.stdout #centos7 still exits 0...
+    assert output.rc == 0
+

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -608,7 +608,7 @@ def test_package_manager_has_installer_deps(Pihole):
     install_dependent_packages ${INSTALLER_DEPS[@]}
     ''')
 
-    assert 'No package' not in output.stdout #centos7 still exits 0...
+    assert 'No package' not in output.stdout  # centos7 still exits 0...
     assert output.rc == 0
 
 
@@ -621,7 +621,7 @@ def test_package_manager_has_pihole_deps(Pihole):
     install_dependent_packages ${PIHOLE_DEPS[@]}
     ''')
 
-    assert 'No package' not in output.stdout #centos7 still exits 0...
+    assert 'No package' not in output.stdout  # centos7 still exits 0...
     assert output.rc == 0
 
 
@@ -634,6 +634,5 @@ def test_package_manager_has_web_deps(Pihole):
     install_dependent_packages ${PIHOLE_WEB_DEPS[@]}
     ''')
 
-    assert 'No package' not in output.stdout #centos7 still exits 0...
+    assert 'No package' not in output.stdout  # centos7 still exits 0...
     assert output.rc == 0
-


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Based on a conversation here : https://github.com/pi-hole/pi-hole/pull/4214

Checks that the `install_dependent_packages` exits cleanly. This works on all OS's apart from one....

Annoyingly `centos7` exits cleanly regardless, so an additional check is added in that case that looks for the string `No package ` (Would like @bcambl 's input on that - `centos8` does not display this behaviour

All dependencies OK:
![image](https://user-images.githubusercontent.com/1998970/124335431-25c04d80-db92-11eb-8a8f-e92d5c473f8c.png)

Invalid dependency added:
![image](https://user-images.githubusercontent.com/1998970/124335445-2fe24c00-db92-11eb-9248-f74774bc568d.png)

