### PR TITLE
Move Mozilla canary domain handling into FTL's namespace

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -273,11 +273,6 @@ trust-anchor=.,20326,8,2,E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC68345710423
         fi
     fi
 
-    # Prevent Firefox from automatically switching over to DNS-over-HTTPS
-    # This follows https://support.mozilla.org/en-US/kb/configuring-networks-disable-dns-over-https
-    # (sourced 7th September 2019)
-    add_dnsmasq_setting "server=/use-application-dns.net/"
-
     # We need to process DHCP settings here as well to account for possible
     # changes in the non-FQDN forwarding. This cannot be done in 01-pihole.conf
     # as we don't want to delete all local=/.../ lines so it's much safer to


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Improve Mozilla canary domain handling.

**How does this PR accomplish the above?:**

Canary domain handling is now happening in FTL where we have much finer control over it, see https://github.com/pi-hole/FTL/pull/1148

**What documentation changes (if any) are needed to support this PR?:**

None