### PR TITLE
Remove local-ttl from set of default dnsmasq options

### DIFF
--- a/advanced/01-pihole.conf
+++ b/advanced/01-pihole.conf
@@ -39,6 +39,4 @@ cache-size=@CACHE_SIZE@
 log-queries
 log-facility=/var/log/pihole.log
 
-local-ttl=2
-
 log-async


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Give users the ability to set `local-ttl` themselves if they want to.

**How does this PR accomplish the above?:**

We used `local-ttl` to control the TTL of blocked queries. We didn't want it to be too high to not render whitelisting ineffective. As https://github.com/pi-hole/FTL/pull/1173 decouples the TTL of blocked queries from other local names, the reason to set this config option vanished.

**What documentation changes (if any) are needed to support this PR?:**

None