### PR TITLE
Remove mod_compress (mod_deflate) from lighttpd to provide backwards compatible support for Debian Bullseye (11)

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -20,7 +20,6 @@ server.modules = (
     "mod_accesslog",
     "mod_auth",
     "mod_expire",
-    "mod_compress",
     "mod_redirect",
     "mod_setenv",
     "mod_rewrite"
@@ -40,26 +39,6 @@ accesslog.format            = "%{%s}t|%V|%r|%s|%b"
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny             = ( "~", ".inc", ".md", ".yml", ".ini" )
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
-
-compress.cache-dir = "/var/cache/lighttpd/compress/"
-compress.filetype  = (
-    "application/json",
-    "application/vnd.ms-fontobject",
-    "application/xml",
-    "font/eot",
-    "font/opentype",
-    "font/otf",
-    "font/ttf",
-    "image/bmp",
-    "image/svg+xml",
-    "image/vnd.microsoft.icon",
-    "image/x-icon",
-    "text/css",
-    "text/html",
-    "text/javascript",
-    "text/plain",
-    "text/xml"
-)
 
 mimetype.assign = (
     ".ico"   => "image/x-icon",


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Support Debian Bullseye without breaking support for older versions of Debian.

**How does this PR accomplish the above?:**

Remove mod_compress (mod_deflate) from Debian's lighttpd config to provide backwards compatible support for Debian Bullseye (11). I did testing of this on Bullseye through docker. Another benefit of this change is that we no longer get this message on boot:

> Warning: "mod_compress" is DEPRECATED and has been replaced with "mod_deflate".  A future release of lighttpd 1.4.x will not contain mod_compress and lighttpd may fail to start up

* `mod_compress` is deprecated
* `mod_deflate` requires a new package on Debian Bullseye which leads to package complexity with older Debian versions. See:
  * https://github.com/pi-hole/pi-hole/pull/4212
  * https://github.com/pi-hole/pi-hole/pull/4218

**Please note, that I left [Fedora's configuration](https://github.com/pi-hole/pi-hole/blob/a52a5e7ef2e202e386ae8362788c4e47ea308278/advanced/lighttpd.conf.fedora) alone since this issue only affects Debian.**

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*

None?

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
