### PR TITLE
Replace `which` with `command -v`

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2277,7 +2277,7 @@ FTLcheckUpdate() {
     printf "  %b Checking for existing FTL binary...\\n" "${INFO}"
 
     local ftlLoc
-    ftlLoc=$(which pihole-FTL 2>/dev/null)
+    ftlLoc=$(command -v pihole-FTL 2>/dev/null)
 
     local ftlBranch
 
@@ -2315,7 +2315,7 @@ FTLcheckUpdate() {
             # We already have a pihole-FTL binary downloaded.
             # Alt branches don't have a tagged version against them, so just confirm the checksum of the local vs remote to decide whether we download or not
             remoteSha1=$(curl -sSL --fail "https://ftl.pi-hole.net/${ftlBranch}/${binary}.sha1" | cut -d ' ' -f 1)
-            localSha1=$(sha1sum "$(which pihole-FTL)" | cut -d ' ' -f 1)
+            localSha1=$(sha1sum "$(command -v pihole-FTL)" | cut -d ' ' -f 1)
 
             if [[ "${remoteSha1}" != "${localSha1}" ]]; then
                 printf "  %b Checksums do not match, downloading from ftl.pi-hole.net.\\n" "${INFO}"
@@ -2345,7 +2345,7 @@ FTLcheckUpdate() {
                 printf "  %b Latest FTL Binary already installed (%s). Confirming Checksum...\\n" "${INFO}" "${FTLlatesttag}"
 
                 remoteSha1=$(curl -sSL --fail "https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1" | cut -d ' ' -f 1)
-                localSha1=$(sha1sum "$(which pihole-FTL)" | cut -d ' ' -f 1)
+                localSha1=$(sha1sum "$(command -v pihole-FTL)" | cut -d ' ' -f 1)
 
                 if [[ "${remoteSha1}" != "${localSha1}" ]]; then
                     printf "  %b Corruption detected...\\n" "${INFO}"


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
On my installation, I get the following warning when running `bash -x /opt/pihole/update.sh`:

```
+++ which pihole-FTL
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
```

**How does this PR accomplish the above?:**
Doing what the warning says on the tin


**What documentation changes (if any) are needed to support this PR?:**
N/A
