### PR TITLE
Return the port FTL is listening on in pihole status function

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -287,7 +287,7 @@ package_manager_detect() {
         # Packages required to run this install script (stored as an array)
         INSTALLER_DEPS=(git iproute2 whiptail ca-certificates)
         # Packages required to run Pi-hole (stored as an array)
-        PIHOLE_DEPS=(cron curl iputils-ping lsof psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2)
+        PIHOLE_DEPS=(cron curl iputils-ping lsof psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2 netcat)
         # Packages required for the Web admin interface (stored as an array)
         # It's useful to separate this from Pi-hole, since the two repos are also setup separately
         PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-sqlite3" "${phpVer}-xml" "${phpVer}-intl")
@@ -332,7 +332,7 @@ package_manager_detect() {
         PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
         OS_CHECK_DEPS=(grep bind-utils)
         INSTALLER_DEPS=(git iproute newt procps-ng which chkconfig ca-certificates)
-        PIHOLE_DEPS=(cronie curl findutils sudo unzip libidn2 psmisc sqlite libcap lsof)
+        PIHOLE_DEPS=(cronie curl findutils sudo unzip libidn2 psmisc sqlite libcap lsof nmap-ncat)
         PIHOLE_WEB_DEPS=(lighttpd lighttpd-fastcgi php-common php-cli php-pdo php-xml php-json php-intl)
         LIGHTTPD_USER="lighttpd"
         LIGHTTPD_GROUP="lighttpd"

--- a/pihole
+++ b/pihole
@@ -285,7 +285,7 @@ Options:
 analyze_ports() {
   # FTL is listening at least on at least one port when this
   # function is getting called
-  echo -e "  ${TICK} DNS service is listening"
+  echo -e "  ${TICK} DNS service is listening on port 53"
   # Check individual address family/protocol combinations
   # For a healthy Pi-hole, they should all be up (nothing printed)
   if grep -q "IPv4.*UDP" <<< "${1}"; then

--- a/pihole
+++ b/pihole
@@ -285,7 +285,6 @@ Options:
 analyze_ports() {
   # FTL is listening at least on at least one port when this
   # function is getting called
-  echo -e "  ${TICK} DNS service is listening on port 53"
   # Check individual address family/protocol combinations
   # For a healthy Pi-hole, they should all be up (nothing printed)
   if grep -q "IPv4.*UDP" <<< "${1}"; then

--- a/pihole
+++ b/pihole
@@ -325,7 +325,7 @@ statusFunc() {
   else
     #get the port pihole-FTL is listening on by using FTL's telnet API
     port="$(echo ">dns-port >quit" | nc 127.0.0.1 4711)"
-    listening="$(lsof -Pni:53)"
+    listening="$(lsof -Pni:${port})"
     if [[ "${port}" == "0" ]]; then
       case "${1}" in
         "web") echo "-1";;
@@ -333,7 +333,8 @@ statusFunc() {
       esac
       return 0
     else
-      if [[ "${1}" != "web" ]] && [[ "$port" -eq 53 ]]; then
+      if [[ "${1}" != "web" ]]; then
+        echo -e "  ${TICK} FTL is listening on port ${port}"
         analyze_ports "${listening}"
       fi
     fi
@@ -350,8 +351,7 @@ statusFunc() {
     # Configs are set
     case "${1}" in
       "web") echo "$port";;
-      *) echo -e "  ${TICK} Pi-hole blocking is enabled. FTL is listening on port ${port}"
-      ;;
+      *) echo -e "  ${TICK} Pi-hole blocking is enabled";;
     esac
   else
     # No configs were found

--- a/pihole
+++ b/pihole
@@ -337,7 +337,7 @@ statusFunc() {
       esac
       return 0
     fi
-
+  fi
   # Determine if Pi-hole's blocking is enabled
   if grep -q "BLOCKING_ENABLED=false" /etc/pihole/setupVars.conf; then
     # A config is commented out

--- a/pihole
+++ b/pihole
@@ -323,43 +323,43 @@ statusFunc() {
     esac
     return 0
   else
-      #get the port pihole-FTL is listening on
-      port="$(lsof -Pni UDP -p ${pid} -a | grep -m1 : | awk -F ":" '{print $2}')"
-      listening="$(lsof -Pni:53)"
-      if [[ ! -z "$port" ]]; then
-        if [[ "${1}" != "web" ]] && [[ "$port" -eq 53 ]]; then
-          analyze_ports "${listening}"
-        fi
-      else
-        case "${1}" in
-          "web") echo "-1";;
-          *) echo -e "  ${CROSS} DNS service is NOT listening";;
-        esac
-        return 0
+    #get the port pihole-FTL is listening on
+    port="$(lsof -Pni UDP -p ${pid} -a | grep -m1 : | awk -F ":" '{print $2}')"
+    listening="$(lsof -Pni:53)"
+    if [[ ! -z "$port" ]]; then
+      if [[ "${1}" != "web" ]] && [[ "$port" -eq 53 ]]; then
+        analyze_ports "${listening}"
       fi
+    else
+      case "${1}" in
+        "web") echo "-1";;
+        *) echo -e "  ${CROSS} DNS service is NOT listening";;
+      esac
+      return 0
+    fi
 
-      # Determine if Pi-hole's blocking is enabled
-      if grep -q "BLOCKING_ENABLED=false" /etc/pihole/setupVars.conf; then
-        # A config is commented out
-        case "${1}" in
-          "web") echo 0;;
-          *) echo -e "  ${CROSS} Pi-hole blocking is disabled";;
-        esac
-      elif grep -q "BLOCKING_ENABLED=true" /etc/pihole/setupVars.conf;  then
-        # Configs are set
-        case "${1}" in
-          "web") echo "$port";;
-          *) echo -e "  ${TICK} Pi-hole blocking is enabled";;
-        esac
-      else
-        # No configs were found
-        case "${1}" in
-          "web") echo -2;;
-          *) echo -e "  ${INFO} Pi-hole blocking will be enabled";;
-        esac
-        # Enable blocking
-        "${PI_HOLE_BIN_DIR}"/pihole enable
-      fi
+  # Determine if Pi-hole's blocking is enabled
+  if grep -q "BLOCKING_ENABLED=false" /etc/pihole/setupVars.conf; then
+    # A config is commented out
+    case "${1}" in
+      "web") echo 0;;
+      *) echo -e "  ${CROSS} Pi-hole blocking is disabled";;
+    esac
+  elif grep -q "BLOCKING_ENABLED=true" /etc/pihole/setupVars.conf;  then
+    # Configs are set
+    case "${1}" in
+      "web") echo "$port";;
+      *) echo -e "  ${TICK} Pi-hole blocking is enabled";;
+    esac
+  else
+    # No configs were found
+    case "${1}" in
+      "web") echo -2;;
+      *) echo -e "  ${INFO} Pi-hole blocking will be enabled";;
+    esac
+    # Enable blocking
+    "${PI_HOLE_BIN_DIR}"/pihole enable
+  fi
 
   fi
 }

