### PR TITLE
Re-order debug log

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1135,8 +1135,8 @@ show_content_of_files_in_dir() {
 
 show_content_of_pihole_config_files() {
     # Show the content of the files in each of Pi-hole's folders
-    show_content_of_files_in_dir "${ETC}"
     show_content_of_files_in_dir "${PIHOLE_DIRECTORY}"
+    show_content_of_files_in_dir "${ETC}"
     show_content_of_files_in_dir "${DNSMASQ_D_DIRECTORY}"
     show_content_of_files_in_dir "${WEB_SERVER_CONFIG_DIRECTORY}"
     show_content_of_files_in_dir "${CRON_D_DIRECTORY}"

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -782,7 +782,6 @@ check_networking() {
     # Runs through several of the functions made earlier; we just clump them
     # together since they are all related to the networking aspect of things
     echo_current_diagnostic "Networking"
-    check_required_ports
     detect_ip_addresses "4"
     detect_ip_addresses "6"
     ping_gateway "4"
@@ -1451,6 +1450,7 @@ check_firewalld
 processor_check
 parse_locale
 disk_usage
+check_required_ports
 check_networking
 check_name_resolution
 check_dhcp_servers

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -782,11 +782,11 @@ check_networking() {
     # Runs through several of the functions made earlier; we just clump them
     # together since they are all related to the networking aspect of things
     echo_current_diagnostic "Networking"
+    check_required_ports
     detect_ip_addresses "4"
     detect_ip_addresses "6"
     ping_gateway "4"
     ping_gateway "6"
-    check_required_ports
 }
 
 check_x_headers() {
@@ -1133,16 +1133,23 @@ show_content_of_files_in_dir() {
     list_files_in_dir "${directory}"
 }
 
-show_content_of_pihole_files() {
+show_content_of_pihole_config_files() {
     # Show the content of the files in each of Pi-hole's folders
+    show_content_of_files_in_dir "${ETC}"
     show_content_of_files_in_dir "${PIHOLE_DIRECTORY}"
     show_content_of_files_in_dir "${DNSMASQ_D_DIRECTORY}"
     show_content_of_files_in_dir "${WEB_SERVER_CONFIG_DIRECTORY}"
     show_content_of_files_in_dir "${CRON_D_DIRECTORY}"
-    show_content_of_files_in_dir "${WEB_SERVER_LOG_DIRECTORY}"
-    show_content_of_files_in_dir "${LOG_DIRECTORY}"
+}
+
+show_content_of_shm_files (){
     show_content_of_files_in_dir "${SHM_DIRECTORY}"
-    show_content_of_files_in_dir "${ETC}"
+}
+
+show_content_of_pihole_log_files() {
+  show_content_of_files_in_dir "${WEB_SERVER_LOG_DIRECTORY}"
+  show_content_of_files_in_dir "${LOG_DIRECTORY}"
+  analyze_pihole_log
 }
 
 head_tail_log() {
@@ -1442,22 +1449,23 @@ diagnose_operating_system
 check_selinux
 check_firewalld
 processor_check
+parse_locale
 disk_usage
 check_networking
 check_name_resolution
 check_dhcp_servers
 process_status
 ftl_full_status
+show_messages
+show_content_of_shm_files
 parse_setup_vars
+show_content_of_pihole_config_files
 check_x_headers
 analyze_gravity_list
 show_groups
 show_domainlist
 show_clients
 show_adlists
-show_content_of_pihole_files
-show_messages
-parse_locale
-analyze_pihole_log
+show_content_of_pihole_log_files
 copy_to_debug_log
 upload_to_tricorder


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Re-orders the components of the debug log into more logical groups.

old: https://tricorder.pi-hole.net/LmUi3gRu/
new: https://tricorder.pi-hole.net/8ngM2ToL/