### PR TITLE
Install netcat-openbsd as dependency explicitly

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -287,7 +287,7 @@ package_manager_detect() {
         # Packages required to run this install script (stored as an array)
         INSTALLER_DEPS=(git iproute2 whiptail ca-certificates)
         # Packages required to run Pi-hole (stored as an array)
-        PIHOLE_DEPS=(cron curl iputils-ping psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2 netcat)
+        PIHOLE_DEPS=(cron curl iputils-ping psmisc sudo unzip idn2 sqlite3 libcap2-bin dns-root-data libcap2 netcat-openbsd)
         # Packages required for the Web admin interface (stored as an array)
         # It's useful to separate this from Pi-hole, since the two repos are also setup separately
         PIHOLE_WEB_DEPS=(lighttpd "${phpVer}-common" "${phpVer}-cgi" "${phpVer}-sqlite3" "${phpVer}-xml" "${phpVer}-intl")


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Since Debian Stretch and Ubuntu Bionic, the "netcat" package is a transitional dummy package which pulls in "netcat-traditional" on Debian Stretch+Buster and Ubuntu Bionic, and "netcat-openbsd" on Debian Bullseye, Ubuntu Focal and up.

On Debian Bookworm (testing), however, the "netcat" package has been removed during the last 3 days at time or writing, so that it fails do be installed. While "netcat-traditional" and "netcat-openbsd" both "Provides: netcat", since it's two alternatives, APT does not automatically pick one but aborts, and the only solution is to install one explicitly.

While this is likely a temporary state of the Debian testing suite, and of course Bookworm is not supported and ~1.5 years away from release, having a closer look at the two alternatives shows that "netcat-openbsd" is a much more actively maintained newer version with additional support for IPv6, proxies, and UNIX sockets, which is likely the reason for the gradual transition via meta package from "netcat-traditional" to "netcat-openbsd". This commit hence consequently follows this aim by skipping the transitional dummy package and installing "netcat-openbsd" explicitly as dependency, to avoid any possible errors like the one which occurs currently on Bookworm.

Both packages can be installed concurrently and do no conflict, but are managed via dpkg's "update-alternatives".

For reference:
- https://packages.debian.org/netcat
- https://packages.ubuntu.com/netcat

**How does this PR accomplish the above?:**
The `netcat` package from Pi-hole dependencies on `apt` based distributions has been replaced with `netcat-openbsd`

**Alternative:**
An alternative would be to remove the dependency together with the use of `nc` throughout Pi-hole. The only two uses I could find were in the [`pihole` command to get the DNS port](https://github.com/pi-hole/pi-hole/blob/5823f5e/pihole#L329) and in [PADD to check for network connectivity](https://github.com/pi-hole/PADD/blob/dc22a6a/padd.sh#L970). The latter can be easily replaced with `ping` or `curl` or even `dig`, the first via `/dev/tcp/127.0.0.1/$(</run/pihole-FTL.port)` file descriptor like it is done elsewhere, also in PADD. But a more important argument to keep `nc` is that this file descriptor method is not nice to use from a console, and hence for end users communicating with the telnet API. Reasonably using `nc` is also the method described in the docs: https://docs.pi-hole.net/ftldns/telnet-api/

**What documentation changes (if any) are needed to support this PR?:**
None

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.