### PR TITLE
Fix generated /etc/os-release file in OS check test

### DIFF
--- a/test/test_automated_install.py
+++ b/test/test_automated_install.py
@@ -1085,9 +1085,9 @@ def test_os_check_fails(host):
     install_dependent_packages ${OS_CHECK_DEPS[@]}
     install_dependent_packages ${INSTALLER_DEPS[@]}
     cat <<EOT > /etc/os-release
-    ID=UnsupportedOS
-    VERSION_ID="2"
-    EOT
+ID=UnsupportedOS
+VERSION_ID="2"
+EOT
     ''')
     detectOS = host.run('''t
     source /opt/pihole/basic-install.sh


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
It aims to fix the issue reported here: https://github.com/pi-hole/pi-hole/pull/4088#discussion_r756386586

**How does this PR accomplish the above?:**
It removes the leading spaces when creating the `/etc/os-release` file for the test.

**What documentation changes (if any) are needed to support this PR?:**
None