--- a/pihole
+++ b/pihole
@@ -312,7 +312,7 @@ analyze_ports() {
 }
 
 statusFunc() {
-  # Determine if there is pihole-FTL service is listening on any UDP port
+  # Determine if there is pihole-FTL service is listening
   local listening pid port
 
   pid="$(getFTLPID)"
@@ -323,21 +323,22 @@ statusFunc() {
     esac
     return 0
   else
-    #get the port pihole-FTL is listening on
-    port="$(lsof -Pni UDP -p ${pid} -a | grep -m1 : | awk -F ":" '{print $2}')"
+    #get the port pihole-FTL is listening on by using FTL's telnet API
+    port="$(echo ">dns-port >quit" | nc 127.0.0.1 4711)"
     listening="$(lsof -Pni:53)"
-    if [[ ! -z "$port" ]]; then
-      if [[ "${1}" != "web" ]] && [[ "$port" -eq 53 ]]; then
-        analyze_ports "${listening}"
-      fi
-    else
+    if [[ "${port}" == "0" ]]; then
       case "${1}" in
         "web") echo "-1";;
         *) echo -e "  ${CROSS} DNS service is NOT listening";;
       esac
       return 0
+    else
+      if [[ "${1}" != "web" ]] && [[ "$port" -eq 53 ]]; then
+        analyze_ports "${listening}"
+      fi
     fi
   fi
+
   # Determine if Pi-hole's blocking is enabled
   if grep -q "BLOCKING_ENABLED=false" /etc/pihole/setupVars.conf; then
     # A config is commented out
@@ -361,7 +362,6 @@ statusFunc() {
     "${PI_HOLE_BIN_DIR}"/pihole enable
   fi
 
-  fi
 }
 
 tailFunc() {

--- a/pihole
+++ b/pihole
@@ -312,42 +312,55 @@ analyze_ports() {
 }
 
 statusFunc() {
-  # Determine if there is a pihole service is listening on port 53
-  local listening
-  listening="$(lsof -Pni:53)"
-  if grep -q "pihole" <<< "${listening}"; then
-    if [[ "${1}" != "web" ]]; then
-      analyze_ports "${listening}"
-    fi
-  else
-    case "${1}" in
-      "web") echo "-1";;
-      *) echo -e "  ${CROSS} DNS service is NOT listening";;
-    esac
-    return 0
-  fi
+  # Determine if there is pihole-FTL service is listening on any UDP port
+  local listening pid port
 
