### PR TITLE
Recommend apt instead of apt-get if updating the package cache failed

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -266,13 +266,8 @@ if is_command apt-get ; then
     # Set some global variables here
     # We don't set them earlier since the installed package manager might be rpm, so these values would be different
     PKG_MANAGER="apt-get"
-    # A variable to store the command used to update the package cache. If apt is available use this as we have seen it
-    # gives more user-friendly (interactive) advice, else fall-back to apt-get
-    if is_command apt ; then
-        UPDATE_PKG_CACHE="apt update"
-    else
-        UPDATE_PKG_CACHE="${PKG_MANAGER} update"
-    fi
+    # A variable to store the command used to update the package cache
+    UPDATE_PKG_CACHE="${PKG_MANAGER} update"
     # The command we will use to actually install packages
     PKG_INSTALL=("${PKG_MANAGER}" -qq --no-install-recommends install)
     # grep -c will return 1 if there are no matches. This is an acceptable condition, so we OR TRUE to prevent set -e exiting the script.
@@ -1486,8 +1481,14 @@ update_package_cache() {
         printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
     else
         # Otherwise, show an error and exit
+
+        # In case we used apt-get and apt is also available, we use this as recommendation as we have seen it
+        # gives more user-friendly (interactive) advice
+        if [[ ${PKG_MANAGER} == "apt-get" ]] && is_command apt ; then
+            UPDATE_PKG_CACHE="apt update"
+        fi
         printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
-        printf "  %bError: Unable to update package cache. Please try \"%s\"%b" "${COL_LIGHT_RED}" "sudo ${UPDATE_PKG_CACHE}" "${COL_NC}"
+        printf "  %bError: Unable to update package cache. Please try \"%s\"%b\\n" "${COL_LIGHT_RED}" "sudo ${UPDATE_PKG_CACHE}" "${COL_NC}"
         return 1
     fi
 }

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -266,8 +266,13 @@ if is_command apt-get ; then
     # Set some global variables here
     # We don't set them earlier since the installed package manager might be rpm, so these values would be different
     PKG_MANAGER="apt-get"
-    # A variable to store the command used to update the package cache
-    UPDATE_PKG_CACHE="${PKG_MANAGER} update"
+    # A variable to store the command used to update the package cache. If apt is available use this as we have seen it
+    # gives more user-friendly (interactive) advice, else fall-back to apt-get
+    if is_command apt ; then
+        UPDATE_PKG_CACHE="apt update"
+    else
+        UPDATE_PKG_CACHE="${PKG_MANAGER} update"
+    fi
     # The command we will use to actually install packages
     PKG_INSTALL=("${PKG_MANAGER}" -qq --no-install-recommends install)
     # grep -c will return 1 if there are no matches. This is an acceptable condition, so we OR TRUE to prevent set -e exiting the script.

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -147,7 +147,6 @@ def test_update_package_cache_failure_no_errors(Pihole):
     '''
     confirms package cache was not updated
     '''
-    mock_command('apt', {'update': ('', '1')}, Pihole)
     mock_command('apt-get', {'update': ('', '1')}, Pihole)
     updateCache = Pihole.run('''
     source /opt/pihole/basic-install.sh

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -147,7 +147,7 @@ def test_update_package_cache_failure_no_errors(Pihole):
     '''
     confirms package cache was not updated
     '''
-    mock_command('apt-get', {'update': ('', '1')}, Pihole)
+    mock_command('apt', {'update': ('', '1')}, Pihole)
     updateCache = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect

--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -148,6 +148,7 @@ def test_update_package_cache_failure_no_errors(Pihole):
     confirms package cache was not updated
     '''
     mock_command('apt', {'update': ('', '1')}, Pihole)
+    mock_command('apt-get', {'update': ('', '1')}, Pihole)
     updateCache = Pihole.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Recommend `apt` instead of `apt-get` for updating the package cache on deb based distribution as it gives more user-friendly output.

Inspired by https://cubiclenate.com/2021/10/31/pi-hole-update-troubles/


**How does this PR accomplish the above?:**
Check for the presence of `apt`, if available use this.

Additional
We don't switch to `apt` for installing the packages as it does not provide all the necessary options.
