### PR TITLE
Add switching 'to...from' message to ftl checkout output

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -168,7 +168,7 @@ checkout() {
         local path
         local oldbranch
         path="${2}/${binary}"
-        oldbranch=$(pihole-FTL -b)
+        oldbranch="$(pihole-FTL -b)"
 
         if check_download_exists "$path"; then
             echo "  ${TICK} Branch ${2} exists"

--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -166,12 +166,15 @@ checkout() {
         checkout_pull_branch "${webInterfaceDir}" "${2}"
     elif [[ "${1}" == "ftl" ]] ; then
         local path
+        local oldbranch
         path="${2}/${binary}"
+        oldbranch=$(pihole-FTL -b)
 
         if check_download_exists "$path"; then
             echo "  ${TICK} Branch ${2} exists"
             echo "${2}" > /etc/pihole/ftlbranch
             chmod 644 /etc/pihole/ftlbranch
+            echo -e "  ${INFO} Switching to branch: \"${2}\" from \"${oldbranch}\""
             FTLinstall "${binary}"
             restart_service pihole-FTL
             enable_service pihole-FTL


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Adds a "Switching from branch X to Y" message to `FTL` checkout output. This existed already for `core` and `web` but was missing for `ftl`

Before
![Bildschirmfoto zu 2021-08-07 06-54-47](https://user-images.githubusercontent.com/26622301/128589016-15b80b5d-eeee-4f32-b275-ff151de3132a.png)

After
![Bildschirmfoto zu 2021-08-07 07-12-53](https://user-images.githubusercontent.com/26622301/128589001-83da2b32-a7c2-49ea-8f1d-6e1bc2eb6f1f.png)

