### PR TITLE
Select proper PHP version on RPM based OS after INSTALLER_DEPS have been installed

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -377,7 +377,7 @@ if is_command apt-get ; then
 
 # If apt-get is not found, check for rpm to see if it's a Red Hat family OS
 elif is_command rpm ; then
-    # Then check if dnf or yum is the package man=dfsdfager
+    # Then check if dnf or yum is the package manager
     if is_command dnf ; then
         PKG_MANAGER="dnf"
     else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -477,16 +477,14 @@ elif grep -qiE 'centos|scientific' /etc/redhat-release; then
                 exit 1
             fi
         fi
-    fi
-fi
-else
-    # Warn user of unsupported version of Fedora or CentOS
+    fi    # Warn user of unsupported version of Fedora or CentOS
     if ! whiptail --defaultno --title "Unsupported RPM based distribution" --yesno "Would you like to continue installation on an unsupported RPM based distribution?\\n\\nPlease ensure the following packages have been installed manually:\\n\\n- lighttpd\\n- lighttpd-fastcgi\\n- PHP version 7+" "${r}" "${c}"; then
         printf "  %b Aborting installation due to unsupported RPM based distribution\\n" "${CROSS}"
         exit
     else
         printf "  %b Continuing installation with unsupported RPM based distribution\\n" "${INFO}"
     fi
