### PR TITLE
Added error handling for when sed is executed on a read-only filesystem.

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -67,16 +67,17 @@ addFTLsetting() {
 }
 
 deleteFTLsetting() {
-    sed -i "/^${1}/d" "${FTLconf}" &> /dev/null
+    sed -i "/^${1}/d" "${FTLconf}"
 }
 
 changeFTLsetting() {
     # Ensure the deleteFTLsetting call succeeds before adding the new setting's value.
     # On failure, print the error but allow the script to continue.
-    if deleteFTLsetting "${1}"; then
+    local error
+    if error=$(deleteFTLsetting "${1}" 2>&1); then
         addFTLsetting "${1}" "${2}"
     else
-        echo "Failed to delete ${1} setting in ${FTLconf}! This setting will remain unchanged."
+        echo -e "Failed to delete ${1} setting in ${FTLconf}! This setting will remain unchanged.\n- $error"
     fi
 }
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -58,8 +58,15 @@ delete_setting() {
 }
 
 change_setting() {
-    delete_setting "${1}"
-    add_setting "${1}" "${2}"
+    # Ensure the deleteFTLsetting call succeeds before adding the new setting's value.
+    # On failure, print the error but allow the script to continue.
+    success=true
+    deleteFTLsetting "${1}" || success=false
+    if [ "${success}" == true ]; then
+        addFTLsetting "${1}" "${2}"
+    else
+        echo "Failed to delete ${1} setting in ${FTLconf}! This setting will remain unchanged."
+    fi
 }
 
 addFTLsetting() {

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -58,15 +58,8 @@ delete_setting() {
 }
 
 change_setting() {
-    # Ensure the deleteFTLsetting call succeeds before adding the new setting's value.
-    # On failure, print the error but allow the script to continue.
-    success=true
-    deleteFTLsetting "${1}" || success=false
-    if [ "${success}" == true ]; then
-        addFTLsetting "${1}" "${2}"
-    else
-        echo "Failed to delete ${1} setting in ${FTLconf}! This setting will remain unchanged."
-    fi
+    delete_setting "${1}"
+    add_setting "${1}" "${2}"
 }
 
 addFTLsetting() {
@@ -74,12 +67,17 @@ addFTLsetting() {
 }
 
 deleteFTLsetting() {
-    sed -i "/^${1}/d" "${FTLconf}"
+    sed -i "/^${1}/d" "${FTLconf}" &> /dev/null
 }
 
 changeFTLsetting() {
-    deleteFTLsetting "${1}"
-    addFTLsetting "${1}" "${2}"
+    # Ensure the deleteFTLsetting call succeeds before adding the new setting's value.
+    # On failure, print the error but allow the script to continue.
+    if deleteFTLsetting "${1}"; then
+        addFTLsetting "${1}" "${2}"
+    else
+        echo "Failed to delete ${1} setting in ${FTLconf}! This setting will remain unchanged."
+    fi
 }
 
 add_dnsmasq_setting() {

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -77,7 +77,7 @@ changeFTLsetting() {
     if error=$(deleteFTLsetting "${1}" 2>&1); then
         addFTLsetting "${1}" "${2}"
     else
-        echo -e "Failed to delete ${1} setting in ${FTLconf}! This setting will remain unchanged.\n- $error"
+        echo -e "Failed to delete ${1} setting in ${FTLconf}! This setting will remain unchanged.\n- ${error}"
     fi
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**

When a setting change is attempted on Kubernetes deployment having `pihole-FTL.conf` volume-mounted using a ConfigMap, the `sed` call in `deleteFTLsetting` fails, which in turn causes `20-start.sh` to error out, which in turn causes the pod to crash loop.

This addresses https://github.com/pi-hole/docker-pi-hole/issues/922


**How does this PR accomplish the above?:**

Added error handling to the `changeFTLsetting` function: if the setting's deletion fails, the function will not attempt to re-add the setting with the supplied value and print an error message.


**What documentation changes (if any) are needed to support this PR?:**

No changes required.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
