### PR TITLE
Wrap touch calls with if/then guards for Buster docker.

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -23,7 +23,7 @@ start() {
     mkdir -pm 0755 /run/pihole
     [ ! -f /run/pihole-FTL.pid ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.pid
     [ ! -f /run/pihole-FTL.port ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.port
-    [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole.log
+    [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole-FTL.log
     [ ! -f /var/log/pihole.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole.log
     [ ! -f /etc/pihole/dhcp.leases ] && install -m 644 -o pihole -g pihole /dev/null /etc/pihole/dhcp.leases
     # Ensure that permissions are set so that pihole-FTL can edit all necessary files

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -21,12 +21,15 @@ start() {
   else
     # Touch files to ensure they exist (create if non-existing, preserve if existing)
     mkdir -pm 0755 /run/pihole
-    touch /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases
+    [ ! -f /run/pihole-FTL.pid ] && install -m 644 -o pihole -g pihole dev/null /run/pihole-FTL.pid
+    [ ! -f /run/pihole-FTL.port ] && install -m 644 -o pihole -g pihole dev/null /run/pihole-FTL.port
+    [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole dev/null /var/log/pihole.log
+    [ ! -f /var/log/pihole.log ] && install -m 644 -o pihole -g pihole dev/null /var/log/pihole.log
+    [ ! -f /etc/pihole/dhcp.leases ] && install -m 644 -o pihole -g pihole dev/null /etc/pihole/dhcp.leases
     # Ensure that permissions are set so that pihole-FTL can edit all necessary files
-    chown pihole:pihole /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases /run/pihole /etc/pihole
-    chmod 0644 /run/pihole-FTL.pid /run/pihole-FTL.port /var/log/pihole-FTL.log /var/log/pihole.log /etc/pihole/dhcp.leases
+    chown pihole:pihole /run/pihole /etc/pihole /var/log/pihole.log /var/log/pihole.log /etc/pihole/dhcp.leases
     # Ensure that permissions are set so that pihole-FTL can edit the files. We ignore errors as the file may not (yet) exist
-    chmod -f 0644 /etc/pihole/macvendor.db
+    chmod -f 0644 /etc/pihole/macvendor.db /etc/pihole/dhcp.leases /var/log/pihole-FTL.log /var/log/pihole.log
     # Chown database files to the user FTL runs as. We ignore errors as the files may not (yet) exist
     chown -f pihole:pihole /etc/pihole/pihole-FTL.db /etc/pihole/gravity.db /etc/pihole/macvendor.db
     # Chown database file permissions so that the pihole group (web interface) can edit the file. We ignore errors as the files may not (yet) exist

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -21,11 +21,11 @@ start() {
   else
     # Touch files to ensure they exist (create if non-existing, preserve if existing)
     mkdir -pm 0755 /run/pihole
-    [ ! -f /run/pihole-FTL.pid ] && install -m 644 -o pihole -g pihole dev/null /run/pihole-FTL.pid
-    [ ! -f /run/pihole-FTL.port ] && install -m 644 -o pihole -g pihole dev/null /run/pihole-FTL.port
-    [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole dev/null /var/log/pihole.log
-    [ ! -f /var/log/pihole.log ] && install -m 644 -o pihole -g pihole dev/null /var/log/pihole.log
-    [ ! -f /etc/pihole/dhcp.leases ] && install -m 644 -o pihole -g pihole dev/null /etc/pihole/dhcp.leases
+    [ ! -f /run/pihole-FTL.pid ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.pid
+    [ ! -f /run/pihole-FTL.port ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.port
+    [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole.log
+    [ ! -f /var/log/pihole.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole.log
+    [ ! -f /etc/pihole/dhcp.leases ] && install -m 644 -o pihole -g pihole /dev/null /etc/pihole/dhcp.leases
     # Ensure that permissions are set so that pihole-FTL can edit all necessary files
     chown pihole:pihole /run/pihole /etc/pihole /var/log/pihole.log /var/log/pihole.log /etc/pihole/dhcp.leases
     # Ensure that permissions are set so that pihole-FTL can edit the files. We ignore errors as the file may not (yet) exist

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1333,8 +1333,7 @@ installConfigs() {
         install -D -m 644 -T ${PI_HOLE_LOCAL_REPO}/advanced/${LIGHTTPD_CFG} "${lighttpdConfig}"
         # Make sure the external.conf file exists, as lighttpd v1.4.50 crashes without it
         if [ ! -f /etc/lighttpd/external.conf ]; then
-            touch /etc/lighttpd/external.conf
-            chmod 644 /etc/lighttpd/external.conf
+            install -m 644 /dev/null /etc/lighttpd/external.com
         fi
         # If there is a custom block page in the html/pihole directory, replace 404 handler in lighttpd config
         if [[ -f "${PI_HOLE_BLOCKPAGE_DIR}/custom.php" ]]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1128,8 +1128,10 @@ chooseBlocklists() {
         appendToListsFile "${choice}"
     done
     # Create an empty adList file with appropriate permissions.
-    touch "${adlistFile}"
-    chmod 644 "${adlistFile}"
+    if [ ! -f "${adlistFile}" ]; then
+        touch "${adlistFile}"
+        chmod 644 "${adlistFile}"
+    fi
 }
 
 # Accept a string parameter, it must be one of the default lists
@@ -1330,8 +1332,10 @@ installConfigs() {
         # and copy in the config file Pi-hole needs
         install -D -m 644 -T ${PI_HOLE_LOCAL_REPO}/advanced/${LIGHTTPD_CFG} "${lighttpdConfig}"
         # Make sure the external.conf file exists, as lighttpd v1.4.50 crashes without it
-        touch /etc/lighttpd/external.conf
-        chmod 644 /etc/lighttpd/external.conf
+        if [ ! -f /etc/lighttpd/external.conf ]; then
+            touch /etc/lighttpd/external.conf
+            chmod 644 /etc/lighttpd/external.conf
+        fi
         # If there is a custom block page in the html/pihole directory, replace 404 handler in lighttpd config
         if [[ -f "${PI_HOLE_BLOCKPAGE_DIR}/custom.php" ]]; then
             sed -i 's/^\(server\.error-handler-404\s*=\s*\).*$/\1"\/pihole\/custom\.php"/' "${lighttpdConfig}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1129,7 +1129,7 @@ chooseBlocklists() {
     done
     # Create an empty adList file with appropriate permissions.
     if [ ! -f "${adlistFile}" ]; then
-        touch "${adlistFile}"
+        install /dev/null "${adlistFile}"
         chmod 644 "${adlistFile}"
     fi
 }

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1129,7 +1129,8 @@ chooseBlocklists() {
     done
     # Create an empty adList file with appropriate permissions.
     if [ ! -f "${adlistFile}" ]; then
-        install /dev/null "${adlistFile}"
+        install -m 644 /dev/null "${adlistFile}"
+    else
         chmod 644 "${adlistFile}"
     fi
 }
@@ -1333,7 +1334,7 @@ installConfigs() {
         install -D -m 644 -T ${PI_HOLE_LOCAL_REPO}/advanced/${LIGHTTPD_CFG} "${lighttpdConfig}"
         # Make sure the external.conf file exists, as lighttpd v1.4.50 crashes without it
         if [ ! -f /etc/lighttpd/external.conf ]; then
-            install -m 644 /dev/null /etc/lighttpd/external.com
+            install -m 644 /dev/null /etc/lighttpd/external.conf
         fi
         # If there is a custom block page in the html/pihole directory, replace 404 handler in lighttpd config
         if [[ -f "${PI_HOLE_BLOCKPAGE_DIR}/custom.php" ]]; then


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 
*please fill any appropriate checkboxes, e.g: [X]*

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**

Buster hosts running our Bullseye docker image can not `touch` existing files do to a libsec2 issue.
