### PR TITLE
add --ff-only to the git pull command(s)

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -582,7 +582,7 @@ update_repo() {
     git stash --all --quiet &> /dev/null || true # Okay for stash failure
     git clean --quiet --force -d || true # Okay for already clean directory
     # Pull the latest commits
-    git pull --quiet &> /dev/null || return $?
+    git pull --ff-only --quiet &> /dev/null || return $?
     # Check current branch. If it is master, then reset to the latest available tag.
     # In case extra commits have been added after tagging/release (i.e in case of metadata updates/README.MD tweaks)
     curBranch=$(git rev-parse --abbrev-ref HEAD)
@@ -1950,7 +1950,7 @@ installLogrotate() {
     if [[ -f ${target} ]]; then
         printf "\\n\\t%b Existing logrotate file found. No changes made.\\n" "${INFO}"
         # Return value isn't that important, using 2 to indicate that it's not a fatal error but
-        # the function did not complete. 
+        # the function did not complete.
         return 2
     fi
     # Copy the file over from the local repo
@@ -2244,7 +2244,7 @@ checkout_pull_branch() {
     # Data in the repositories is public anyway so we can make it readable by everyone (+r to keep executable permission if already set by git)
     chmod -R a+rX "${directory}"
 
-    git_pull=$(git pull || return 1)
+    git_pull=$(git pull --ff-only || return 1)
 
     if [[ "$git_pull" == *"up-to-date"* ]]; then
         printf "  %b %s\\n" "${INFO}" "${git_pull}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Newer versions of git display a hint when performing `git pull` without specifying how to reconcile divergent branches. This fix aims to supress that hint by specifying `--ff-only` as the pull type in the only two places the command is references.

Spotted when testing Ubuntu 21.04

![image](https://user-images.githubusercontent.com/1998970/125695431-0807f0aa-4187-40c3-970e-e8bc894c08c6.png)


More screenshots after resetting repo to some other previous commit:

![image](https://user-images.githubusercontent.com/1998970/125695542-a67ec9c3-c3f2-4e82-9da2-01c73330c9f6.png)

![image](https://user-images.githubusercontent.com/1998970/125695592-32e7e38f-0089-4571-ae48-1253d5890b77.png)


