### PR TITLE
Perform a check of required packages befor updating pihole

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -95,6 +95,10 @@ main() {
     # shellcheck disable=1090,2154
     source "${setupVars}"
 
+    # Install packages used by this installation script (necessary if users have removed e.g. git from their systems)
+    package_manager_detect
+    install_dependent_packages "${INSTALLER_DEPS[@]}"
+
     # This is unlikely
     if ! is_repo "${PI_HOLE_FILES_DIR}" ; then
         echo -e "\\n  ${COL_LIGHT_RED}Error: Core Pi-hole repo is missing from system!"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
For discussion.

**What does this PR aim to accomplish?:**
Fixes rare edge cases like https://github.com/pi-hole/pi-hole/issues/2866

If users have removed packages that are part of `INSTALLER_DEPS` (e.g. git), `pihole -up` will fail. 
This PR re-uses the `install_dependent_packages "${INSTALLER_DEPS[@]}"` from the installer script to check, and if necessary, install the missing packages.

```
rockpi@rockpi-4b:~$ sudo apt remove git
[sudo] password for rockpi: 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  git-man liberror-perl
Use 'sudo apt autoremove' to remove them.
The following packages will be REMOVED:
  git
0 upgraded, 0 newly installed, 1 to remove and 5 not upgraded.
After this operation, 36.1 MB disk space will be freed.
Do you want to continue? [Y/n] y
(Reading database ... 41003 files and directories currently installed.)
Removing git (1:2.20.1-2+deb10u3) ...
rockpi@rockpi-4b:~$ pihole -up

  Error: Core Pi-hole repo is missing from system!
  Please re-run install script from https://pi-hole.net

rockpi@rockpi-4b:~$ sudo ./update.sh 
  [✓] Update local cache of available packages
  [i] Existing PHP installation detected : PHP version 7.3.29-1~deb10u1
  [i] Checking for git (will be installed)
  [✓] Checking for iproute2
  [✓] Checking for whiptail
  [i] Processing apt-get install(s) for: git, please wait...
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Selecting previously unselected package git.
(Reading database ... 40250 files and directories currently installed.)
Preparing to unpack .../git_1%3a2.20.1-2+deb10u3_arm64.deb ...
Unpacking git (1:2.20.1-2+deb10u3) ...
Setting up git (1:2.20.1-2+deb10u3) ...
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  [i] Checking for updates...
  [i] Pi-hole Core:	update available
  [i] Web Interface:	up to date
  [i] FTL:		update available
  [i] Warning: You are using FTL from a custom branch (release/v5.9) and might be missing future releases.

```