### PR TITLE
Fixed path to 404 file when using custom.php

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1334,7 +1334,7 @@ installConfigs() {
         chmod 644 /etc/lighttpd/external.conf
         # If there is a custom block page in the html/pihole directory, replace 404 handler in lighttpd config
         if [[ -f "${PI_HOLE_BLOCKPAGE_DIR}/custom.php" ]]; then
-            sed -i 's/^\(server\.error-handler-404\s*=\s*\).*$/\1"pihole\/custom\.php"/' "${lighttpdConfig}"
+            sed -i 's/^\(server\.error-handler-404\s*=\s*\).*$/\1"\/pihole\/custom\.php"/' "${lighttpdConfig}"
         fi
         # Make the directories if they do not exist and set the owners
         mkdir -p /run/lighttpd


### PR DESCRIPTION
Signed-off-by: Computroniks <mnickson@sidingsmedia.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code. (This wouldn't be useful in this case)
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
When running an unattended reconfigure using the command `sudo /etc/.pihole/automated\ install/basic-install.sh --reconfigure --unattended` as recommended in the discourse post https://discourse.pi-hole.net/t/force-pi-hole-to-recheck-setupvars-conf/16874/2, the path to the 404 error file is configured without a `/` at the start of the path when a `custom.php` file is detected. This causes the client to recieve a `HTTP 400` error when accessing blocked sites and causes the following error in `/var/log/lighttpd/error.log`:
```
2021-12-28 16:00:26: (response.c.410) uri-path does not begin with '/': pihole/custom.php -> 400
```
The path to the error file should begin with a `/`.


**How does this PR accomplish the above?:**
This PR updates the command issued by the install script to include the `/` at the start of the path.


**What documentation changes (if any) are needed to support this PR?:**
No documentation changes are required.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
