### PR TITLE
use sed substitute instead of delete and append

### DIFF
--- a/pihole
+++ b/pihole
@@ -223,8 +223,7 @@ Time:
       fi
 
       local str="Pi-hole Disabled"
-      sed -i "/BLOCKING_ENABLED=/d" "${setupVars}"
-      echo "BLOCKING_ENABLED=false" >> "${setupVars}"
+      sed -i "s/BLOCKING_ENABLED=true/BLOCKING_ENABLED=false/" "${setupVars}"
     fi
   else
     # Enable Pi-hole
@@ -236,8 +235,7 @@ Time:
     echo -e "  ${INFO} Enabling blocking"
     local str="Pi-hole Enabled"
 
-    sed -i "/BLOCKING_ENABLED=/d" "${setupVars}"
-    echo "BLOCKING_ENABLED=true" >> "${setupVars}"
+    sed -i "s/BLOCKING_ENABLED=false/BLOCKING_ENABLED=true/" "${setupVars}"
   fi
 
   restartDNS reload-lists

--- a/pihole
+++ b/pihole
@@ -223,7 +223,7 @@ Time:
       fi
 
       local str="Pi-hole Disabled"
-      sed -i "s/BLOCKING_ENABLED=true/BLOCKING_ENABLED=false/" "${setupVars}"
+      sed -i "s/^BLOCKING_ENABLED=true/BLOCKING_ENABLED=false/" "${setupVars}"
     fi
   else
     # Enable Pi-hole
@@ -235,7 +235,7 @@ Time:
     echo -e "  ${INFO} Enabling blocking"
     local str="Pi-hole Enabled"
 
-    sed -i "s/BLOCKING_ENABLED=false/BLOCKING_ENABLED=true/" "${setupVars}"
+    sed -i "s/^BLOCKING_ENABLED=false/BLOCKING_ENABLED=true/" "${setupVars}"
   fi
 
   restartDNS reload-lists


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*

When using `pihole disable` or disabling in the webinterface, the order of lines in setupVars.conf is changed.
With this change, the order is kept intact.

It also makes it consistent with the usage of sed in the piholeLogging() method below.

**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*

using sed's s/ instead of /d

**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*

none

---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
