### PR TITLE
Fix gravity in case there are no adlists at all or all are disabled

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -402,14 +402,12 @@ gravity_DownloadBlocklists() {
   )"
 
   local str="Pulling blocklist source list into range"
+  echo -e "${OVER}  ${TICK} ${str}"
 
-  if [[ -n "${sources[*]}" ]] && [[ -n "${sourceDomains[*]}" ]]; then
-    echo -e "${OVER}  ${TICK} ${str}"
-  else
-    echo -e "${OVER}  ${CROSS} ${str}"
+  if [[ -z "${sources[*]}" ]] || [[ -z "${sourceDomains[*]}" ]]; then
     echo -e "  ${INFO} No source list found, or it is empty"
     echo ""
-    return 1
+    unset sources
   fi
 
   local url domain agent cmd_ext str target compression


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix https://github.com/pi-hole/pi-hole/issues/4519

**How does this PR accomplish the above?:**

Create database even when there is nothing to add

### Screenshot for all adlists are disabled

Before:
![Screenshot from 2022-01-08 11-30-49](https://user-images.githubusercontent.com/16748619/148641056-03a804c8-c196-43db-a960-42ae7076767d.png)


Now:
![Screenshot from 2022-01-08 11-25-29](https://user-images.githubusercontent.com/16748619/148641082-aba8616b-7ee1-4d64-a0d7-618a4f9b1567.png)



**What documentation changes (if any) are needed to support this PR?:**

None