### PR TITLE
Generate colorful debug logs to web interface

### DIFF
--- a/advanced/Scripts/COL_TABLE
+++ b/advanced/Scripts/COL_TABLE
@@ -1,5 +1,5 @@
 # Determine if terminal is capable of showing colors
-if [[ -t 1 ]] && [[ $(tput colors) -ge 8 ]]; then
+if ([[ -t 1 ]] && [[ $(tput colors) -ge 8 ]]) || [[ "${WEBCALL}" ]]; then
   # Bold and underline may not show up on all clients
   # If something MUST be emphasized, use both
   COL_BOLD='[1m'


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Debug logs are colorful when generated via command line, but don't display colors in the web interface.
This PR generate colorful debug logs to be shown in the web interface.

**How does this PR accomplish the above?:**

Uses the same color codes used in command line log version to create the web version.

**Note:**
needs https://github.com/pi-hole/AdminLTE/pull/2142 to work.


**What documentation changes (if any) are needed to support this PR?:**
none