### PR TITLE
Allow users to skip setting static IP adress

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -775,9 +775,9 @@ getStaticIPv4Settings() {
     DHCPChoice=$(whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --menu --separate-output "Do you want to use your current network settings as a static address? \\n
           IP address:    ${IPV4_ADDRESS} \\n
           Gateway:       ${IPv4gw} \\n" "${r}" "${c}" 3\
-          "Yes" "Set static IP as shown above (recommended)" \
-          "Manual" "Manually enter IP adress now" \
-          "No" "Take care of static adress all by yourself" 3>&2 2>&1 1>&3) || \
+          "Yes" "Set static IP to the current address" \
+          "Manual" "Set static IP to a custom IP" \
+          "No" "Set static address manually later" 3>&2 2>&1 1>&3) || \
           { printf "  %bCancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"; exit 1; }
 
     case ${DHCPChoice} in

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -775,9 +775,9 @@ getStaticIPv4Settings() {
     DHCPChoice=$(whiptail --backtitle "Calibrating network interface" --title "Static IP Address" --menu --separate-output "Do you want to use your current network settings as a static address? \\n
           IP address:    ${IPV4_ADDRESS} \\n
           Gateway:       ${IPv4gw} \\n" "${r}" "${c}" 3\
-          "Yes" "Set static IP to the current address" \
-          "Manual" "Set static IP to a custom IP" \
-          "No" "Set static address manually later" 3>&2 2>&1 1>&3) || \
+          "Yes" "Set static IP using current values" \
+          "No" "Set static IP using custom values" \
+          "Skip" "I will set a static IP later, or have already done so" 3>&2 2>&1 1>&3) || \
           { printf "  %bCancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"; exit 1; }
 
     case ${DHCPChoice} in
@@ -790,7 +790,7 @@ getStaticIPv4Settings() {
         setDHCPCD
         ;;
 
-        "Manual")
+        "No")
         # Otherwise, we need to ask the user to input their desired settings.
         # Start by getting the IPv4 address (pre-filling it with info gathered from DHCP)
         # Start a loop to let the user enter their information with the chance to go back and edit it if necessary


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
On distribution using `dhcpd` we offer users to set a static IP during Pi-hole installation. However, the current implementation **forces** users with `/etc/dhcpcd.conf` to set a static IP (take the current or set one manually). There was no way to circumvent this during setup.

This PR adds a third option, to not set any static IP even if `/etc/dhcpcd.conf` exists.
Fixes https://github.com/pi-hole/pi-hole/issues/4418

![image](https://user-images.githubusercontent.com/1998970/140622995-131fd041-eb73-45a0-b798-7a9d6a8215dd.png)

Additionally, the PR moves the IP selection to a earlier time point in the installer (before selecting upstream and blocklist) as the welcome warning about the necessity of a static IP address might still be more present.