### PR TITLE
Improving debug log

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -36,6 +36,11 @@ server.port                 = 80
 accesslog.filename          = "/var/log/lighttpd/access.log"
 accesslog.format            = "%{%s}t|%V|%r|%s|%b"
 
+# Allow streaming response
+# reference: https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_stream-response-bodyDetails
+server.stream-response-body = 1
+#ssl.read-ahead              = "disable"
+
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny             = ( "~", ".inc", ".md", ".yml", ".ini" )
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -37,6 +37,11 @@ server.port                 = 80
 accesslog.filename          = "/var/log/lighttpd/access.log"
 accesslog.format            = "%{%s}t|%V|%r|%s|%b"
 
+# Allow streaming response
+# reference: https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_stream-response-bodyDetails
+server.stream-response-body = 1
+#ssl.read-ahead              = "disable"
+
 index-file.names            = ( "index.php", "index.html", "index.lighttpd.html" )
 url.access-deny             = ( "~", ".inc", ".md", ".yml", ".ini" )
 static-file.exclude-extensions = ( ".php", ".pl", ".fcgi" )


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

This PR allows `lighttpd` to stream large contents to the browser.

A few years a go, `lighttpd` default settings were defined to buffer as little as possible and stream the content.
Now, the current default setting is to always buffer the entire response before send it to the browser.
As a result, the browser only receives the "Debug log" after it is completely finished.

Using a new configuration the browser will start to receive the log as soon as possible. 

**How does this PR accomplish the above?:**

Adding the corresponding `lighttpd` configuration. 

<details><summary>Lighttpd Reference</summary>
<a href="https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_stream-response-bodyDetails">https://redmine.lighttpd.net/projects/lighttpd/wiki/Server_stream-response-bodyDetails</a>
</details>

<details><summary>Technical details</summary>
<br>
We replaced:
<ul>
<li><del><code>stream-response-body = 0</code> (default) buffer entire response body before sending to client</del> with</li>  
<li><code>stream-response-body = 1</code> <small>stream response body to client</small></li>
</ul>
 
<p>
<b><i>lighttpd</i></b> Docs recommends to set <code>ssl.read-ahead=disable</code>, when operating in a memory constrained environment and using HTTPS.
</p>
<p>
However, this configuration required <code>mod_openssl</code> which we do not use, because we don't use HTTPS for the web interface. 
<code>ssl.read-ahead=disable</code> is also the default value, so adding it would not have any effect.
</p>
<br>
</details>



**What documentation changes (if any) are needed to support this PR?:**
none