### PR TITLE
Unblock adlist domain during gravity run in NODATA mode

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -597,7 +597,7 @@ gravity_DownloadBlocklistFromUrl() {
         blocked=true
       fi;;
     "NODATA")
-      if [[ $(dig "${domain}" | grep "NOERROR" -c) -ge 1 ]] && [[ -z $(dig +noall +answer "${domain}" |awk '{print $5}') ]]; then
+      if [[ $(dig "${domain}" | grep "NOERROR" -c) -ge 1 ]] && [[ -z $(dig +short "${domain}") ]]; then
          blocked=true
       fi;;
     "NULL"|*)

--- a/gravity.sh
+++ b/gravity.sh
@@ -596,6 +596,10 @@ gravity_DownloadBlocklistFromUrl() {
       if [[ $(dig "${domain}" | grep "NXDOMAIN" -c) -ge 1 ]]; then
         blocked=true
       fi;;
+    "NODATA")
+      if [[ $(dig "${domain}" | grep "NOERROR" -c) -ge 1 ]] && [[ -z $(dig +noall +answer "${domain}" |awk '{print $5}') ]]; then
+         blocked=true
+      fi;;
     "NULL"|*)
       if [[ $(dig "${domain}" +short | grep "0.0.0.0" -c) -ge 1 ]]; then
         blocked=true


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
https://github.com/pi-hole/pi-hole/pull/2347 added a way to circumvent blocking during a gravity download in case the adlist domain is on another adlist. However, blocking mode `NODATA` was added later (https://github.com/pi-hole/FTL/pull/433) and the circumvent mechanism was never extended for `NODATA`


**How does this PR accomplish the above?:**
Check for `NODATA` as `BLOCKINGMODE`, check if `dig domain` results in `NOERROR` but empty response. If so, use the available upstream DNS server

**Example**: block `raw.githubusercontent.com` and having `NODATA` as blocking mode

Before
![Bildschirmfoto zu 2021-12-03 09-18-23](https://user-images.githubusercontent.com/26622301/144570050-2e3b3dc3-9a99-41df-b771-162171ea42c6.png)


After
![Bildschirmfoto zu 2021-12-03 09-20-56](https://user-images.githubusercontent.com/26622301/144570112-c934c3ee-8cfc-46e9-a940-9a30f7ed6276.png)

