### PR TITLE
Fix number of invalid domains

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -516,7 +516,7 @@ parseList() {
   # Find (up to) five domains containing invalid characters (see above)
   incorrect_lines="$(sed -e "/[^a-zA-Z0-9.\_-]/!d" "${src}" | head -n 5)"
 
-  local num_target_lines num_correct_lines num_invalid
+  local num_target_lines num_correct_lines
   # Get number of lines in source file
   num_lines="$(grep -c "^" "${src}")"
   # Get number of lines in destination file

--- a/gravity.sh
+++ b/gravity.sh
@@ -248,7 +248,7 @@ database_adlist_number() {
     return;
   fi
 
-  output=$( { printf ".timeout 30000\\nUPDATE adlist SET number = %i, invalid_domains = %i WHERE id = %i;\\n" "${num_lines}" "${num_invalid}" "${1}" | sqlite3 "${gravityDBfile}"; } 2>&1 )
+  output=$( { printf ".timeout 30000\\nUPDATE adlist SET number = %i, invalid_domains = %i WHERE id = %i;\\n" "${num_source_lines}" "${num_invalid}" "${1}" | sqlite3 "${gravityDBfile}"; } 2>&1 )
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
@@ -503,8 +503,9 @@ gravity_DownloadBlocklists() {
   gravity_Blackbody=true
 }
 
-total_num=0
-num_lines=0
+# num_target_lines does increase for every correctly added domain in pareseList()
+num_target_lines=0
+num_source_lines=0
 num_invalid=0
 parseList() {
   local adlistID="${1}" src="${2}" target="${3}" incorrect_lines
@@ -516,18 +517,20 @@ parseList() {
   # Find (up to) five domains containing invalid characters (see above)
   incorrect_lines="$(sed -e "/[^a-zA-Z0-9.\_-]/!d" "${src}" | head -n 5)"
 
-  local num_target_lines num_correct_lines
+  local num_target_lines_new num_correct_lines
   # Get number of lines in source file
-  num_lines="$(grep -c "^" "${src}")"
-  # Get number of lines in destination file
-  num_target_lines="$(grep -c "^" "${target}")"
-  num_correct_lines="$(( num_target_lines-total_num ))"
-  total_num="$num_target_lines"
-  num_invalid="$(( num_lines-num_correct_lines ))"
+  num_source_lines="$(grep -c "^" "${src}")"
+  # Get the new number of lines in destination file
+  num_target_lines_new="$(grep -c "^" "${target}")"
+  # Number of new correctly added lines
+  num_correct_lines="$(( num_target_lines_new-num_target_lines ))"
+  # Upate number of lines in target file
+  num_target_lines="$num_target_lines_new"
+  num_invalid="$(( num_source_lines-num_correct_lines ))"
   if [[ "${num_invalid}" -eq 0 ]]; then
-    echo "  ${INFO} Analyzed ${num_lines} domains"
+    echo "  ${INFO} Analyzed ${num_source_lines} domains"
   else
-    echo "  ${INFO} Analyzed ${num_lines} domains, ${num_invalid} domains invalid!"
+    echo "  ${INFO} Analyzed ${num_source_lines} domains, ${num_invalid} domains invalid!"
   fi
 
   # Display sample of invalid lines if we found some
@@ -686,7 +689,7 @@ gravity_DownloadBlocklistFromUrl() {
     else
       echo -e "  ${CROSS} List download failed: ${COL_LIGHT_RED}no cached list available${COL_NC}"
       # Manually reset these two numbers because we do not call parseList here
-      num_lines=0
+      num_source_lines=0
       num_invalid=0
       database_adlist_number "${adlistID}"
       database_adlist_status "${adlistID}" "4"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
During gravity update the number of invalid domains was counted correctly but not saved to the database. Instead it was always 0.

Fixes #4441

**How does this PR accomplish the above?:**
Remove `num_invalid` to be set as local in `parseList` as it is later used in `database_adlist_number` again to save to the database

![Bildschirmfoto zu 2021-12-01 11-11-07](https://user-images.githubusercontent.com/26622301/144215569-9c5928bf-bffe-4cc3-b9b6-34a5d6d5bad4.png)

**Addition**
Some variables in `parseList()` have been renamed to increase comprehensibility

