### PR TITLE
Fix updating based on tags on older git versions by doing a full fetch

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -41,7 +41,7 @@ GitCheckUpdateAvail() {
     cd "${directory}" || return
 
     # Fetch latest changes in this repo
-    git fetch --tags --quiet origin
+    git fetch --quiet origin
 
     # Check current branch. If it is master, then check for the latest available tag instead of latest commit.
     curBranch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
PR #4475 introduced updating based on tags instead of commits for master branch. This works well, except for older versions of git which are shipped by default on CentOS 7 (currently supported OS). It turned out, that fetching using `--tags` was the issue here (https://github.com/pi-hole/pi-hole/pull/4475#issuecomment-1019357036)

This PR does the fetching without `--tags` (which is what we used before #4475). It has been confirmed working on CentOS 7 (https://github.com/pi-hole/pi-hole/pull/4475#issuecomment-1019358878).

