### PR TITLE
Update default DHCP domain name to home.arpa

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -387,7 +387,7 @@ ProcessDHCPSettings() {
         fi
 
         if [[ "${PIHOLE_DOMAIN}" == "" ]]; then
-            PIHOLE_DOMAIN="lan"
+            PIHOLE_DOMAIN="home.arpa"
             change_setting "PIHOLE_DOMAIN" "${PIHOLE_DOMAIN}"
         fi
 


### PR DESCRIPTION
from lan. RFC 8375[1] suggests it as a sensible default.

[1]: https://datatracker.ietf.org/doc/html/rfc8375

Other supporting sources in order of relevance:

- pfSense also followed suit c.f. https://redmine.pfsense.org/issues/10533
  a year ago.
- https://superuser.com/q/1566825/165044 ("Best choice for
private/home network TLD? Overlap with mDNS?")
- https://github.com/pi-hole/pi-hole/issues/3429#issuecomment-632984174

Related but not worthy of mentioning in the commit message:

- https://datatracker.ietf.org/doc/html/draft-chapin-rfc2606bis-00 seems to suggest .lan as problematic.
- https://www.ctrl.blog/entry/homenet-domain-name.html: This guy does a great job at explaining the rationale.
- https://en.wikipedia.org/wiki/.arpa

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [N/A] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))