### PR TITLE
Guard for non-zero return value in logrotate install.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [debian_9, debian_10, debian_11, ubuntu_16, ubuntu_18, ubuntu_20, centos_7, centos_8, fedora_32, fedora_33]
+        distro: [debian_9, debian_10, debian_11, ubuntu_16, ubuntu_18, ubuntu_20, ubuntu_21, centos_7, centos_8, fedora_32, fedora_33]
     env:
       DISTRO: ${{matrix.distro}}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [debian_9, debian_10, ubuntu_16, ubuntu_18, ubuntu_20, centos_7, centos_8, fedora_32, fedora_33]
+        distro: [debian_9, debian_10, debian_11, ubuntu_16, ubuntu_18, ubuntu_20, centos_7, centos_8, fedora_32, fedora_33]
     env:
       DISTRO: ${{matrix.distro}}
     steps:

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -410,12 +410,12 @@ os_check() {
     # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
     # and determines whether or not the script is running on one of those systems
     local remote_os_domain valid_os valid_version detected_os detected_version cmdResult digReturnCode response
-    remote_os_domain="versions.pi-hole.net"
+    remote_os_domain=${OS_CHECK_DOMAIN_NAME:-"versions.pi-hole.net"}
 
     detected_os=$(grep "\bID\b" /etc/os-release | cut -d '=' -f2 | tr -d '"')
     detected_version=$(grep VERSION_ID /etc/os-release | cut -d '=' -f2 | tr -d '"')
 
-    cmdResult="$(dig +short -t txt ${remote_os_domain} @ns1.pi-hole.net 2>&1; echo $?)"
+    cmdResult="$(dig +short -t txt "${remote_os_domain}" @ns1.pi-hole.net 2>&1; echo $?)"
     #Get the return code of the previous command (last line)
     digReturnCode="${cmdResult##*$'\n'}"
 

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -21,7 +21,6 @@ server.modules = (
     "mod_expire",
     "mod_fastcgi",
     "mod_accesslog",
-    "mod_compress",
     "mod_redirect",
     "mod_setenv",
     "mod_rewrite"
@@ -41,26 +40,6 @@ accesslog.format            = "%{%s}t|%V|%r|%s|%b"
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny             = ( "~", ".inc", ".md", ".yml", ".ini" )
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )
-
-compress.cache-dir = "/var/cache/lighttpd/compress/"
-compress.filetype  = (
-    "application/json",
-    "application/vnd.ms-fontobject",
-    "application/xml",
-    "font/eot",
-    "font/opentype",
-    "font/otf",
-    "font/ttf",
-    "image/bmp",
-    "image/svg+xml",
-    "image/vnd.microsoft.icon",
-    "image/x-icon",
-    "text/css",
-    "text/html",
-    "text/javascript",
-    "text/plain",
-    "text/xml"
-)
 
 mimetype.assign = (
     ".ico"   => "image/x-icon",

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2042,8 +2042,10 @@ installPihole() {
     fi
     # Install the cron file
     installCron
-    # Install the logrotate file
-    installLogrotate
+    if ! installLogrotate; then
+        printf "  %b Failure in logrotate installation function.\\n" "${CROSS}"
+        # This isn't fatal, no need to exit.    
+    fi
     # Check if dnsmasq is present. If so, disable it and back up any possible
     # config file
     disable_dnsmasq

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -186,12 +186,12 @@ os_check() {
         # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
         # and determines whether or not the script is running on one of those systems
         local remote_os_domain valid_os valid_version valid_response detected_os detected_version display_warning cmdResult digReturnCode response
-        remote_os_domain="versions.pi-hole.net"
+        remote_os_domain=${OS_CHECK_DOMAIN_NAME:-"versions.pi-hole.net"}
 
         detected_os=$(grep "\bID\b" /etc/os-release | cut -d '=' -f2 | tr -d '"')
         detected_version=$(grep VERSION_ID /etc/os-release | cut -d '=' -f2 | tr -d '"')
 
-        cmdResult="$(dig +short -t txt ${remote_os_domain} @ns1.pi-hole.net 2>&1; echo $?)"
+        cmdResult="$(dig +short -t txt "${remote_os_domain}" @ns1.pi-hole.net 2>&1; echo $?)"
         # Gets the return code of the previous command (last line)
         digReturnCode="${cmdResult##*$'\n'}"
 

--- a/pihole
+++ b/pihole
@@ -369,7 +369,7 @@ tailFunc() {
   # Color everything else as gray
   tail -f /var/log/pihole.log | grep --line-buffered "${1}" | sed -E \
     -e "s,($(date +'%b %d ')| dnsmasq\[[0-9]*\]),,g" \
-    -e "s,(.*(blacklisted |gravity blocked ).* is (0.0.0.0|::|NXDOMAIN).*),${COL_RED}&${COL_NC}," \
+    -e "s,(.*(blacklisted |gravity blocked ).*),${COL_RED}&${COL_NC}," \
     -e "s,.*(query\\[A|DHCP).*,${COL_NC}&${COL_NC}," \
     -e "s,.*,${COL_GRAY}&${COL_NC},"
   exit 0

--- a/supportedos.txt
+++ b/supportedos.txt
@@ -1,5 +1,5 @@
 Raspbian=9,10
 Ubuntu=16,18,20
-Debian=9,10
+Debian=9,10,11
 Fedora=32,33
 CentOS=7,8

--- a/supportedos.txt
+++ b/supportedos.txt
@@ -1,5 +1,0 @@
-Raspbian=9,10
-Ubuntu=16,18,20,21
-Debian=9,10,11
-Fedora=32,33
-CentOS=7,8

--- a/supportedos.txt
+++ b/supportedos.txt
@@ -1,5 +1,5 @@
 Raspbian=9,10
-Ubuntu=16,18,20
+Ubuntu=16,18,20,21
 Debian=9,10,11
 Fedora=32,33
 CentOS=7,8

--- a/test/_centos_7.Dockerfile
+++ b/test/_centos_7.Dockerfile
@@ -12,5 +12,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_centos_8.Dockerfile
+++ b/test/_centos_8.Dockerfile
@@ -12,5 +12,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_debian_10.Dockerfile
+++ b/test/_debian_10.Dockerfile
@@ -12,5 +12,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_debian_11.Dockerfile
+++ b/test/_debian_11.Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:bullseye-scm
+
+ENV GITDIR /etc/.pihole
+ENV SCRIPTDIR /opt/pihole
+
+RUN mkdir -p $GITDIR $SCRIPTDIR /etc/pihole
+ADD . $GITDIR
+RUN cp $GITDIR/advanced/Scripts/*.sh $GITDIR/gravity.sh $GITDIR/pihole $GITDIR/automated\ install/*.sh $SCRIPTDIR/
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$SCRIPTDIR
+
+RUN true && \
+    chmod +x $SCRIPTDIR/*
+
+ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
+
+#sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_debian_9.Dockerfile
+++ b/test/_debian_9.Dockerfile
@@ -12,5 +12,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_fedora_32.Dockerfile
+++ b/test/_fedora_32.Dockerfile
@@ -12,5 +12,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_fedora_33.Dockerfile
+++ b/test/_fedora_33.Dockerfile
@@ -12,5 +12,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_ubuntu_16.Dockerfile
+++ b/test/_ubuntu_16.Dockerfile
@@ -12,5 +12,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_ubuntu_18.Dockerfile
+++ b/test/_ubuntu_18.Dockerfile
@@ -12,5 +12,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_ubuntu_20.Dockerfile
+++ b/test/_ubuntu_20.Dockerfile
@@ -13,5 +13,6 @@ RUN true && \
     chmod +x $SCRIPTDIR/*
 
 ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
 
 #sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/_ubuntu_21.Dockerfile
+++ b/test/_ubuntu_21.Dockerfile
@@ -1,0 +1,18 @@
+FROM buildpack-deps:hirsute-scm
+
+ENV GITDIR /etc/.pihole
+ENV SCRIPTDIR /opt/pihole
+
+RUN mkdir -p $GITDIR $SCRIPTDIR /etc/pihole
+ADD . $GITDIR
+RUN cp $GITDIR/advanced/Scripts/*.sh $GITDIR/gravity.sh $GITDIR/pihole $GITDIR/automated\ install/*.sh $SCRIPTDIR/
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$SCRIPTDIR
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN true && \
+    chmod +x $SCRIPTDIR/*
+
+ENV PH_TEST true
+ENV OS_CHECK_DOMAIN_NAME dev-supportedos.pi-hole.net
+
+#sed '/# Start the installer/Q' /opt/pihole/basic-install.sh > /opt/pihole/stub_basic-install.sh && \

--- a/test/tox.debian_11.ini
+++ b/test/tox.debian_11.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py37
+
+[testenv]
+whitelist_externals = docker
+deps = -rrequirements.txt
+commands = docker build -f _debian_11.Dockerfile -t pytest_pihole:test_container ../
+           pytest {posargs:-vv -n auto} ./test_automated_install.py

--- a/test/tox.ubuntu_21.ini
+++ b/test/tox.ubuntu_21.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py37
+
+[testenv]
+whitelist_externals = docker
+deps = -rrequirements.txt
+commands = docker build -f _ubuntu_21.Dockerfile -t pytest_pihole:test_container ../
+           pytest {posargs:-vv -n auto} ./test_automated_install.py


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

The `installLogrotate` function has a possible non-zero return value. Since we use `set -e` we need to make sure every non-zero return is caught and does not halt the script.

**How does this PR accomplish the above?:**

Wrap the function call in an `if` guard. This is not fatal, we can continue to run the script.

**What documentation changes (if any) are needed to support this PR?:**

None
