### PR TITLE
Remove DHCPv6, use leasetime from interface

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -440,7 +440,7 @@ dhcp-leasefile=/etc/pihole/dhcp.leases
             echo "#quiet-dhcp6
 #enable-ra
 dhcp-option=option6:dns-server,[::]
-dhcp-range=::100,::1ff,constructor:${interface},ra-names,slaac,64,3600
+dhcp-range=::,constructor:${interface},ra-names,ra-stateless,64
 ra-param=*,0,0
 " >> "${dhcpconfig}"
         fi


### PR DESCRIPTION
Signed-off-by: Omoeba <38597972+Omoeba@users.noreply.github.com>

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
- Remove stateful DHCPv6 since it is unnecessary with SLAAC and is [unsupported](https://issuetracker.google.com/issues/36949085) on some platforms
- Use the valid and preferred lifetimes from the interface instead of hardcoding it to `3600`. This provides accurate prefix lifetimes to clients on the subnet.


**How does this PR accomplish the above?:**
- Removed stateful DHCPv6 by setting the mode to `ra-stateless` instead of `slaac`
- Changed the range start and end to `::` as per the [documentation](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html#:~:text=If%20a%20%2D%2Ddhcp%2Drange%20is%20only%20being%20used%20for%20stateless%20DHCP%20and/or%20SLAAC%2C%20then%20the%20address%20can%20be%20simply%20%3A%3A)
- Removed the explicit leasetime of `3600` to use the `valid_lft` and `preferred_lft` from the interface as the valid and preferred lifetimes of the prefix (observed behavior by using `radvdump` on another computer in the subnet and manually adjusting the `valid_lft` and `preferred_lft` on the Pi-hole)


**What documentation changes (if any) are needed to support this PR?:**
- None


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
