### PR TITLE
Replace whiptails in RPM part of package_manager_detect

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -449,8 +449,8 @@ elif is_command rpm ; then
             # The PHP version available via default repositories is older than version 7
             printf "  %b PHP 7 Update (recommended)\\n" "${INFO}"
             printf "  %b PHP 7.x is recommended for both security and language features.\\n" "${INFO}"
-            printf "  %b Would you like to install PHP7 via Remi's RPM repository?\\n" ${INFO}"
-            printf "  %b See: https://rpms.remirepo.net for more information\\n" ${INFO}"
+            printf "  %b Would you like to install PHP7 via Remi's RPM repository?\\n" ""${INFO}"
+            printf "  %b See: https://rpms.remirepo.net for more information\\n" "${INFO}"
             read -r -p "  Do you whish to install PHP7? [y/N] " response
             case "${response}" in
                 [yY][eE][sS]|[yY])
@@ -480,8 +480,8 @@ elif is_command rpm ; then
         # Warn user of unsupported version of Fedora or CentOS
         printf "  %b Unsupported RPM based distribution\\n" "${INFO}"
         printf "  %b Would you like to continue installation on an unsupported RPM based distribution?\\n\\n" "${INFO}"
-        printf "  %b Please ensure the following packages have been installed manually:\\n\\n" ${INFO}"
-        printf "  %b - lighttpd\\n- lighttpd-fastcgi\\n- PHP version 7+\\" ${INFO}"
+        printf "  %b Please ensure the following packages have been installed manually:\\n\\n" "${INFO}"
+        printf "  %b - lighttpd\\n- lighttpd-fastcgi\\n- PHP version 7+\\" "${INFO}"
         read -r -p "  Do you whish to proceed with the installaton [y/N] " response
         case "${response}" in
             [yY][eE][sS]|[yY])

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -449,7 +449,7 @@ elif is_command rpm ; then
             # The PHP version available via default repositories is older than version 7
             printf "  %b PHP 7 Update (recommended)\\n" "${INFO}"
             printf "  %b PHP 7.x is recommended for both security and language features.\\n" "${INFO}"
-            printf "  %b Would you like to install PHP7 via Remi's RPM repository?\\n" ""${INFO}"
+            printf "  %b Would you like to install PHP7 via Remi's RPM repository?\\n" "${INFO}"
             printf "  %b See: https://rpms.remirepo.net for more information\\n" "${INFO}"
             read -r -p "  Do you whish to install PHP7? [y/N] " response
             case "${response}" in


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
In the `RPM` block of `detect_package_manager` two whiptail are present, despite we can not assume this package is already installed at this point, because installation of `install_dependent_packages "${INSTALLER_DEPS[@]}` happens later in the script.
This PR replaces both whiptails with `read -p`

See the discussion here https://github.com/pi-hole/pi-hole/issues/3297