### PR TITLE
Use exec to run gravity script

### DIFF
--- a/pihole
+++ b/pihole
@@ -71,8 +71,7 @@ reconfigurePiholeFunc() {
 }
 
 updateGravityFunc() {
-  "${PI_HOLE_SCRIPT_DIR}"/gravity.sh "$@"
-  exit $?
+  exec "${PI_HOLE_SCRIPT_DIR}"/gravity.sh "$@"
 }
 
 queryFunc() {


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Instead of directly calling the gravity script invoke it via `exec` See the comment here 
https://github.com/pi-hole/pi-hole/pull/4370#discussion_r761424108

