### PR TITLE
Update pihole-FTL.service

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 ### BEGIN INIT INFO
 # Provides:          pihole-FTL
 # Required-Start:    $remote_fs $syslog $network
@@ -9,11 +9,8 @@
 # Description:       Enable service provided by pihole-FTL daemon
 ### END INIT INFO
 
-FTLUSER=pihole
-PIDFILE=/run/pihole-FTL.pid
-
 is_running() {
-    pgrep -o "pihole-FTL" > /dev/null 2>&1
+  pgrep -xo "pihole-FTL" > /dev/null
 }
 
 
@@ -23,27 +20,18 @@ start() {
     echo "pihole-FTL is already running"
   else
     # Touch files to ensure they exist (create if non-existing, preserve if existing)
-    touch /var/log/pihole-FTL.log /var/log/pihole.log
-    touch /run/pihole-FTL.pid /run/pihole-FTL.port
-    touch /etc/pihole/dhcp.leases
-    mkdir -p /run/pihole
-    mkdir -p /var/log/pihole
-    chown pihole:pihole /run/pihole /var/log/pihole
-    # Remove possible leftovers from previous pihole-FTL processes
-    rm -f /dev/shm/FTL-* 2> /dev/null
-    rm /run/pihole/FTL.sock 2> /dev/null
+    mkdir -pm 0755 /run/pihole
+    touch /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases
     # Ensure that permissions are set so that pihole-FTL can edit all necessary files
-    chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port
-    chown pihole:pihole /etc/pihole /etc/pihole/dhcp.leases 2> /dev/null
-    chown pihole:pihole /var/log/pihole-FTL.log /var/log/pihole.log
-    chmod 0644 /var/log/pihole-FTL.log /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole.log
+    chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases /run/pihole /etc/pihole
+    chmod 0644 /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases
     # Chown database files to the user FTL runs as. We ignore errors as the files may not (yet) exist
-    chown pihole:pihole /etc/pihole/pihole-FTL.db /etc/pihole/gravity.db 2> /dev/null
-    if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE+eip "$(which pihole-FTL)"; then
-      su -s /bin/sh -c "/usr/bin/pihole-FTL" "$FTLUSER"
+    chown -f pihole:pihole /etc/pihole/pihole-FTL.db /etc/pihole/gravity.db
+    if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE+eip "/usr/bin/pihole-FTL"; then
+      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole
     else
       echo "Warning: Starting pihole-FTL as root because setting capabilities is not supported on this system"
-      pihole-FTL
+      /usr/bin/pihole-FTL
     fi
     echo
   fi
@@ -52,20 +40,20 @@ start() {
 # Stop the service
 stop() {
   if is_running; then
-    pkill -o pihole-FTL
-    for i in {1..5}; do
+    pkill -xo "pihole-FTL"
+    for i in 1 2 3 4 5; do
       if ! is_running; then
         break
       fi
 
-      echo -n "."
+      printf "."
       sleep 1
     done
     echo
 
     if is_running; then
       echo "Not stopped; may still be shutting down or shutdown may have failed, killing now"
-      pkill -o -9 pihole-FTL
+      pkill -xo -9 "pihole-FTL"
       exit 1
     else
       echo "Stopped"
@@ -73,6 +61,8 @@ stop() {
   else
     echo "Not running"
   fi
+  # Cleanup
+  rm -f /run/pihole/FTL.sock /dev/shm/FTL-*
   echo
 }
 
@@ -101,7 +91,7 @@ case "$1" in
         start
         ;;
   *)
-        echo $"Usage: $0 {start|stop|restart|reload|status}"
+        echo "Usage: $0 {start|stop|restart|reload|status}"
         exit 1
 esac
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
    - I'm sorry to basically mix many small enhancements together here and I'm willing to fork some out in dedicated PRs, if wanted.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish and how does this PR accomplish the above?:**
- Make this script a bourne shell script, which requires the removal of only a single bashism, the `{n..m}` expansion. Furthermore, since POSIX echo has no reliable command line options, switch to `printf` when line breaks shall be omitted. On most distros/setups `sh` calls a much lighter bourne shell like `dash`, which inits and runs much faster than `bash`.
- Remove unused `PIDFILE` variable, remove the single case of `$FTLUSER` call and remove it as well. Using variables here might give the wrong impression that there is a change these can be varied. But both are hardcoded in many places throughout Pi-hole, so in this service script.
- Consolidate and merge the commands to pre-create and set permissions for required files and directories. The `/var/log/pihole` directory is and was never used (fixes #3041), the `touch`, `chmod` and `chown` call can be merged into one each to reduce overhead. Use `-f` option to to fail on missing database files instead of redirecting STDERR, which is otherwise helpful to debug other possible errors, like missing or corrupted commands, filesystem errors and such.
- Do not use `which pihole-FTL` when setting capabilities when the hardcoded path `/usr/bin/pihole-FTL` is used for the actual daemon call. It makes sense to use the full path here, as the Pi-hole installer and updater installs it explicitly there, and so we prevent users from e.g. overriding it via `/usr/local/bin/pihole-FTL` too easily.
- On `pgrep` and `pkill` calls, add the `-x` flag to assure that only `pihole-FTL` is matched and not `foo-pihole-FTL` or `pihole-FTL-bar`.
- Do not remove possible leftovers from previous `pihole-FTL` processes on start, but on stop instead. Since `start` includes a proceeding `stop` as well, on service start nothing changes, but on service stop, some resources are now freed.
- Remove leading `$` from usage message. In bash this was omitted, as `$'...`' is a special syntax for escape sequence expansion, which is not applicable here. In dash it would be printed literally. To keep previous behaviour, it is hence removed.

**What documentation changes (if any) are needed to support this PR?:**
None