### PR TITLE
update tests: remove fedora 32, add fedora 34

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     needs: smoke-test
     strategy:
       matrix:
-        distro: [debian_9, debian_10, debian_11, ubuntu_16, ubuntu_18, ubuntu_20, ubuntu_21, centos_7, centos_8, fedora_32, fedora_33]
+        distro: [debian_9, debian_10, debian_11, ubuntu_16, ubuntu_18, ubuntu_20, ubuntu_21, centos_7, centos_8, fedora_33, fedora_34]
     env:
       DISTRO: ${{matrix.distro}}
     steps:

--- a/test/_fedora_34.Dockerfile
+++ b/test/_fedora_34.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:34
 
 ENV GITDIR /etc/.pihole
 ENV SCRIPTDIR /opt/pihole

--- a/test/tox.fedora_34.ini
+++ b/test/tox.fedora_34.ini
@@ -4,5 +4,5 @@ envlist = py37
 [testenv]
 whitelist_externals = docker
 deps = -rrequirements.txt
-commands = docker build -f _fedora_32.Dockerfile -t pytest_pihole:test_container ../
+commands = docker build -f _fedora_34.Dockerfile -t pytest_pihole:test_container ../
            pytest {posargs:-vv -n auto} ./test_automated_install.py ./test_centos_fedora_common_support.py ./test_fedora_support.py


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. 

---
**What does this PR aim to accomplish?:**
Replace Fedora 32 test configs with Fedora 34.

**Note:** The following test is expected to fail due to DNS TXT version check:
```
[gw3] [ 90%] FAILED test_automated_install.py::test_os_check_passes[test_container]
```

**How does this PR accomplish the above?:**
No code changes, just updating the tests to pull Fedora 34 images and discontinue 32. (EOL 2021-05-25)

**What documentation changes (if any) are needed to support this PR?:**
I will PR an update to the docs to reflect this update.

