### PR TITLE
Add `ca-certificates` to INSTALLER_DEPS

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -327,7 +327,7 @@ if is_command apt-get ; then
     # Packages required to perfom the os_check (stored as an array)
     OS_CHECK_DEPS=(grep dnsutils)
     # Packages required to run this install script (stored as an array)
-    INSTALLER_DEPS=(git "${iproute_pkg}" whiptail)
+    INSTALLER_DEPS=(git "${iproute_pkg}" whiptail ca-certificates)
     # Packages required to run Pi-hole (stored as an array)
     PIHOLE_DEPS=(cron curl iputils-ping lsof netcat psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2)
     # Packages required for the Web admin interface (stored as an array)
@@ -373,7 +373,7 @@ elif is_command rpm ; then
     PKG_INSTALL=("${PKG_MANAGER}" install -y)
     PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
     OS_CHECK_DEPS=(grep bind-utils)
-    INSTALLER_DEPS=(git iproute newt procps-ng which chkconfig)
+    INSTALLER_DEPS=(git iproute newt procps-ng which chkconfig ca-certificates)
     PIHOLE_DEPS=(cronie curl findutils nmap-ncat sudo unzip libidn2 psmisc sqlite libcap lsof)
     PIHOLE_WEB_DEPS=(lighttpd lighttpd-fastcgi php-common php-cli php-pdo php-xml php-json php-intl)
     LIGHTTPD_USER="lighttpd"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Partly fixes https://github.com/pi-hole/pi-hole/issues/4333

On fresh Debian 10 we have seen the installer to fail because `ca-certificates` was not present and cloning the git repository failed. 
Normally ca-certificates is installed as a recommended part of git. But, if the pi-hole installer uses apt-get "no-install-recommends" so "ca-certificates" does not get installed. 


**How does this PR accomplish the above?:**
Adds `ca-certificates` explicitly to `INSTALLER_DEPS`


**What documentation changes (if any) are needed to support this PR?:**
None.