-  # Determine if Pi-hole's blocking is enabled
-  if grep -q "BLOCKING_ENABLED=false" /etc/pihole/setupVars.conf; then
-    # A config is commented out
-    case "${1}" in
-      "web") echo 0;;
-      *) echo -e "  ${CROSS} Pi-hole blocking is disabled";;
-    esac
-  elif grep -q "BLOCKING_ENABLED=true" /etc/pihole/setupVars.conf;  then
-    # Configs are set
-    case "${1}" in
-      "web") echo 1;;
-      *) echo -e "  ${TICK} Pi-hole blocking is enabled";;
-    esac
+  pid="$(getFTLPID)"
+  if [[ "$pid" -eq "-1" ]]; then
+      case "${1}" in
+        "web") echo "-1";;
+        *) echo -e "  ${CROSS} DNS service is NOT running";;
+      esac
+      return 0
   else
-    # No configs were found
-    case "${1}" in
-      "web") echo 99;;
-      *) echo -e "  ${INFO} Pi-hole blocking will be enabled";;
-    esac
-    # Enable blocking
-    "${PI_HOLE_BIN_DIR}"/pihole enable
+      #get the port pihole-FTL is listening on
+      port="$(lsof -Pni UDP -p ${pid} -a | grep -m1 : | awk -F ":" '{print $2}')"
+      listening="$(lsof -Pni:53)"
+      if [[ ! -z "$port" ]]; then
+        if [[ "${1}" != "web" ]]; then
+          analyze_ports "${listening}"
+        fi
+      else
+        case "${1}" in
+          "web") echo "-1";;
+          *) echo -e "  ${CROSS} DNS service is NOT listening";;
+        esac
+        return 0
+      fi
+
+      # Determine if Pi-hole's blocking is enabled
+      if grep -q "BLOCKING_ENABLED=false" /etc/pihole/setupVars.conf; then
+        # A config is commented out
+        case "${1}" in
+          "web") echo 0;;
+          *) echo -e "  ${CROSS} Pi-hole blocking is disabled";;
+        esac
+      elif grep -q "BLOCKING_ENABLED=true" /etc/pihole/setupVars.conf;  then
+        # Configs are set
+        case "${1}" in
+          "web") echo "$port";;
+          *) echo -e "  ${TICK} Pi-hole blocking is enabled";;
+        esac
+      else
+        # No configs were found
+        case "${1}" in
+          "web") echo -2;;
+          *) echo -e "  ${INFO} Pi-hole blocking will be enabled";;
+        esac
+        # Enable blocking
+        "${PI_HOLE_BIN_DIR}"/pihole enable
+      fi
+
   fi
 }
 

--- a/pihole
+++ b/pihole
@@ -350,7 +350,8 @@ statusFunc() {
     # Configs are set
     case "${1}" in
       "web") echo "$port";;
-      *) echo -e "  ${TICK} Pi-hole blocking is enabled";;
+      *) echo -e "  ${TICK} Pi-hole blocking is enabled. FTL is listening on port ${port}"
+      ;;
     esac
   else
     # No configs were found

--- a/pihole
+++ b/pihole
@@ -327,7 +327,7 @@ statusFunc() {
       port="$(lsof -Pni UDP -p ${pid} -a | grep -m1 : | awk -F ":" '{print $2}')"
       listening="$(lsof -Pni:53)"
       if [[ ! -z "$port" ]]; then
-        if [[ "${1}" != "web" ]]; then
+        if [[ "${1}" != "web" ]] && [[ "$port" -eq 53 ]]; then
           analyze_ports "${listening}"
         fi
       else

--- a/pihole
+++ b/pihole
@@ -317,11 +317,11 @@ statusFunc() {
 
   pid="$(getFTLPID)"
   if [[ "$pid" -eq "-1" ]]; then
-      case "${1}" in
-        "web") echo "-1";;
-        *) echo -e "  ${CROSS} DNS service is NOT running";;
-      esac
-      return 0
+    case "${1}" in
+      "web") echo "-1";;
+      *) echo -e "  ${CROSS} DNS service is NOT running";;
+    esac
+    return 0
   else
       #get the port pihole-FTL is listening on
       port="$(lsof -Pni UDP -p ${pid} -a | grep -m1 : | awk -F ":" '{print $2}')"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**

Includes the port which FTL is running on in `pihole status` which is used in the web interface. 
It does this by using the FTL's telnet API endpoint `dns-port` introduced by https://github.com/pi-hole/FTL/pull/1264

As the API is used via netcat, this is (re-) added to the dependencies.

Corresponding `web` PR: https://github.com/pi-hole/AdminLTE/pull/2031
