### PR TITLE
Include df -h in debug log

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -587,11 +587,22 @@ processor_check() {
 
 disk_usage() {
     local file_system
+    local hide
+
     echo_current_diagnostic "Disk usage"
     mapfile -t file_system < <(df -h)
 
+    # Some lines of df might contain sensitive information like usernames and passwords.
+    # E.g. curlftpfs filesystems (https://www.looklinux.com/mount-ftp-share-on-linux-using-curlftps/)
+    # We are not interested in those lines so we collect keyword, to remove them from the output
+    # Additinal keywords can be added, separated by "|"
+    hide="curlftpfs"
+
+    # only show those lines not containg a sensitive phrase
     for line in "${file_system[@]}"; do
+      if [[ ! $line =~ $hide ]]; then
         log_write "   ${line}"
+      fi
     done
 }
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Does what it says. Sometimes we have seen Pi-hole issues which were related to full file system. This PR includes the ouput of `df -h` in the debug log.


```
*** [ DIAGNOSING ]: Processor
[✓] aarch64

*** [ DIAGNOSING ]: Disk usage
Filesystem      Size  Used Avail Use% Mounted on
udev            1.9G     0  1.9G   0% /dev
tmpfs           387M   40M  348M  11% /run
/dev/mmcblk1p1   58G  4.8G   53G   9% /
tmpfs           1.9G  2.2M  1.9G   1% /dev/shm
tmpfs           5.0M  4.0K  5.0M   1% /run/lock
tmpfs           1.9G     0  1.9G   0% /sys/fs/cgroup
tmpfs           1.9G  376M  1.6G  20% /tmp
/dev/zram1       49M   11M   35M  25% /var/log
tmpfs           387M     0  387M   0% /run/user/998
tmpfs           387M     0  387M   0% /run/user/1000

*** [ DIAGNOSING ]: Networking
[✓] IPv4 address(es) bound to the eth0 interface:
    10.0.1.5/24
```
