### PR TITLE
On enabling/disabeling only reload-lists instead of reload

### DIFF
--- a/pihole
+++ b/pihole
@@ -242,7 +242,7 @@ Time:
     echo "BLOCKING_ENABLED=true" >> "${setupVars}"
   fi
 
-  restartDNS reload
+  restartDNS reload-lists
 
   echo -e "${OVER}  ${TICK} ${str}"
 }


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
When blocking is enabled/disabled `pihole restartdns reload` was executed. Changing to `pihole restartdns reload-lists` should be sufficient and minimize restart time as well as preserve DNS cache.

Inspired by https://discourse.pi-hole.net/t/why-are-dhcp-leases-reconfirmed-when-disabling-and-enabling-blocking/48720