### PR TITLE
Base upstrem tag detecion on rev-list

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -49,7 +49,8 @@ GitCheckUpdateAvail() {
         # get the latest local tag
         LOCAL=$(git describe --abbrev=0 --tags master)
         # get the latest tag from remote
-        REMOTE=$(git describe --abbrev=0 --tags origin/master)
+        # we can't use "git describe --abbrev=0 --tags origin/master" here because it is not supported on older git versions
+        REMOTE=$(git describe --tags $(git rev-list --tags -1))
 
     else
         # @ alone is a shortcut for HEAD. Older versions of git


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
PR https://github.com/pi-hole/pi-hole/pull/4475 introduced updating based on tags instead of commits for master branch. This works well, except for older versions of `git` which are shipped by default on CentOS 7 (currently supported OS). It turned out, that the detection of the latest upstream tag by `git describe --abbrev=0 --tags origin/master` failed (See https://github.com/pi-hole/pi-hole/pull/4475#issuecomment-1019353628) 

This pr changes the detection to be based on `rev-list`. The used command has been confirmed working on CentOS 7 (here https://github.com/pi-hole/pi-hole/pull/4475#issuecomment-1019354638)
