### PR TITLE
Do not export `DNS_FQDN_REQUIRED` and `DNS_BOGUS_PRIV` unconditionally

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1774,15 +1774,15 @@ finalExports() {
     echo "CACHE_SIZE=${CACHE_SIZE}"
     }>> "${setupVars}"
 
-    # if this runs the first time set the varibale to true otherwiese keep the old value
-    if ! grep -q '^DNS_FQDN_REQUIRED=' ${setupVars}; then
+    # if this runs the first time (variable not set yet) set the varibale to true otherwiese keep the old value
+    if [[ ! -v DNS_FQDN_REQUIRED ]]; then
       echo "DNS_FQDN_REQUIRED=true" >> "${setupVars}"
     else
       echo "DNS_FQDN_REQUIRED=${DNS_FQDN_REQUIRED}" >> "${setupVars}"
     fi
 
-    # if this runs the first time set the varibale to true otherwiese keep the old value
-    if ! grep -q '^DNS_BOGUS_PRIV=' ${setupVars}; then
+    # if this runs the first time (variable not set yet) set the varibale to true otherwiese keep the old value
+    if [[ ! -v DNS_BOGUS_PRIV ]]; then
       echo "DNS_BOGUS_PRIV=true" >> "${setupVars}"
     else
       echo "DNS_BOGUS_PRIV=${DNS_BOGUS_PRIV}" >> "${setupVars}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1772,14 +1772,9 @@ finalExports() {
     echo "INSTALL_WEB_INTERFACE=${INSTALL_WEB_INTERFACE}"
     echo "LIGHTTPD_ENABLED=${LIGHTTPD_ENABLED}"
     echo "CACHE_SIZE=${CACHE_SIZE}"
+    echo "DNS_FQDN_REQUIRED=${DNS_FQDN_REQUIRED:-true}"
+    echo "DNS_BOGUS_PRIV=${DNS_BOGUS_PRIV:-true}"
     }>> "${setupVars}"
-
-    # if this runs the first time (variable not set yet) set the varibale to true otherwiese keep the old value
-     echo "DNS_FQDN_REQUIRED=${DNS_FQDN_REQUIRED:-true}" >> "${setupVars}"
-
-    # if this runs the first time (variable not set yet) set the varibale to true otherwiese keep the old value
-    echo "DNS_BOGUS_PRIV=${DNS_BOGUS_PRIV:-true}" >> "${setupVars}"
-
     chmod 644 "${setupVars}"
 
     # Set the privacy level

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1775,18 +1775,10 @@ finalExports() {
     }>> "${setupVars}"
 
     # if this runs the first time (variable not set yet) set the varibale to true otherwiese keep the old value
-    if [[ ! -v DNS_FQDN_REQUIRED ]]; then
-      echo "DNS_FQDN_REQUIRED=true" >> "${setupVars}"
-    else
-      echo "DNS_FQDN_REQUIRED=${DNS_FQDN_REQUIRED}" >> "${setupVars}"
-    fi
+     echo "DNS_FQDN_REQUIRED=${DNS_FQDN_REQUIRED:-true}" >> "${setupVars}"
 
     # if this runs the first time (variable not set yet) set the varibale to true otherwiese keep the old value
-    if [[ ! -v DNS_BOGUS_PRIV ]]; then
-      echo "DNS_BOGUS_PRIV=true" >> "${setupVars}"
-    else
-      echo "DNS_BOGUS_PRIV=${DNS_BOGUS_PRIV}" >> "${setupVars}"
-    fi
+    echo "DNS_BOGUS_PRIV=${DNS_BOGUS_PRIV:-true}" >> "${setupVars}"
 
     chmod 644 "${setupVars}"
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1758,7 +1758,7 @@ finalExports() {
     # If the setup variable file exists,
     if [[ -e "${setupVars}" ]]; then
         # update the variables in the file
-        sed -i.update.bak '/PIHOLE_INTERFACE/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1\b/d;/PIHOLE_DNS_2\b/d;/QUERY_LOGGING/d;/INSTALL_WEB_SERVER/d;/INSTALL_WEB_INTERFACE/d;/LIGHTTPD_ENABLED/d;/CACHE_SIZE/d;' "${setupVars}"
+        sed -i.update.bak '/PIHOLE_INTERFACE/d;/IPV4_ADDRESS/d;/IPV6_ADDRESS/d;/PIHOLE_DNS_1\b/d;/PIHOLE_DNS_2\b/d;/QUERY_LOGGING/d;/INSTALL_WEB_SERVER/d;/INSTALL_WEB_INTERFACE/d;/LIGHTTPD_ENABLED/d;/CACHE_SIZE/d;/DNS_FQDN_REQUIRED/d;/DNS_BOGUS_PRIV/d;' "${setupVars}"
     fi
     # echo the information to the user
     {
@@ -1772,9 +1772,22 @@ finalExports() {
     echo "INSTALL_WEB_INTERFACE=${INSTALL_WEB_INTERFACE}"
     echo "LIGHTTPD_ENABLED=${LIGHTTPD_ENABLED}"
     echo "CACHE_SIZE=${CACHE_SIZE}"
-    echo "DNS_FQDN_REQUIRED=true"
-    echo "DNS_BOGUS_PRIV=true"
     }>> "${setupVars}"
+
+    # if this runs the first time set the varibale to true otherwiese keep the old value
+    if ! grep -q '^DNS_FQDN_REQUIRED=' ${setupVars}; then
+      echo "DNS_FQDN_REQUIRED=true" >> "${setupVars}"
+    else
+      echo "DNS_FQDN_REQUIRED=${DNS_FQDN_REQUIRED}" >> "${setupVars}"
+    fi
+
+    # if this runs the first time set the varibale to true otherwiese keep the old value
+    if ! grep -q '^DNS_BOGUS_PRIV=' ${setupVars}; then
+      echo "DNS_BOGUS_PRIV=true" >> "${setupVars}"
+    else
+      echo "DNS_BOGUS_PRIV=${DNS_BOGUS_PRIV}" >> "${setupVars}"
+    fi
+
     chmod 644 "${setupVars}"
 
     # Set the privacy level


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
https://github.com/pi-hole/pi-hole/pull/4327 added `DNS_FQDN_REQUIRED` and `DNS_BOGUS_PRIV` to the final export variables. 
However, this export was static and unconditionally. On every update, repair or core branch switch this would have added `variable=true` to `setupVars.conf`. 
This PR does two things:
1) if the variables have never been set (first install), it sets them to `true` (same as the other PR)
2) if they have been set before, preserve them during export.

