### PR TITLE
Document all pihole -a functions in help text and manual

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -47,8 +47,8 @@ Options:
   -i, interface       Specify dnsmasq's interface listening behavior. Use -h for help
   -l, privacylevel    Set privacy level (0 = lowest, 3 = highest)
   -t, teleporter      Backup configuration as an archive
-  poweroff            Poweroff the sysetem
-  reboot              Reboot the sysetem
+  poweroff            Poweroff the system
+  reboot              Reboot the system
   restartdns          Restarts Pi-hole
   layout              Set the web GUI layout [boxed/traditional]
   theme               Set the web GUI theme [default-light/default-dark/default-darker/default-auto]
@@ -393,7 +393,7 @@ SetQueryLogOptions() {
     if [[ "$3" == "-h" ]] || [[ "$3" == "--help" ]]; then
         echo "Usage: pihole -a setquerylog [Value]
         Set which queries should be shown in the query log.
-        Valures are [all/permittedonly/blockedonly/nothing]
+        Values are [all/permittedonly/blockedonly/nothing]
         "
 
         exit 0

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -53,24 +53,22 @@ Options:
   layout              Set the web GUI layout [boxed/traditional]
   theme               Set the web GUI theme [default-light/default-dark/default-darker/default-auto]
   adlist              Manipulate adlists. Use -h for help
-  audit               Adds a domain to the audit log. Seperate doamins by comma.
+  audit               Adds a domain to the audit log. Seperate doamins by comma
   clearaudit          Remove all domains from the audit log.
   addcustomdns        Adds an entry to the Local DNS Records. Use -h for help
   removecustomdns     Removes an entry from the Local DNS Records. Use -h for help
   addcustomcname      Adds a local CNAME. Use -h for help
   removecustomcname   Removes a local CNAME. Use -h for help
-
-
   enabledhcp          Enable the DHCP server. Use -h for help
   disabledhcp         Disable the DHCP server
   addstaticdhcp       Adds a static DHCP lease. Use -h for help
   removestaticdhcp    Removes a static DHCP lease defind by [MAC]
-
-  The following settings will override their previous state.
-
-  setdns              Set Pihole's upstream DNS server. Comma-seperate individual server, use # to add specific port
-  setexcludedomains   Set domains to exclude from the web GUI dashboard's Top Domains. Comma-seperate individual domains
-  setexcludeclients   Set clients to exclude from the web GUI dashboard's Top Clients.Comma-seperate individual clients
+  setdns              Set Pihole's upstream DNS server. Comma-seperate
+                      individual server, use # to add specific port
+  setexcludedomains   Set domains to exclude from the web GUI dashboard's Top Domains.
+                      Comma-seperate individual domains
+  setexcludeclients   Set clients to exclude from the web GUI dashboard's Top Clients.
+                      Comma-seperate individual clients
   setquerylog         Set which queries should be shown in the query log. Use -h for help"
 
     exit 0
@@ -917,25 +915,25 @@ main() {
         "poweroff"            ) Poweroff;;
         "reboot"              ) Reboot;;
         "restartdns"          ) RestartDNS;;
-        "setquerylog"         ) SetQueryLogOptions;;
-        "enabledhcp"          ) EnableDHCP;;
+        "setquerylog"         ) SetQueryLogOptions "$@";;
+        "enabledhcp"          ) EnableDHCP"$@";;
         "disabledhcp"         ) DisableDHCP;;
         "layout"              ) SetWebUILayout;;
         "theme"               ) SetWebUITheme;;
         "-h" | "--help"       ) helpFunc;;
-        "addstaticdhcp"       ) AddDHCPStaticAddress;;
+        "addstaticdhcp"       ) AddDHCPStaticAddress "$@";;
         "removestaticdhcp"    ) RemoveDHCPStaticAddress;;
         "-e" | "email"        ) SetAdminEmail "$3";;
         "-i" | "interface"    ) SetListeningMode "$@";;
         "-t" | "teleporter"   ) Teleporter;;
-        "adlist"              ) CustomizeAdLists;;
+        "adlist"              ) CustomizeAdLists "$@";;
         "audit"               ) addAudit "$@";;
         "clearaudit"          ) clearAudit;;
         "-l" | "privacylevel" ) SetPrivacyLevel;;
-        "addcustomdns"        ) AddCustomDNSAddress;;
-        "removecustomdns"     ) RemoveCustomDNSAddress;;
-        "addcustomcname"      ) AddCustomCNAMERecord;;
-        "removecustomcname"   ) RemoveCustomCNAMERecord;;
+        "addcustomdns"        ) AddCustomDNSAddress "$@";;
+        "removecustomdns"     ) RemoveCustomDNSAddress "$@";;
+        "addcustomcname"      ) AddCustomCNAMERecord "$@";;
+        "removecustomcname"   ) RemoveCustomCNAMERecord "$@";;
         *                     ) helpFunc;;
     esac
 


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Adds all functions available to `pihole -a` to the help text and the man page. Although, `pihole -a` will be removed one day when Pi-hole v6 adds a new API, it might still be valuable for some users.

Additionally, removes the unused functions  `SetPrivacyMode` and `ResolutionSettings`.

Fixes https://github.com/pi-hole/pi-hole/issues/3496

and the core part of https://github.com/pi-hole/AdminLTE/pull/1943

