### PR TITLE
Fix log flush with new query database schema

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -63,7 +63,7 @@ else
         fi
     fi
     # Delete most recent 24 hours from FTL's database, leave even older data intact (don't wipe out all history)
-    deleted=$(pihole-FTL sqlite3 "${DBFILE}" "DELETE FROM queries WHERE timestamp >= strftime('%s','now')-86400; select changes() from queries limit 1")
+    deleted=$(pihole-FTL sqlite3 "${DBFILE}" "DELETE FROM query_storage WHERE timestamp >= strftime('%s','now')-86400; select changes() from query_storage limit 1")
 
     # Restart pihole-FTL to force reloading history
     sudo pihole restartdns


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Fixes a bug reported on discourse: https://discourse.pi-hole.net/t/flushing-log-fails-with-v5-9-ftl-v5-14/53532/1

With https://github.com/pi-hole/FTL/pull/1255 the table `queries` was converted to a view and the actual data is now in `query_storage`. We forgot to adjust the `flush_log` function accordingly.
```

rockpi@rockpi-4b:~$ pihole -f
[sudo] password for rockpi: 
  [i] Flushing /var/log/pihole.log ...Error: in prepare, cannot modify queries because it is a view (1)
  [✓] Restarting DNS server
  [✓] Flushed /var/log/pihole.log
  [✓] Deleted  queries from database

...

Current Pi-hole version is fix/flush v5.8.1-50-gf4286a4d
  Current AdminLTE version is devel v5.10.1-84-g10984d52
  Current FTL version is development vDev-3a5c0ac
rockpi@rockpi-4b:~$ pihole -f
  [✓] Restarting DNS server
  [✓] Flushed /var/log/pihole.log
  [✓] Deleted 16806 queries from database
```
