### PR TITLE
Tweak/api port

### DIFF
--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -33,3 +33,30 @@ addOrEditKeyValPair() {
     echo "${key}=${value}" >> "${file}"
   fi
 }
+
+#######################
+# returns FTL's current telnet API port
+#######################
+getFTLAPIPort(){
+  local -r FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
+  local -r DEFAULT_PORT_FILE="/run/pihole-FTL.port"
+  local -r DEFAULT_FTL_PORT=4711
+  local PORTFILE
+  local ftl_api_port
+
+  if [[ -f "$FTLCONFFILE" ]]; then
+    # if PORTFILE is not set in pihole-FTL.conf, use the default path
+    PORTFILE="$( (grep "^PORTFILE=" $FTLCONFFILE || echo "$DEFAULT_PORT_FILE") | cut -d"=" -f2-)"
+  fi
+
+  if [[ -s "$PORTFILE" ]]; then
+    # -s: FILE exists and has a size greater than zero
+    ftl_api_port=$(<"$PORTFILE")
+    # Exploit prevention: unset the variable if there is malicious content
+    # Verify that the value read from the file is numeric
+    [[ "$ftl_api_port" =~ [^[:digit:]] ]] && unset ftl_api_port
+  fi
+
+  # echo the port found in the portfile or default to the default port
+  echo "${ftl_api_port:=$DEFAULT_FTL_PORT}"
+}

--- a/pihole
+++ b/pihole
@@ -316,9 +316,10 @@ analyze_ports() {
 
 statusFunc() {
   # Determine if there is pihole-FTL service is listening
-  local listening pid port
+  local pid port ftl_api_port
 
   pid="$(getFTLPID)"
+  ftl_api_port="$(getFTLAPIPort)"
   if [[ "$pid" -eq "-1" ]]; then
     case "${1}" in
       "web") echo "-1";;
@@ -326,8 +327,8 @@ statusFunc() {
     esac
     return 0
   else
-    #get the port pihole-FTL is listening on by using FTL's telnet API
-    port="$(echo ">dns-port >quit" | nc 127.0.0.1 4711)"
+    #get the DNS port pihole-FTL is listening on by using FTL's telnet API
+    port="$(echo ">dns-port >quit" | nc 127.0.0.1 "$ftl_api_port")"
     if [[ "${port}" == "0" ]]; then
       case "${1}" in
         "web") echo "-1";;

--- a/test/test_any_utils.py
+++ b/test/test_any_utils.py
@@ -1,16 +1,38 @@
 def test_key_val_replacement_works(host):
     ''' Confirms addOrEditKeyValPair provides the expected output '''
     host.run('''
-    setupvars=./testoutput
     source /opt/pihole/utils.sh
     addOrEditKeyValPair "KEY_ONE" "value1" "./testoutput"
     addOrEditKeyValPair "KEY_TWO" "value2" "./testoutput"
     addOrEditKeyValPair "KEY_ONE" "value3" "./testoutput"
     addOrEditKeyValPair "KEY_FOUR" "value4" "./testoutput"
-    cat ./testoutput
     ''')
     output = host.run('''
     cat ./testoutput
     ''')
     expected_stdout = 'KEY_ONE=value3\nKEY_TWO=value2\nKEY_FOUR=value4\n'
+    assert expected_stdout == output.stdout
+
+
+def test_getFTLAPIPort_default(host):
+    ''' Confirms getFTLAPIPort returns the default API port '''
+    output = host.run('''
+    source /opt/pihole/utils.sh
+    getFTLAPIPort
+    ''')
+    expected_stdout = '4711\n'
+    assert expected_stdout == output.stdout
+
+
+def test_getFTLAPIPort_custom(host):
+    ''' Confirms getFTLAPIPort returns a custom API port in a custom PORTFILE location '''
+    host.run('''
+    echo "PORTFILE=/tmp/port.file" > /etc/pihole/pihole-FTL.conf
+    echo "1234" > /tmp/port.file
+    ''')
+    output = host.run('''
+    source /opt/pihole/utils.sh
+    getFTLAPIPort
+    ''')
+    expected_stdout = '1234\n'
     assert expected_stdout == output.stdout


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
We allow users to change the telnet API port in `pihole-FTL.conf` https://docs.pi-hole.net/ftldns/configfile/#ftlport
Therefore, we should not hardcode the port.


**How does this PR accomplish the above?:**
FTL does save its current port to `/run/pihole-FTL.port` or whatever location is set in `PORTFILE` (https://docs.pi-hole.net/ftldns/configfile/#file_PORTFILE)

This PR checks for a `PORTFILE` and reads the value saved in that file. It defaults back to the standard port file if `PORTFILE` is not set. If anything goes wrong, it defaults to the default port of 4711.