### PR TITLE
Fix for gravity syntax error (see #4322)

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -122,7 +122,7 @@ gravity_swap_databases() {
   gravityBlocks=$(stat --format "%b" ${gravityDBfile})
   # Only keep the old database if available disk space is at least twice the size of the existing gravity.db.
   # Better be safe than sorry...
-  if [ "${availableBlocks}" -gt "$(("${gravityBlocks}" * 2))" ] && [ -f "${gravityDBfile}" ]; then
+  if [ "${availableBlocks}" -gt "$((gravityBlocks * 2))" ] && [ -f "${gravityDBfile}" ]; then
     echo -e "  ${TICK} The old database remains available."
     mv "${gravityDBfile}" "${gravityOLDfile}"
   else


### PR DESCRIPTION
Signed-off-by: jpgpi250 <jpgpi250@gmail.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
fix Pi-hole v5.4 update - syntax error #4322 which should only affect systems, running bash prior to v4.4, such as Ubuntu 16.04.7 LTS

**How does this PR accomplish the above?:**
changed "$(("${gravityBlocks}" * 2))" into "$((gravityBlocks * 2))" as already indicated by Dan Schaper, thanks for that


**What documentation changes (if any) are needed to support this PR?:**
none

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
