### PR TITLE
Remove extra failure display when installation of logrotate file is skipped because the file already exists

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2042,11 +2042,10 @@ installPihole() {
     fi
     # Install the cron file
     installCron
+
     # Install the logrotate file
-    if ! installLogrotate; then
-        printf "  %b Failure in logrotate installation function.\\n" "${CROSS}"
-        # This isn't fatal, no need to exit.    
-    fi
+    installLogrotate || true
+
     # Check if dnsmasq is present. If so, disable it and back up any possible
     # config file
     disable_dnsmasq


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Remove extra failure display when installation of logrotate file is skipped because the file already exists.

**How does this PR accomplish the above?:**

Just ensure that the script is not killed by `set -e`

**What documentation changes (if any) are needed to support this PR?:**

None