### PR TITLE
Add content of /etc/resolv.conf to debug output

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -73,6 +73,7 @@ HTML_DIRECTORY="/var/www/html"
 WEB_GIT_DIRECTORY="${HTML_DIRECTORY}/admin"
 #BLOCK_PAGE_DIRECTORY="${HTML_DIRECTORY}/pihole"
 SHM_DIRECTORY="/dev/shm"
+ETC="/etc"
 
 # Files required by Pi-hole
 # https://discourse.pi-hole.net/t/what-files-does-pi-hole-use/1684
@@ -136,6 +137,8 @@ PIHOLE_FTL_LOG="$(get_ftl_conf_value "LOGFILE" "${LOG_DIRECTORY}/pihole-FTL.log"
 PIHOLE_WEB_SERVER_ACCESS_LOG_FILE="${WEB_SERVER_LOG_DIRECTORY}/access.log"
 PIHOLE_WEB_SERVER_ERROR_LOG_FILE="${WEB_SERVER_LOG_DIRECTORY}/error.log"
 
+RESOLVCONF="${ETC}/resolv.conf"
+
 # An array of operating system "pretty names" that we officially support
 # We can loop through the array at any time to see if it matches a value
 #SUPPORTED_OS=("Raspbian" "Ubuntu" "Fedora" "Debian" "CentOS")
@@ -180,7 +183,8 @@ REQUIRED_FILES=("${PIHOLE_CRON_FILE}"
 "${PIHOLE_DEBUG_LOG}"
 "${PIHOLE_FTL_LOG}"
 "${PIHOLE_WEB_SERVER_ACCESS_LOG_FILE}"
-"${PIHOLE_WEB_SERVER_ERROR_LOG_FILE}")
+"${PIHOLE_WEB_SERVER_ERROR_LOG_FILE}"
+"${RESOLVCONF}")
 
 DISCLAIMER="This process collects information from your Pi-hole, and optionally uploads it to a unique and random directory on tricorder.pi-hole.net.
 
@@ -1118,6 +1122,7 @@ show_content_of_pihole_files() {
     show_content_of_files_in_dir "${WEB_SERVER_LOG_DIRECTORY}"
     show_content_of_files_in_dir "${LOG_DIRECTORY}"
     show_content_of_files_in_dir "${SHM_DIRECTORY}"
+    show_content_of_files_in_dir "${ETC}"
 }
 
 head_tail_log() {


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Sometimes we see support requests on discourse where the solution turned out to be changing nameservers in `/etc/resolv.conf`. So far, the content of this file was not part of the debug log.


**How does this PR accomplish the above?:**
Adding `/etc` to the list of `show_content_of_pihole_files` and `/etc/resolv.conf` to `REQUIRED_FILES`. This ensures that only the content of this file is included in the debug log.


Example output

```
-rw------- 1 pihole pihole 8.0K Sep  5 20:24 /dev/shm/FTL-overTime
-rw------- 1 pihole pihole 4.0K Sep  5 20:24 /dev/shm/FTL-per-client-regex
-rw------- 1 pihole pihole 1.3M Sep  5 20:24 /dev/shm/FTL-queries
-rw------- 1 pihole pihole 12 Sep  5 20:24 /dev/shm/FTL-settings
-rw------- 1 pihole pihole 80K Sep  5 20:24 /dev/shm/FTL-strings
-rw------- 1 pihole pihole 20K Sep  5 20:24 /dev/shm/FTL-upstreams

*** [ DIAGNOSING ]: contents of /etc

-rw-r--r-- 1 root root 70 Sep  5 20:24 /etc/resolv.conf
   nameserver 127.0.0.1
   nameserver 8.8.8.8

*** [ DIAGNOSING ]: Pi-hole diagnosis messages

*** [ DIAGNOSING ]: Locale
    LANG=en_US.UTF-8
```

