### PR TITLE
Add content of /etc/dnsmasq.conf to debug output

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -138,6 +138,7 @@ PIHOLE_WEB_SERVER_ACCESS_LOG_FILE="${WEB_SERVER_LOG_DIRECTORY}/access.log"
 PIHOLE_WEB_SERVER_ERROR_LOG_FILE="${WEB_SERVER_LOG_DIRECTORY}/error.log"
 
 RESOLVCONF="${ETC}/resolv.conf"
+DNSMASQ_CONF="${ETC}/dnsmasq.conf"
 
 # An array of operating system "pretty names" that we officially support
 # We can loop through the array at any time to see if it matches a value
@@ -184,7 +185,8 @@ REQUIRED_FILES=("${PIHOLE_CRON_FILE}"
 "${PIHOLE_FTL_LOG}"
 "${PIHOLE_WEB_SERVER_ACCESS_LOG_FILE}"
 "${PIHOLE_WEB_SERVER_ERROR_LOG_FILE}"
-"${RESOLVCONF}")
+"${RESOLVCONF}"
+"${DNSMASQ_CONF}")
 
 DISCLAIMER="This process collects information from your Pi-hole, and optionally uploads it to a unique and random directory on tricorder.pi-hole.net.
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Does what it says. Inspired by https://github.com/pi-hole/pi-hole/pull/4311#issuecomment-913471968


Sample output

```
-rw------- 1 pihole pihole 12 Sep  2 06:43 /dev/shm/FTL-settings
-rw------- 1 pihole pihole 120K Sep  6 16:49 /dev/shm/FTL-strings
-rw------- 1 pihole pihole 20K Sep  2 06:43 /dev/shm/FTL-upstreams

*** [ DIAGNOSING ]: contents of /etc

-rw-r--r-- 1 root root 24 Sep  1 20:24 /etc/dnsmasq.conf
   conf-dir=/etc/dnsmasq.d

-rw-r--r-- 1 root root 69 Aug 31 22:01 /etc/resolv.conf
   nameserver 8.8.8.8
   nameserver 10.0.1.1

*** [ DIAGNOSING ]: Pi-hole diagnosis messages
```


