### PR TITLE
Use ss instead of lsof

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -287,7 +287,7 @@ package_manager_detect() {
         # Packages required to run this install script (stored as an array)
         INSTALLER_DEPS=(git iproute2 whiptail ca-certificates)
         # Packages required to run Pi-hole (stored as an array)
-        PIHOLE_DEPS=(cron curl iputils-ping lsof psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2 netcat)
+        PIHOLE_DEPS=(cron curl iputils-ping psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2 netcat)
         # Packages required for the Web admin interface (stored as an array)
         # It's useful to separate this from Pi-hole, since the two repos are also setup separately
         PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-sqlite3" "${phpVer}-xml" "${phpVer}-intl")
@@ -332,7 +332,7 @@ package_manager_detect() {
         PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l"
         OS_CHECK_DEPS=(grep bind-utils)
         INSTALLER_DEPS=(git iproute newt procps-ng which chkconfig ca-certificates)
-        PIHOLE_DEPS=(cronie curl findutils sudo unzip libidn2 psmisc sqlite libcap lsof nmap-ncat)
+        PIHOLE_DEPS=(cronie curl findutils sudo unzip libidn2 psmisc sqlite libcap nmap-ncat)
         PIHOLE_WEB_DEPS=(lighttpd lighttpd-fastcgi php-common php-cli php-pdo php-xml php-json php-intl)
         LIGHTTPD_USER="lighttpd"
         LIGHTTPD_GROUP="lighttpd"

--- a/pihole
+++ b/pihole
@@ -288,7 +288,7 @@ analyze_ports() {
   # function is getting called
   # Check individual address family/protocol combinations
   # For a healthy Pi-hole, they should all be up (nothing printed)
-  lv4="$(ss --ipv4 --listening --numeric --tcp --udp | grep ":${port} ")"
+  lv4="$(ss --ipv4 --listening --numeric --tcp --udp src :${port})"
   if grep -q "udp " <<< "${lv4}"; then
       echo -e "     ${TICK} UDP (IPv4)"
   else
@@ -299,7 +299,7 @@ analyze_ports() {
   else
       echo -e "     ${CROSS} TCP (IPv4)"
   fi
-  lv6="$(ss --ipv6 --listening --numeric --tcp --udp | grep ":${port} ")"
+  lv6="$(ss --ipv6 --listening --numeric --tcp --udp src :${port})"
   if grep -q "udp " <<< "${lv6}"; then
       echo -e "     ${TICK} UDP (IPv6)"
   else

--- a/pihole
+++ b/pihole
@@ -283,26 +283,29 @@ Options:
 }
 
 analyze_ports() {
+  local lv4 lv6 port=${1}
   # FTL is listening at least on at least one port when this
   # function is getting called
   # Check individual address family/protocol combinations
   # For a healthy Pi-hole, they should all be up (nothing printed)
-  if grep -q "IPv4.*UDP" <<< "${1}"; then
+  lv4="$(ss --ipv4 --listening --numeric --tcp --udp | grep ":${port} ")"
+  if grep -q "udp " <<< "${lv4}"; then
       echo -e "     ${TICK} UDP (IPv4)"
   else
       echo -e "     ${CROSS} UDP (IPv4)"
   fi
-  if grep -q "IPv4.*TCP" <<< "${1}"; then
+  if grep -q "tcp " <<< "${lv4}"; then
       echo -e "     ${TICK} TCP (IPv4)"
   else
       echo -e "     ${CROSS} TCP (IPv4)"
   fi
-  if grep -q "IPv6.*UDP" <<< "${1}"; then
+  lv6="$(ss --ipv6 --listening --numeric --tcp --udp | grep ":${port} ")"
+  if grep -q "udp " <<< "${lv6}"; then
       echo -e "     ${TICK} UDP (IPv6)"
   else
       echo -e "     ${CROSS} UDP (IPv6)"
   fi
-  if grep -q "IPv6.*TCP" <<< "${1}"; then
+  if grep -q "tcp " <<< "${lv6}"; then
       echo -e "     ${TICK} TCP (IPv6)"
   else
       echo -e "     ${CROSS} TCP (IPv6)"
@@ -324,7 +327,6 @@ statusFunc() {
   else
     #get the port pihole-FTL is listening on by using FTL's telnet API
     port="$(echo ">dns-port >quit" | nc 127.0.0.1 4711)"
-    listening="$(lsof -Pni:${port})"
     if [[ "${port}" == "0" ]]; then
       case "${1}" in
         "web") echo "-1";;
@@ -334,7 +336,7 @@ statusFunc() {
     else
       if [[ "${1}" != "web" ]]; then
         echo -e "  ${TICK} FTL is listening on port ${port}"
-        analyze_ports "${listening}"
+        analyze_ports "${port}"
       fi
     fi
   fi


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix an issue with `docker` not being able to use `lsof` without adding capability: https://github.com/pi-hole/docker-pi-hole/issues/734

**How does this PR accomplish the above?:**

Use `ss` instead of `lsof`

As `ss` produces different output, the debug log port printing is adapted so I do not have to reinvent the wheel:

![Screenshot from 2022-01-05 17-03-31](https://user-images.githubusercontent.com/16748619/148251983-a6117e27-e333-4e77-96dd-eb1062bc0ca4.png)


**What documentation changes (if any) are needed to support this PR?:**

None