+fi
 fi
 }
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2549,7 +2549,7 @@ main() {
     notify_package_updates_available
 
     # Install packages necessary to perform os_check
-    printf "  %b Checking for / installing Required dependencies for OS Check ...\\n" "${INFO}"
+    printf "  %b Checking for / installing Required dependencies for OS Check...\\n" "${INFO}"
     install_dependent_packages "${OS_CHECK_DEPS[@]}"
 
     # Check that the installed OS is officially supported - display warning if not
@@ -2655,7 +2655,7 @@ main() {
     local theRest
     theRest="${funcOutput%pihole-FTL*}" # Print the rest of get_binary_name's output to display (cut out from first instance of "pihole-FTL")
     if ! FTLdetect "${binary}" "${theRest}"; then
-        printf "  %b FRed Hat family OSTL Engine not installed\\n" "${CROSS}"
+        printf "  %b FTL Engine not installed\\n" "${CROSS}"
         exit 1
     fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -377,7 +377,7 @@ if is_command apt-get ; then
 
 # If apt-get is not found, check for rpm to see if it's a Red Hat family OS
 elif is_command rpm ; then
-    # Then check if dnf or yum is the package manager
+    # Then check if dnf or yum is the package man=dfsdfager
     if is_command dnf ; then
         PKG_MANAGER="dnf"
     else
@@ -394,89 +394,6 @@ elif is_command rpm ; then
     LIGHTTPD_USER="lighttpd"
     LIGHTTPD_GROUP="lighttpd"
     LIGHTTPD_CFG="lighttpd.conf.fedora"
-    # If the host OS is Fedora,
-    if grep -qiE 'fedora|fedberry' /etc/redhat-release; then
-        # all required packages should be available by default with the latest fedora release
-        : # continue
-    # or if host OS is CentOS,
-    elif grep -qiE 'centos|scientific' /etc/redhat-release; then
-        # Pi-Hole currently supports CentOS 7+ with PHP7+
-        SUPPORTED_CENTOS_VERSION=7
-        SUPPORTED_CENTOS_PHP_VERSION=7
-        # Check current CentOS major release version
-        CURRENT_CENTOS_VERSION=$(grep -oP '(?<= )[0-9]+(?=\.?)' /etc/redhat-release)
-        # Check if CentOS version is supported
-        if [[ $CURRENT_CENTOS_VERSION -lt $SUPPORTED_CENTOS_VERSION ]]; then
-            printf "  %b CentOS %s is not supported.\\n" "${CROSS}" "${CURRENT_CENTOS_VERSION}"
-            printf "      Please update to CentOS release %s or later.\\n" "${SUPPORTED_CENTOS_VERSION}"
-            # exit the installer
-            exit
-        fi
-        # php-json is not required on CentOS 7 as it is already compiled into php
-        # verifiy via `php -m | grep json`
-        if [[ $CURRENT_CENTOS_VERSION -eq 7 ]]; then
-            # create a temporary array as arrays are not designed for use as mutable data structures
-            CENTOS7_PIHOLE_WEB_DEPS=()
-            for i in "${!PIHOLE_WEB_DEPS[@]}"; do
-                if [[ ${PIHOLE_WEB_DEPS[i]} != "php-json" ]]; then
-                    CENTOS7_PIHOLE_WEB_DEPS+=( "${PIHOLE_WEB_DEPS[i]}" )
-                fi
-            done
-            # re-assign the clean dependency array back to PIHOLE_WEB_DEPS
-            PIHOLE_WEB_DEPS=("${CENTOS7_PIHOLE_WEB_DEPS[@]}")
-            unset CENTOS7_PIHOLE_WEB_DEPS
-        fi
-        # CentOS requires the EPEL repository to gain access to Fedora packages
-        EPEL_PKG="epel-release"
-        rpm -q ${EPEL_PKG} &> /dev/null || rc=$?
-        if [[ $rc -ne 0 ]]; then
-            printf "  %b Enabling EPEL package repository (https://fedoraproject.org/wiki/EPEL)\\n" "${INFO}"
-            "${PKG_INSTALL[@]}" ${EPEL_PKG} &> /dev/null
-            printf "  %b Installed %s\\n" "${TICK}" "${EPEL_PKG}"
-        fi
-
-        # The default php on CentOS 7.x is 5.4 which is EOL
-        # Check if the version of PHP available via installed repositories is >= to PHP 7
-        AVAILABLE_PHP_VERSION=$("${PKG_MANAGER}" info php | grep -i version | grep -o '[0-9]\+' | head -1)
-        if [[ $AVAILABLE_PHP_VERSION -ge $SUPPORTED_CENTOS_PHP_VERSION ]]; then
-            # Since PHP 7 is available by default, install via default PHP package names
-            : # do nothing as PHP is current
-        else
-            REMI_PKG="remi-release"
-            REMI_REPO="remi-php72"
-            rpm -q ${REMI_PKG} &> /dev/null || rc=$?
-        if [[ $rc -ne 0 ]]; then
-            # The PHP version available via default repositories is older than version 7
-            if ! whiptail --defaultno --title "PHP 7 Update (recommended)" --yesno "PHP 7.x is recommended for both security and language features.\\nWould you like to install PHP7 via Remi's RPM repository?\\n\\nSee: https://rpms.remirepo.net for more information" "${r}" "${c}"; then
-                # User decided to NOT update PHP from REMI, attempt to install the default available PHP version
-                printf "  %b User opt-out of PHP 7 upgrade on CentOS. Deprecated PHP may be in use.\\n" "${INFO}"
-                : # continue with unsupported php version
-            else
-                printf "  %b Enabling Remi's RPM repository (https://rpms.remirepo.net)\\n" "${INFO}"
-                "${PKG_INSTALL[@]}" "https://rpms.remirepo.net/enterprise/${REMI_PKG}-$(rpm -E '%{rhel}').rpm" &> /dev/null
-                # enable the PHP 7 repository via yum-config-manager (provided by yum-utils)
-                "${PKG_INSTALL[@]}" "yum-utils" &> /dev/null
-                yum-config-manager --enable ${REMI_REPO} &> /dev/null
-                printf "  %b Remi's RPM repository has been enabled for PHP7\\n" "${TICK}"
-                # trigger an install/update of PHP to ensure previous version of PHP is updated from REMI
-                if "${PKG_INSTALL[@]}" "php-cli" &> /dev/null; then
-                    printf "  %b PHP7 installed/updated via Remi's RPM repository\\n" "${TICK}"
-                else
-                    printf "  %b There was a problem updating to PHP7 via Remi's RPM repository\\n" "${CROSS}"
-                    exit 1
-                fi
-            fi
-        fi
-    fi
-    else
-        # Warn user of unsupported version of Fedora or CentOS
-        if ! whiptail --defaultno --title "Unsupported RPM based distribution" --yesno "Would you like to continue installation on an unsupported RPM based distribution?\\n\\nPlease ensure the following packages have been installed manually:\\n\\n- lighttpd\\n- lighttpd-fastcgi\\n- PHP version 7+" "${r}" "${c}"; then
-            printf "  %b Aborting installation due to unsupported RPM based distribution\\n" "${CROSS}"
-            exit
-        else
-            printf "  %b Continuing installation with unsupported RPM based distribution\\n" "${INFO}"
-        fi
-    fi
 
 # If neither apt-get or yum/dnf package managers were found
 else
@@ -484,6 +401,92 @@ else
     printf "  %b OS distribution not supported\\n" "${CROSS}"
     # so exit the installer
     exit
+fi
+}
+
+select_rpm_php(){
+# If the host OS is Fedora,
+if grep -qiE 'fedora|fedberry' /etc/redhat-release; then
+    # all required packages should be available by default with the latest fedora release
+    : # continue
+# or if host OS is CentOS,
+elif grep -qiE 'centos|scientific' /etc/redhat-release; then
+    # Pi-Hole currently supports CentOS 7+ with PHP7+
+    SUPPORTED_CENTOS_VERSION=7
+    SUPPORTED_CENTOS_PHP_VERSION=7
+    # Check current CentOS major release version
+    CURRENT_CENTOS_VERSION=$(grep -oP '(?<= )[0-9]+(?=\.?)' /etc/redhat-release)
+    # Check if CentOS version is supported
+    if [[ $CURRENT_CENTOS_VERSION -lt $SUPPORTED_CENTOS_VERSION ]]; then
+        printf "  %b CentOS %s is not supported.\\n" "${CROSS}" "${CURRENT_CENTOS_VERSION}"
+        printf "      Please update to CentOS release %s or later.\\n" "${SUPPORTED_CENTOS_VERSION}"
+        # exit the installer
+        exit
+    fi
+    # php-json is not required on CentOS 7 as it is already compiled into php
+    # verifiy via `php -m | grep json`
+    if [[ $CURRENT_CENTOS_VERSION -eq 7 ]]; then
+        # create a temporary array as arrays are not designed for use as mutable data structures
+        CENTOS7_PIHOLE_WEB_DEPS=()
+        for i in "${!PIHOLE_WEB_DEPS[@]}"; do
+            if [[ ${PIHOLE_WEB_DEPS[i]} != "php-json" ]]; then
+                CENTOS7_PIHOLE_WEB_DEPS+=( "${PIHOLE_WEB_DEPS[i]}" )
+            fi
+        done
+        # re-assign the clean dependency array back to PIHOLE_WEB_DEPS
+        PIHOLE_WEB_DEPS=("${CENTOS7_PIHOLE_WEB_DEPS[@]}")
+        unset CENTOS7_PIHOLE_WEB_DEPS
+    fi
+    # CentOS requires the EPEL repository to gain access to Fedora packages
+    EPEL_PKG="epel-release"
+    rpm -q ${EPEL_PKG} &> /dev/null || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        printf "  %b Enabling EPEL package repository (https://fedoraproject.org/wiki/EPEL)\\n" "${INFO}"
+        "${PKG_INSTALL[@]}" ${EPEL_PKG} &> /dev/null
+        printf "  %b Installed %s\\n" "${TICK}" "${EPEL_PKG}"
+    fi
+
+    # The default php on CentOS 7.x is 5.4 which is EOL
+    # Check if the version of PHP available via installed repositories is >= to PHP 7
+    AVAILABLE_PHP_VERSION=$("${PKG_MANAGER}" info php | grep -i version | grep -o '[0-9]\+' | head -1)
+    if [[ $AVAILABLE_PHP_VERSION -ge $SUPPORTED_CENTOS_PHP_VERSION ]]; then
+        # Since PHP 7 is available by default, install via default PHP package names
+        : # do nothing as PHP is current
+    else
+        REMI_PKG="remi-release"
+        REMI_REPO="remi-php72"
+        rpm -q ${REMI_PKG} &> /dev/null || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        # The PHP version available via default repositories is older than version 7
+        if ! whiptail --defaultno --title "PHP 7 Update (recommended)" --yesno "PHP 7.x is recommended for both security and language features.\\nWould you like to install PHP7 via Remi's RPM repository?\\n\\nSee: https://rpms.remirepo.net for more information" "${r}" "${c}"; then
+            # User decided to NOT update PHP from REMI, attempt to install the default available PHP version
+            printf "  %b User opt-out of PHP 7 upgrade on CentOS. Deprecated PHP may be in use.\\n" "${INFO}"
+            : # continue with unsupported php version
+        else
+            printf "  %b Enabling Remi's RPM repository (https://rpms.remirepo.net)\\n" "${INFO}"
+            "${PKG_INSTALL[@]}" "https://rpms.remirepo.net/enterprise/${REMI_PKG}-$(rpm -E '%{rhel}').rpm" &> /dev/null
+            # enable the PHP 7 repository via yum-config-manager (provided by yum-utils)
+            "${PKG_INSTALL[@]}" "yum-utils" &> /dev/null
+            yum-config-manager --enable ${REMI_REPO} &> /dev/null
+            printf "  %b Remi's RPM repository has been enabled for PHP7\\n" "${TICK}"
+            # trigger an install/update of PHP to ensure previous version of PHP is updated from REMI
+            if "${PKG_INSTALL[@]}" "php-cli" &> /dev/null; then
+                printf "  %b PHP7 installed/updated via Remi's RPM repository\\n" "${TICK}"
+            else
+                printf "  %b There was a problem updating to PHP7 via Remi's RPM repository\\n" "${CROSS}"
+                exit 1
+            fi
+        fi
+    fi
+fi
+else
+    # Warn user of unsupported version of Fedora or CentOS
+    if ! whiptail --defaultno --title "Unsupported RPM based distribution" --yesno "Would you like to continue installation on an unsupported RPM based distribution?\\n\\nPlease ensure the following packages have been installed manually:\\n\\n- lighttpd\\n- lighttpd-fastcgi\\n- PHP version 7+" "${r}" "${c}"; then
+        printf "  %b Aborting installation due to unsupported RPM based distribution\\n" "${CROSS}"
+        exit
+    else
+        printf "  %b Continuing installation with unsupported RPM based distribution\\n" "${INFO}"
+    fi
 fi
 }
 
@@ -2546,7 +2549,7 @@ main() {
     notify_package_updates_available
 
     # Install packages necessary to perform os_check
-    printf "  %b Checking for / installing Required dependencies for OS Check...\\n" "${INFO}"
+    printf "  %b Checking for / installing Required dependencies for OS Check ...\\n" "${INFO}"
     install_dependent_packages "${OS_CHECK_DEPS[@]}"
 
     # Check that the installed OS is officially supported - display warning if not
@@ -2555,6 +2558,11 @@ main() {
     # Install packages used by this installation script
     printf "  %b Checking for / installing Required dependencies for this install script...\\n" "${INFO}"
     install_dependent_packages "${INSTALLER_DEPS[@]}"
+
+    #In case of RPM based distro, select the proper PHP version
+    if [[ "$PKG_MANAGER" == "yum" || "$PKG_MANAGER" == "dnf" ]] ; then
+      select_rpm_php
+    fi
 
     # Check if SELinux is Enforcing
     checkSelinux
@@ -2647,7 +2655,7 @@ main() {
     local theRest
     theRest="${funcOutput%pihole-FTL*}" # Print the rest of get_binary_name's output to display (cut out from first instance of "pihole-FTL")
     if ! FTLdetect "${binary}" "${theRest}"; then
-        printf "  %b FTL Engine not installed\\n" "${CROSS}"
+        printf "  %b FRed Hat family OSTL Engine not installed\\n" "${CROSS}"
         exit 1
     fi
 

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -618,6 +618,7 @@ def test_package_manager_has_pihole_deps(Pihole):
     output = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     install_dependent_packages ${PIHOLE_DEPS[@]}
     ''')
 
@@ -631,6 +632,7 @@ def test_package_manager_has_web_deps(Pihole):
     output = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     install_dependent_packages ${PIHOLE_WEB_DEPS[@]}
     ''')
 

--- a/test/test_centos_7_support.py
+++ b/test/test_centos_7_support.py
@@ -12,6 +12,7 @@ def test_php_upgrade_default_optout_centos_eq_7(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     expected_stdout = info_box + (' User opt-out of PHP 7 upgrade on CentOS. '
                                   'Deprecated PHP may be in use.')
@@ -30,6 +31,7 @@ def test_php_upgrade_user_optout_centos_eq_7(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     expected_stdout = info_box + (' User opt-out of PHP 7 upgrade on CentOS. '
                                   'Deprecated PHP may be in use.')
@@ -48,6 +50,7 @@ def test_php_upgrade_user_optin_centos_eq_7(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     assert 'opt-out' not in package_manager_detect.stdout
     expected_stdout = info_box + (' Enabling Remi\'s RPM repository '

--- a/test/test_centos_8_support.py
+++ b/test/test_centos_8_support.py
@@ -13,6 +13,7 @@ def test_php_upgrade_default_continue_centos_gte_8(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     unexpected_stdout = info_box + (' User opt-out of PHP 7 upgrade on CentOS.'
                                     ' Deprecated PHP may be in use.')
@@ -33,6 +34,7 @@ def test_php_upgrade_user_optout_skipped_centos_gte_8(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     unexpected_stdout = info_box + (' User opt-out of PHP 7 upgrade on CentOS.'
                                     ' Deprecated PHP may be in use.')
@@ -53,6 +55,7 @@ def test_php_upgrade_user_optin_skipped_centos_gte_8(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     assert 'opt-out' not in package_manager_detect.stdout
     unexpected_stdout = info_box + (' Enabling Remi\'s RPM repository '

--- a/test/test_centos_common_support.py
+++ b/test/test_centos_common_support.py
@@ -16,6 +16,7 @@ def test_release_supported_version_check_centos(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     expected_stdout = cross_box + (' CentOS 6 is not supported.')
     assert expected_stdout in package_manager_detect.stdout
@@ -30,6 +31,7 @@ def test_enable_epel_repository_centos(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     expected_stdout = info_box + (' Enabling EPEL package repository '
                                   '(https://fedoraproject.org/wiki/EPEL)')
@@ -54,6 +56,7 @@ def test_php_version_lt_7_detected_upgrade_default_optout_centos(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     expected_stdout = info_box + (' User opt-out of PHP 7 upgrade on CentOS. '
                                   'Deprecated PHP may be in use.')
@@ -78,6 +81,7 @@ def test_php_version_lt_7_detected_upgrade_user_optout_centos(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     expected_stdout = info_box + (' User opt-out of PHP 7 upgrade on CentOS. '
                                   'Deprecated PHP may be in use.')
@@ -102,6 +106,7 @@ def test_php_version_lt_7_detected_upgrade_user_optin_centos(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     install_dependent_packages PIHOLE_WEB_DEPS[@]
     ''')
     expected_stdout = info_box + (' User opt-out of PHP 7 upgrade on CentOS. '

--- a/test/test_fedora_support.py
+++ b/test/test_fedora_support.py
@@ -6,6 +6,7 @@ def test_epel_and_remi_not_installed_fedora(Pihole):
     package_manager_detect = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
+    select_rpm_php
     ''')
     assert package_manager_detect.stdout == ''
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

Refractor the `RPM` block of detect_package_manager to ensure `whiptail` package is already installed when the PHP selection happens. Prior to the PR, installation of install_dependent_packages "${INSTALLER_DEPS[@]} happend after the selection, so in some circumstances `whiptail` might not have been present

See the discussion here #3297
