### PR TITLE
Use a fixed list height for network interface selection

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -674,7 +674,7 @@ chooseInterface() {
         # Feed the available interfaces into this while loop
         done <<< "${availableInterfaces}"
         # The whiptail command that will be run, stored in a variable
-        chooseInterfaceCmd=(whiptail --separate-output --radiolist "Choose An Interface (press space to toggle selection)" "${r}" "${c}" "${interfaceCount}")
+        chooseInterfaceCmd=(whiptail --separate-output --radiolist "Choose An Interface (press space to toggle selection)" "${r}" "${c}" 6)
         # Now run the command using the interfaces saved into the array
         chooseInterfaceOptions=$("${chooseInterfaceCmd[@]}" "${interfacesArray[@]}" 2>&1 >/dev/tty) || \
         # If the user chooses Cancel, exit


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
This solves the issue reported here: https://github.com/pi-hole/pi-hole/issues/4196
It replaces the other suggested solution here: https://github.com/pi-hole/pi-hole/pull/4197

The benefit of using a fixed/limited list height, compared to allowing larger whiptail/dialogue dimension, is that it works on small screens as well, where the screen or console size itself is too small to hold the interface list + text above + whiptail frame.

It the amount of list elements exceeds the defined list height, automatically a visual scroll bar is added and the list can be scrolled with up/down pageup/pagedown buttons, hence it is generally not required to adjust a list height based on the amount of elements. The fixed height of "6" is chosen since all other "--radiolist" calls use this fixed height as well, it fits and looks good within a 20 rows high whiptail dialogue, and in the common Pi-hole use cases there are no more than 6 network interfaces.

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

Changing the network interface selection radio list height to 6 rows instead of the amount of available network interfaces.

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*

None

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
