### PR TITLE
Remove oneline from ss call

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -753,7 +753,7 @@ check_required_ports() {
     # Sort the addresses and remove duplicates
     while IFS= read -r line; do
         ports_in_use+=( "$line" )
-    done < <( ss --listening --numeric --tcp --udp --processes --oneline --no-header )
+    done < <( ss --listening --numeric --tcp --udp --processes --no-header )
 
     # Now that we have the values stored,
     for i in "${!ports_in_use[@]}"; do


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
PR https://github.com/pi-hole/pi-hole/pull/4518 switched from `lsof` to `ss` to analyse the ports in use. For the debug log it uses the `--oneline`` option. 
However, this option is only available in `iproute2` >=[5.10](https://git.kernel.org/pub/scm/network/iproute2/iproute2.git/commit/?id=296b5de72423ea93bc62dcbc51c54fa096bd5ec7). Some supported OS like Debian 10 ship `iproute2` v4.20, therefore `ss --oneline` fails. 


**How does this PR accomplish the above?:**
Removes the `oneline` option. 
Generation of debug output works anyway (maybe not failproof?)

```
*** [ DIAGNOSING ]: Ports in use
    udp:0.0.0.0:51820 is in use by <unknown>
    udp:127.0.0.1:5335 is in use by unbound
    udp:127.0.0.1:5335 is in use by unbound
    udp:0.0.0.0:3478 is in use by docker-proxy
[✓] udp:0.0.0.0:53 is in use by pihole-FTL
    udp:0.0.0.0:68 is in use by dhcpcd
    udp:127.0.0.1:323 is in use by chronyd
    udp:[::]:51820 is in use by <unknown>
[✓] udp:[::]:53 is in use by pihole-FTL
    udp:[::1]:323 is in use by chronyd
    tcp:0.0.0.0:8843 is in use by docker-proxy
[✓] tcp:0.0.0.0:80 is in use by lighttpd
    tcp:0.0.0.0:8080 is in use by docker-proxy
    tcp:0.0.0.0:8880 is in use by docker-proxy
[✓] tcp:0.0.0.0:53 is in use by pihole-FTL
    tcp:0.0.0.0:22 is in use by sshd
    tcp:127.0.0.1:5335 is in use by unbound
    tcp:127.0.0.1:5335 is in use by unbound
    tcp:0.0.0.0:8888 is in use by docker-proxy
    tcp:127.0.0.1:8953 is in use by unbound
    tcp:0.0.0.0:8443 is in use by docker-proxy
[✓] tcp:127.0.0.1:4711 is in use by pihole-FTL
[✓] tcp:[::]:80 is in use by lighttpd
[✓] tcp:[::]:53 is in use by pihole-FTL
    tcp:[::]:22 is in use by sshd

```