### PR TITLE
Install only minimal requiered package before performing os_check

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -359,7 +359,7 @@ if is_command apt-get ; then
     # Packages required to run this install script (stored as an array)
     INSTALLER_DEPS=(git "${iproute_pkg}" whiptail)
     # Packages required to run Pi-hole (stored as an array)
-    PIHOLE_DEPS=(dhcpcd5 cron curl iputils-ping lsof netcat psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2)
+    PIHOLE_DEPS=(sudo dhcpcd5 cron curl iputils-ping lsof netcat psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2)
     # Packages required for the Web admin interface (stored as an array)
     # It's useful to separate this from Pi-hole, since the two repos are also setup separately
     PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-${phpSqlite}" "${phpVer}-xml" "${phpVer}-intl")
@@ -404,7 +404,7 @@ elif is_command rpm ; then
     PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
     OS_CHECK_DEPS=(grep bind-utils)
     INSTALLER_DEPS=(git iproute newt procps-ng which chkconfig)
-    PIHOLE_DEPS=(cronie curl findutils nmap-ncat sudo unzip libidn2 psmisc sqlite libcap lsof)
+    PIHOLE_DEPS=(sudo cronie curl findutils nmap-ncat sudo unzip libidn2 psmisc sqlite libcap lsof)
     PIHOLE_WEB_DEPS=(lighttpd lighttpd-fastcgi php-common php-cli php-pdo php-xml php-json php-intl)
     LIGHTTPD_USER="lighttpd"
     LIGHTTPD_GROUP="lighttpd"

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -568,6 +568,7 @@ def test_os_check_fails(Pihole):
     Pihole.run('''
     source /opt/pihole/basic-install.sh
     distro_check
+    install_dependent_packages ${OS_CHECK_DEPS[@]}
     install_dependent_packages ${INSTALLER_DEPS[@]}
     cat <<EOT > /etc/os-release
     ID=UnsupportedOS
@@ -587,6 +588,7 @@ def test_os_check_passes(Pihole):
     Pihole.run('''
     source /opt/pihole/basic-install.sh
     distro_check
+    install_dependent_packages ${OS_CHECK_DEPS[@]}
     install_dependent_packages ${INSTALLER_DEPS[@]}
     ''')
     detectOS = Pihole.run('''


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Inspired by https://github.com/pi-hole/pi-hole/issues/4249

Pi-hole should only install as few packages as necessary before the OS check is performed in case it does not pass and users decide to not install Pi-hole. So we reduce messing with users systems if they can not install Pi-hole.


**How does this PR accomplish the above?:**
Only `dig` and `grep` are necessary to perform the `os_check`. Move those dependencies from `INSTALLER_DEPS` into the new `OS_CHECK_DEPS` and perform installation of all other dependencies **after** the `os_check`. 

Additionally, move `dhcp5` from `INSTALLER_DEPS` to `PIHOLE_DEPS`

