### PR TITLE
Remove obsolete iproute APT package check

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -303,19 +303,8 @@ if is_command apt-get ; then
             printf "  %b Enabled %s\\n" "${TICK}" "'universe' repository"
         fi
     fi
-    # Update package cache. This is required already here to assure apt-cache calls have package lists available.
+    # Update package cache
     update_package_cache || exit 1
-    # Debian 7 doesn't have iproute2 so check if it's available first
-    if apt-cache show iproute2 > /dev/null 2>&1; then
-        iproute_pkg="iproute2"
-    # Otherwise, check if iproute is available
-    elif apt-cache show iproute > /dev/null 2>&1; then
-        iproute_pkg="iproute"
-    # Else print error and exit
-    else
-        printf "  %b Aborting installation: iproute2 and iproute packages were not found in APT repository.\\n" "${CROSS}"
-        exit 1
-    fi
     # Check for and determine version number (major and minor) of current php install
     if is_command php ; then
         printf "  %b Existing PHP installation detected : PHP version %s\\n" "${INFO}" "$(php <<< "<?php echo PHP_VERSION ?>")"
@@ -355,7 +344,7 @@ if is_command apt-get ; then
         exit 1
     fi
     # Packages required to run this install script (stored as an array)
-    INSTALLER_DEPS=(dhcpcd5 git "${iproute_pkg}" whiptail dnsutils)
+    INSTALLER_DEPS=(dhcpcd5 git iproute2 whiptail dnsutils)
     # Packages required to run Pi-hole (stored as an array)
     PIHOLE_DEPS=(cron curl iputils-ping lsof netcat psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2)
     # Packages required for the Web admin interface (stored as an array)
@@ -1651,9 +1640,6 @@ disable_resolved_stublistener() {
 }
 
 update_package_cache() {
-    # Running apt-get update/upgrade with minimal output can cause some issues with
-    # requiring user input (e.g password for phpmyadmin see #218)
-
     # Update package cache on apt based OSes. Do this every time since
     # it's quick and packages can be updated at any time.
 
@@ -1731,6 +1717,8 @@ install_dependent_packages() {
         # If there's anything to install, install everything in the list.
         if [[ "${#installArray[@]}" -gt 0 ]]; then
             test_dpkg_lock
+            # Running apt-get install with minimal output can cause some issues with
+            # requiring user input (e.g password for phpmyadmin see #218)
             printf "  %b Processing %s install(s) for: %s, please wait...\\n" "${INFO}" "${PKG_MANAGER}" "${installArray[*]}"
             printf '%*s\n' "$columns" '' | tr " " -;
             "${PKG_INSTALL[@]}" "${installArray[@]}"
@@ -1950,7 +1938,7 @@ installLogrotate() {
     if [[ -f ${target} ]]; then
         printf "\\n\\t%b Existing logrotate file found. No changes made.\\n" "${INFO}"
         # Return value isn't that important, using 2 to indicate that it's not a fatal error but
-        # the function did not complete. 
+        # the function did not complete.
         return 2
     fi
     # Copy the file over from the local repo


### PR DESCRIPTION
[Internal]

Redo of https://github.com/pi-hole/pi-hole/pull/4114

`development-v6` branch is broken following rebase - a lot of changes have been lost between it and `development`, and I think I would rather start it again at some point than try to sort it on the existing branch.

This is the only PR that's been merged into `development-v6`, so I have tweaked it slightly and targeted `development`.

@MichaIng , please can I borrow your eyes to ensure I've cherry picked this correctly? Else feel free to just redo the changes based on `development` and submit a fresh PR, thanks!

`development-v6` is closed to pull requests until further notice

