### PR TITLE
Give pihole its own logrotate state file

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -11,6 +11,11 @@
 colfile="/opt/pihole/COL_TABLE"
 source ${colfile}
 
+# In case we're running at the same time as a system logrotate, use a
+# separate logrotate state file to prevent stepping on each other's
+# toes.
+STATEFILE="/var/lib/logrotate/pihole"
+
 # Determine database location
 # Obtain DBFILE=... setting from pihole-FTL.db
 # Constructed to return nothing when
@@ -32,7 +37,7 @@ if [[ "$@" == *"once"* ]]; then
     # Nightly logrotation
     if command -v /usr/sbin/logrotate >/dev/null; then
         # Logrotate once
-        /usr/sbin/logrotate --force /etc/pihole/logrotate
+        /usr/sbin/logrotate --force --state "${STATEFILE}" /etc/pihole/logrotate
     else
         # Copy pihole.log over to pihole.log.1
         # and empty out pihole.log
@@ -47,8 +52,8 @@ else
     # Manual flushing
     if command -v /usr/sbin/logrotate >/dev/null; then
         # Logrotate twice to move all data out of sight of FTL
-        /usr/sbin/logrotate --force /etc/pihole/logrotate; sleep 3
-        /usr/sbin/logrotate --force /etc/pihole/logrotate
+        /usr/sbin/logrotate --force --state "${STATEFILE}" /etc/pihole/logrotate; sleep 3
+        /usr/sbin/logrotate --force --state "${STATEFILE}" /etc/pihole/logrotate
     else
         # Flush both pihole.log and pihole.log.1 (if existing)
         echo " " > /var/log/pihole.log

--- a/advanced/Templates/pihole.cron
+++ b/advanced/Templates/pihole.cron
@@ -26,7 +26,7 @@
 #          parameter "quiet": don't print messages
 00 00   * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole flush once quiet
 
-@reboot root /usr/sbin/logrotate /etc/pihole/logrotate
+@reboot root /usr/sbin/logrotate --state /var/lib/logrotate/pihole /etc/pihole/logrotate
 
 # Pi-hole: Grab local version and branch every 10 minutes
 */10 *  * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker local


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
In the pihole cron file, `pihole flush` is run daily at midnight. On many systems, this occasionally happens at the same time as a default system-installed logrotate cronjob. When multiple invocations of logrotate are running at the same time, they may attempt to operate on the default logrotate state file `/var/lib/logrotate/status` simultaneously, causing errors. For this reason, pihole's invocation of logrotate needs to use its own separate state file.

**How does this PR accomplish the above?:**
This PR modifies the `piholeLogFlush.sh` script and the `pihole.cron` cronjob, providing all invocations of logrotate with the additional flag `--state /var/lib/logrotate/pihole` so that they won't run into conflicts with other logrotate processes.

**What documentation changes (if any) are needed to support this PR?:**
None.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
