### PR TITLE
Set the permissions for the database explicitly

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -1012,8 +1012,10 @@ fi
 update_gravity_timestamp
 
 # Ensure proper permissions are set for the database
+chown root:pihole "${piholeDir}"
+chmod 0775 "${piholeDir}"
 chown pihole:pihole "${gravityDBfile}"
-chmod g+w "${piholeDir}" "${gravityDBfile}"
+chmod 0664   "${gravityDBfile}"
 
 # Compute numbers to be displayed
 gravity_ShowCount


### PR DESCRIPTION
This makes the gravity.sh script set the right permissions for the pihole directory and the database file explicitly.

**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
*A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues*


**How does this PR accomplish the above?:**
*A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix*


**What documentation changes (if any) are needed to support this PR?:**
*A detailed list of any necessary changes*


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
