### PR TITLE
Check for updates on master based on tags not commits

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -49,7 +49,7 @@ GitCheckUpdateAvail() {
         # get the latest local tag
         LOCAL=$(git describe --abbrev=0 --tags)
         # get remote repo_name and URL
-        repo_name="$(basename -s .git $(git remote get-url origin))"
+        repo_name="$(basename -s .git "$(git remote get-url origin)")"
         repo_url="https://api.github.com/repos/pi-hole/${repo_name}/releases/latest"
         # get the latest tag from remote
         REMOTE=$(curl -s "${repo_url}"  2> /dev/null | grep tag_name | awk 'BEGIN { FS = "\"" } ; { print $4}')

--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -49,11 +49,10 @@ GitCheckUpdateAvail() {
         # get the latest local tag
         LOCAL=$(git describe --abbrev=0 --tags)
         # get remote repo_name and URL
-        repo_name="$(git config --get remote.origin.url |  awk -F '[/.]' '{ print $6}')"
+        repo_name="$(basename -s .git $(git remote get-url origin))"
         repo_url="https://api.github.com/repos/pi-hole/${repo_name}/releases/latest"
         # get the latest tag from remote
-        REMOTE="$(curl -s "${repo_url}"  2> /dev/null |grep tag_name | awk 'BEGIN { FS = "\"" } ; { print $4}')"
-
+        REMOTE=$(curl -s "${repo_url}"  2> /dev/null | grep tag_name | awk 'BEGIN { FS = "\"" } ; { print $4}')
 
     else
         # @ alone is a shortcut for HEAD. Older versions of git

--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -52,7 +52,7 @@ GitCheckUpdateAvail() {
         repo_name="$(git config --get remote.origin.url |  awk -F '[/.]' '{ print $6}')"
         repo_url="https://api.github.com/repos/pi-hole/${repo_name}/releases/latest"
         # get the latest tag from remote
-        REMOTE="$(curl -s ${repo_url}  2> /dev/null |grep tag_name | awk 'BEGIN { FS = "\"" } ; { print $4}')"
+        REMOTE="$(curl -s "${repo_url}"  2> /dev/null |grep tag_name | awk 'BEGIN { FS = "\"" } ; { print $4}')"
 
 
     else

--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -41,7 +41,7 @@ GitCheckUpdateAvail() {
     cd "${directory}" || return
 
     # Fetch latest changes in this repo
-    git fetch --quiet origin
+    git fetch --tags --quiet origin
 
     # Check current branch. If it is master, then check for the latest available tag instead of latest commit.
     curBranch=$(git rev-parse --abbrev-ref HEAD)

--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -35,7 +35,7 @@ source "/opt/pihole/COL_TABLE"
 
 GitCheckUpdateAvail() {
     local directory
-    local repo_name repo_url
+    local curBranch
     directory="${1}"
     curdir=$PWD
     cd "${directory}" || return
@@ -47,12 +47,9 @@ GitCheckUpdateAvail() {
     curBranch=$(git rev-parse --abbrev-ref HEAD)
     if [[ "${curBranch}" == "master" ]]; then
         # get the latest local tag
-        LOCAL=$(git describe --abbrev=0 --tags)
-        # get remote repo_name and URL
-        repo_name="$(basename -s .git "$(git remote get-url origin)")"
-        repo_url="https://api.github.com/repos/pi-hole/${repo_name}/releases/latest"
+        LOCAL=$(git describe --abbrev=0 --tags master)
         # get the latest tag from remote
-        REMOTE=$(curl -s "${repo_url}"  2> /dev/null | grep tag_name | awk 'BEGIN { FS = "\"" } ; { print $4}')
+        REMOTE=$(git describe --abbrev=0 --tags origin/master)
 
     else
         # @ alone is a shortcut for HEAD. Older versions of git


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Check for updates in `pihole -up` based on tags (not commits) when branch is `master`.

So far, we compared commit hashes to decide if an update is available, but later reset the local repo back to the latest tag if on master.
https://github.com/pi-hole/pi-hole/blob/a3cc5df317ffeec2b6bf78d37e075f33aeb0f79c/automated%20install/basic-install.sh#L519-L522

This led to an update loop if non-taged commits have been pushed to master.

**How does this PR accomplish the above?:**
If the local repo is on `master` we check for the latest tag to decide if an update is available.

P.S. `updatecheck.sh` already checks based on tags https://github.com/pi-hole/pi-hole/blob/a3cc5df317ffeec2b6bf78d37e075f33aeb0f79c/advanced/Scripts/updatecheck.sh#L52-L57
