### PR TITLE
Export DNS_FQDN_REQUIRED and DNS_BOGUS_PRIV to setupVars.conf during installation

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1814,6 +1814,8 @@ finalExports() {
     echo "INSTALL_WEB_INTERFACE=${INSTALL_WEB_INTERFACE}"
     echo "LIGHTTPD_ENABLED=${LIGHTTPD_ENABLED}"
     echo "CACHE_SIZE=${CACHE_SIZE}"
+    echo "DNS_FQDN_REQUIRED=true"
+    echo "DNS_BOGUS_PRIV=true"
     }>> "${setupVars}"
     chmod 644 "${setupVars}"
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
On a fresh installation there is a mismatch between the options "Never formward non-FQDN" and "Never forward reverse lookups for private IP ranges" which are apparently enabled on the web interface but the resp. options (domain-needed and bogus-priv) are missing in the `01-pihole.conf` dnsmasq config file.

Although the options are set in the template of `01-pihole.conf` located in the local repo clone, they are going to be removed at the end of the installation script because it calls 
https://github.com/pi-hole/pi-hole/blob/2673c2c0720fb3871a4c3cae6a3f38f9ccede24e/advanced/Scripts/webpage.sh#L147

from webpage.sh. The options would have been re-added by the script but only if `DNS_FQDN_REQUIRED` and `DNS_BOGUS_PRIV` are true. But they are not, because they have not been exported to `setupVars.conf` in the install scripts

https://github.com/pi-hole/pi-hole/blob/2673c2c0720fb3871a4c3cae6a3f38f9ccede24e/automated%20install/basic-install.sh#L1806-L1817

___
For more information see here: https://github.com/pi-hole/AdminLTE/pull/1873#issuecomment-917707168
___

I see two solutions to this:
1) Add DNS_FQDN_REQUIRED and DNS_BOGUS_PRIV to `setupVars.conf`
2) Don't tick the boxes in the web interface by default and remove the options from `01-pihole.conf` template

**How does this PR accomplish the above?:**
Implements solution 1.
Exports DNS_FQDN_REQUIRED and DNS_BOGUS_PRIV to setupVars.conf during installation


**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
