### PR TITLE
Hardcode whiptail dimensions to 20 rows and 70 chars width

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -94,24 +94,9 @@ if [ -z "${USER}" ]; then
   USER="$(id -un)"
 fi
 
-
-# Check if we are running on a real terminal and find the rows and columns
-# If there is no real terminal, we will default to 80x24
-if [ -t 0 ] ; then
-  screen_size=$(stty size)
-else
-  screen_size="24 80"
-fi
-# Determine terminal rows and columns by parsing screen_size
-printf -v rows '%d' "${screen_size%% *}"
-printf -v columns '%d' "${screen_size##* }"
-
-# Divide by two so the dialogs take up half of the screen, which looks nice.
-r=$(( rows / 2 ))
-c=$(( columns / 2 ))
-# Unless the screen is tiny
-r=$(( r < 20 ? 20 : r ))
-c=$(( c < 70 ? 70 : c ))
+# whiptail dialog dimensions: 20 rows and 70 chars width assures to fit on small screens and is known to hold all content.
+r=20
+c=70
 
 ######## Undocumented Flags. Shhh ########
 # These are undocumented flags; some of which we can use when repairing an installation
@@ -2050,7 +2035,7 @@ update_dialogs() {
         strAdd="You will be updated to the latest version."
     fi
     opt2a="Reconfigure"
-    opt2b="This will reset your Pi-hole and allow you to enter new settings."
+    opt2b="Resets Pi-hole and allows re-selecting settings."
 
     # Display the information to the user
     UpdateCmd=$(whiptail --title "Existing Install Detected!" --menu "\\n\\nWe have detected an existing install.\\n\\nPlease choose from the following options: \\n($strAdd)" "${r}" "${c}" 2 \


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
With the suggested way to call the installer via `curl -sSL https://install.pi-hole.net | bash`, STDIN is no terminal, but overridden by the curl output, hence in most cases, the minimum dimensions were applied, even on larger screens. All whiptail calls are hence assured to work fine with those dimensions (aside of one case, see below) making the calculations obsolete.


**How does this PR accomplish the above?:**
This commit hardcodes the whiptail dimensions to the prior minimum and removes the calculations. This also helps with testing, as it does not matter anymore how the script is called, and developers have a clearly defined space to make dialogs look nice, including line breaks, menu and list heights.

The only case which does not fit the 70 character width, the second menu entry of the `pihole -r` dialog, has been shortened accordingly. This was not an issue before, as `pihole -r` does not override the scripts STDIN and hence did use larger dimensions based on the now removed calculations.

See the following discussions for reference:
- https://github.com/pi-hole/pi-hole/issues/3323
- https://github.com/pi-hole/pi-hole/pull/4197#issuecomment-876702380

**What documentation changes (if any) are needed to support this PR?:**
None