### PR TITLE
Remove ineffective Access-Control-Allow-Origin header

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -78,11 +78,6 @@ $HTTP["url"] =~ "^/admin/" {
         "X-Pi-hole" => "The Pi-hole Web interface is working!",
         "X-Frame-Options" => "DENY"
     )
-
-    $HTTP["url"] =~ "\.(eot|otf|tt[cf]|woff2?)$" {
-        # Allow Block Page access to local fonts
-        setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
-    }
 }
 
 # Block . files from being served, such as .git, .github, .gitignore

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -86,11 +86,6 @@ $HTTP["url"] =~ "^/admin/" {
         "X-Pi-hole" => "The Pi-hole Web interface is working!",
         "X-Frame-Options" => "DENY"
     )
-
-    $HTTP["url"] =~ "\.(eot|otf|tt[cf]|woff2?)$" {
-        # Allow Block Page access to local fonts
-        setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
-    }
 }
 
 # Block . files from being served, such as .git, .github, .gitignore


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
The [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) header has only relevance, when a resource is loaded from an external host, so one that does not match the host of the primary loaded website. As the fonts are reasonably loaded via local URLs without hostname or scheme from the blocking page style sheet, they are never seen as external resources, regardless whether the blocking page is shown to the browser from a blocked domain or from the Pi-hole domain/IP. To minimise transferred data and to not explicitly allow external hosts to load resources from each Pi-hole instance, the header should hence be removed.

Addresses #3462

**How does this PR accomplish the above?:**
The Access-Control-Allow-Origin header is removed from the Lighttpd configurations.

**What documentation changes (if any) are needed to support this PR?:**
None