### PR TITLE
Companion to pi-hole/adminlte #1996

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -92,5 +92,10 @@ $HTTP["url"] =~ "/teleporter\.php$" {
     }
 }
 
+# allow API qr code iframe on settings page
+$HTTP["url"] =~ "/admin/settings\.php$" {
+    setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
+}
+
 # Default expire header
 expire.url = ( "" => "access plus 0 seconds" )

--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -85,15 +85,8 @@ $HTTP["url"] =~ "^/admin/\.(.*)" {
     url.access-deny = ("")
 }
 
-# allow teleporter iframe on settings page
-$HTTP["url"] =~ "/teleporter\.php$" {
-    $HTTP["referer"] =~ "/admin/settings\.php" {
-        setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
-    }
-}
-
-# allow API qr code iframe on settings page
-$HTTP["url"] =~ "/api_token\.php$" {
+# allow teleporter and API qr code iframe on settings page
+$HTTP["url"] =~ "/(teleporter|api_token)\.php$" {
     $HTTP["referer"] =~ "/admin/settings\.php" {
         setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
     }

--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -93,8 +93,10 @@ $HTTP["url"] =~ "/teleporter\.php$" {
 }
 
 # allow API qr code iframe on settings page
-$HTTP["url"] =~ "/admin/settings\.php$" {
-    setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
+$HTTP["url"] =~ "/api_token\.php$" {
+    $HTTP["referer"] =~ "/admin/settings\.php" {
+        setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
+    }
 }
 
 # Default expire header

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -93,15 +93,8 @@ $HTTP["url"] =~ "^/admin/\.(.*)" {
     url.access-deny = ("")
 }
 
-# allow teleporter iframe on settings page
-$HTTP["url"] =~ "/teleporter\.php$" {
-    $HTTP["referer"] =~ "/admin/settings\.php" {
-        setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
-    }
-}
-
-# allow API qr code iframe on settings page
-$HTTP["url"] =~ "/api_token\.php$" {
+# allow teleporter and API qr code iframe on settings page
+$HTTP["url"] =~ "/(teleporter|api_token)\.php$" {
     $HTTP["referer"] =~ "/admin/settings\.php" {
         setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
     }

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -101,8 +101,10 @@ $HTTP["url"] =~ "/teleporter\.php$" {
 }
 
 # allow API qr code iframe on settings page
-$HTTP["url"] =~ "/admin/settings\.php$" {
-    setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
+$HTTP["url"] =~ "/api_token\.php$" {
+    $HTTP["referer"] =~ "/admin/settings\.php" {
+        setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
+    }
 }
 
 # Default expire header

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -100,5 +100,10 @@ $HTTP["url"] =~ "/teleporter\.php$" {
     }
 }
 
+# allow API qr code iframe on settings page
+$HTTP["url"] =~ "/admin/settings\.php$" {
+    setenv.add-response-header = ( "X-Frame-Options" => "SAMEORIGIN" )
+}
+
 # Default expire header
 expire.url = ( "" => "access plus 0 seconds" )


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Allows QR Code iframe on the settings page

**How does this PR accomplish the above?:**
Adjust code we already used for the teleporter iframe in https://github.com/pi-hole/pi-hole/pull/4375