### PR TITLE
Use --no-progress-meter instead of --silent so error reasons are printed

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1334,7 +1334,7 @@ curl_to_tricorder() {
     # Users can submit their debug logs using curl (encrypted)
     log_write "    * Using ${COL_GREEN}curl${COL_NC} for transmission."
     # transmit he log via TLS and store the token returned in a variable
-    tricorder_token=$(curl --silent --upload-file ${PIHOLE_DEBUG_LOG} https://tricorder.pi-hole.net)
+    tricorder_token="$(curl --no-progress-meter --upload-file ${PIHOLE_DEBUG_LOG} https://tricorder.pi-hole.net)"
     if [ -z "${tricorder_token}" ]; then
         log_write "    * ${COL_GREEN}curl${COL_NC} failed, contact Pi-hole support for assistance."
     fi

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1333,7 +1333,7 @@ analyze_pihole_log() {
 curl_to_tricorder() {
     # Users can submit their debug logs using curl (encrypted)
     log_write "    * Using ${COL_GREEN}curl${COL_NC} for transmission."
-    # transmit he log via TLS and store the token returned in a variable
+    # transmit the log via TLS and store the token returned in a variable
     tricorder_token=$(curl --silent --fail --show-error --upload-file ${PIHOLE_DEBUG_LOG} https://tricorder.pi-hole.net 2>&1)
     if [[ "${tricorder_token}" != "https://tricorder.pi-hole.net/"* ]]; then
         log_write "    * ${COL_GREEN}curl${COL_NC} failed, contact Pi-hole support for assistance."

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1338,7 +1338,7 @@ curl_to_tricorder() {
     if [[ "${tricorder_token}" != "https://tricorder.pi-hole.net/"* ]]; then
         log_write "    * ${COL_GREEN}curl${COL_NC} failed, contact Pi-hole support for assistance."
         # Log curl error (if available)
-        if [ ! -z "${tricorder_token}" ]; then
+        if [ -n "${tricorder_token}" ]; then
             log_write "    * Error message: ${COL_RED}${tricorder_token}${COL_NC}\\n"
             tricorder_token=""
         fi
@@ -1386,15 +1386,14 @@ upload_to_tricorder() {
         # Again, try to make this visually striking so the user realizes they need to do something with this information
         # Namely, provide the Pi-hole devs with the token
         log_write ""
-        log_write "${COL_PURPLE}***********************************${COL_NC}"
-        log_write "${COL_PURPLE}***********************************${COL_NC}"
+        log_write "${COL_PURPLE}*****************************************************************${COL_NC}"
+        log_write "${COL_PURPLE}*****************************************************************${COL_NC}\\n"
         log_write "${TICK} Your debug token is: ${COL_GREEN}${tricorder_token}${COL_NC}"
-        log_write "${INFO}${COL_RED} Logs are deleted 48 hours after upload.${COL_NC}"
-        log_write "${COL_PURPLE}***********************************${COL_NC}"
-        log_write "${COL_PURPLE}***********************************${COL_NC}"
+        log_write "${INFO}${COL_RED} Logs are deleted 48 hours after upload.${COL_NC}\\n"
+        log_write "${COL_PURPLE}*****************************************************************${COL_NC}"
+        log_write "${COL_PURPLE}*****************************************************************${COL_NC}"
         log_write ""
-        log_write "   * Provide the token above to the Pi-hole team for assistance at"
-        log_write "   * ${FORUMS_URL}"
+        log_write "   * Provide the token above to the Pi-hole team for assistance at ${FORUMS_URL}"
 
     # If no token was generated
     else

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1334,9 +1334,14 @@ curl_to_tricorder() {
     # Users can submit their debug logs using curl (encrypted)
     log_write "    * Using ${COL_GREEN}curl${COL_NC} for transmission."
     # transmit he log via TLS and store the token returned in a variable
-    tricorder_token="$(curl --no-progress-meter --upload-file ${PIHOLE_DEBUG_LOG} https://tricorder.pi-hole.net)"
-    if [ -z "${tricorder_token}" ]; then
+    tricorder_token=$(curl --silent --fail --show-error --upload-file ${PIHOLE_DEBUG_LOG} https://tricorder.pi-hole.net 2>&1)
+    if [[ "${tricorder_token}" != "https://tricorder.pi-hole.net/"* ]]; then
         log_write "    * ${COL_GREEN}curl${COL_NC} failed, contact Pi-hole support for assistance."
+        # Log curl error (if available)
+        if [ ! -z "${tricorder_token}" ]; then
+            log_write "    * Error message: ${COL_RED}${tricorder_token}${COL_NC}\\n"
+            tricorder_token=""
+        fi
     fi
 }
 

--- a/pihole
+++ b/pihole
@@ -409,7 +409,7 @@ tricorderFunc() {
   if [[ "${tricorder_token}" != "https://tricorder.pi-hole.net/"* ]]; then
       echo -e "${CROSS} uploading failed, contact Pi-hole support for assistance."
       # Log curl error (if available)
-      if [ ! -z "${tricorder_token}" ]; then
+      if [ -n "${tricorder_token}" ]; then
           echo -e "${INFO} Error message: ${COL_RED}${tricorder_token}${COL_NC}\\n"
           tricorder_token=""
       fi

--- a/pihole
+++ b/pihole
@@ -405,12 +405,17 @@ tricorderFunc() {
     exit 1
   fi
 
-  tricorder_token="$(curl --no-progress-meter --upload-file "-" https://tricorder.pi-hole.net/upload < /dev/stdin)"
-  if [ -z "${tricorder_token}" ]; then
-        echo -e "${CROSS} uploading failed, contact Pi-hole support for assistance."
-        exit 1
+  tricorder_token=$(curl --silent --fail --show-error --upload-file "-" https://tricorder.pi-hole.net/upload < /dev/stdin 2>&1)
+  if [[ "${tricorder_token}" != "https://tricorder.pi-hole.net/"* ]]; then
+      echo -e "${CROSS} uploading failed, contact Pi-hole support for assistance."
+      # Log curl error (if available)
+      if [ ! -z "${tricorder_token}" ]; then
+          echo -e "${INFO} Error message: ${COL_RED}${tricorder_token}${COL_NC}\\n"
+          tricorder_token=""
+      fi
+      exit 1
   fi
-  echo "Upload successful, your token is: ${COL_BLUE}${tricorder_token}${COL_NC}"
+  echo "Upload successful, your token is: ${COL_GREEN}${tricorder_token}${COL_NC}"
   exit 0
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Keep and print possible errors when `curl` fails to upload to Tricorder.

**How does this PR accomplish the above?:**

Use `--no-progress-meter` instead of `--silent` in the `curl` call

**What documentation changes (if any) are needed to support this PR?:**

None