### PR TITLE
Fix PHP8.0 detection

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -292,7 +292,7 @@ if is_command apt-get ; then
     # It's useful to separate this from Pi-hole, since the two repos are also setup separately
     PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-sqlite3" "${phpVer}-xml" "${phpVer}-intl")
     # Prior to PHP8.0, JSON functionality is provided as dedicated module, required by Pi-hole AdminLTE: https://www.php.net/manual/json.installation.php
-    if [[ "${phpInsNewer}" != true || "${phpInsMajor}" -lt 8 ]]; then
+    if [[ -z "${phpInsMajor}" || "${phpInsMajor}" -lt 8 ]]; then
         PIHOLE_WEB_DEPS+=("${phpVer}-json")
     fi
     # The Web server user,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://github.com/pi-hole/pi-hole/wiki/How-to-signoff-your-commits.) all commits. Pi-hole enforces the [DCO](https://github.com/pi-hole/pi-hole/wiki/Contributing-to-the-project).

---
**What does this PR aim to accomplish?:**
Fix PHP installation if PHP8.0 was installed before.


**How does this PR accomplish the above?:**
The `phpInsNewer` variable is not set anymore, so that the JSON module is now always tried to be installed. Instead of checking for `phpInsNewer` to derive whether PHP was installed already, `phpInsMajor` is now checked. If it is set, PHP is installed already, and then only if the major version is lower than 8, the JSON module can be installed.


**What documentation changes (if any) are needed to support this PR?:**
None


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
