### PR TITLE
Guard for logrotate func non-zero return

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2043,7 +2043,10 @@ installPihole() {
     # Install the cron file
     installCron
     # Install the logrotate file
-    installLogrotate
+    if ! installLogrotate; then
+        printf "  %b Failure in logrotate installation function.\\n" "${CROSS}"
+        # This isn't fatal, no need to exit.    
+    fi
     # Check if dnsmasq is present. If so, disable it and back up any possible
     # config file
     disable_dnsmasq


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

The `installLogrotate` function has a possible non-zero return value. Since we use `set -e` we need to make sure every non-zero return is caught and does not halt the script.

**How does this PR accomplish the above?:**

Wrap the function call in an `if` guard. This is not fatal, we can continue to run the script.

**What documentation changes (if any) are needed to support this PR?:**

None
