### PR TITLE
Download all adlists that are enabled during gravity run

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -379,8 +379,8 @@ gravity_DownloadBlocklists() {
 
   # Retrieve source URLs from gravity database
   # We source only enabled adlists, sqlite3 stores boolean values as 0 (false) or 1 (true)
-  mapfile -t sources <<< "$(sqlite3 "${gravityDBfile}" "SELECT address FROM vw_adlist;" 2> /dev/null)"
-  mapfile -t sourceIDs <<< "$(sqlite3 "${gravityDBfile}" "SELECT id FROM vw_adlist;" 2> /dev/null)"
+  mapfile -t sources <<< "$(sqlite3 "${gravityDBfile}" "SELECT address FROM adlist WHERE enabled = 1;" 2> /dev/null)"
+  mapfile -t sourceIDs <<< "$(sqlite3 "${gravityDBfile}" "SELECT id FROM adlist WHERE enabled =1;" 2> /dev/null)"
 
   # Parse source domains from $sources
   mapfile -t sourceDomains <<< "$(


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
So far, gravity will only download adlists that are in the `vw_adlist` which means
1) enabled
**AND**
2) in the default group or in at least one active group

https://github.com/pi-hole/pi-hole/blob/dad6247cb0c90fe8cc1ad541e0ccf8f02e1dd2be/gravity.sh#L383-L385

https://github.com/pi-hole/pi-hole/blob/dad6247cb0c90fe8cc1ad541e0ccf8f02e1dd2be/advanced/Templates/gravity.db.sql#L146-L151

This can confuse users as the web interface lists them as "active" suggesting they will be downloaded and stored in the database, even if the are only in a group that is (at the moment) not active.

This has been discussed here:
https://discourse.pi-hole.net/t/group-blocking-later-fails-if-blocklists-are-updated-when-the-group-is-disabled/50189

**How does this PR accomplish the above?:**
Instead of using `vw_adlist`, gravity downloads all adlists that are enabled, regardless of their group assignment.


**What documentation changes (if any) are needed to support this PR?:**
None.