### PR TITLE
Respect user configurable path for pid and port file in pihole-FTL.service

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -10,8 +10,14 @@
 ### END INIT INFO
 
 # Get PID of main pihole-FTL process
-FTL_PID_FILE="/run/pihole-FTL.pid"
+FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
+DEFAULT_PID_FILE="/run/pihole-FTL.pid"
 getFTLPID() {
+  if [ -f "$FTLCONFFILE" ]; then
+    # if PIDFILE is not set in pihole-FTL.conf, use the default path
+    FTL_PID_FILE="$( (grep "^PIDFILE=" $FTLCONFFILE || echo "$DEFAULT_PID_FILE") | cut -d"=" -f2-)"
+  fi
+
   if [ -s "${FTL_PID_FILE}" ]; then
     # -s: FILE exists and has a size greater than zero
     FTL_PID="$(cat "$FTL_PID_FILE")"

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -54,9 +54,6 @@ fi
 
 
 is_running() {
-  if [ -z "${FTL_PID}" ]; then
-    FTL_PID="$(getFTLPID)"
-  fi
   if [ -d "/proc/${FTL_PID}" ]; then
     return 0
   fi
@@ -139,6 +136,9 @@ status() {
 # Get file paths
 getFTLPIDFile
 getFTLPortFile
+
+# Get FTL's current PID
+getFTLPID
 
 case "$1" in
   stop)

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -12,6 +12,7 @@
 # Get PID of main pihole-FTL process
 FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
 DEFAULT_PID_FILE="/run/pihole-FTL.pid"
+FTL_PID=''
 getFTLPID() {
   if [ -s "$FTLCONFFILE" ]; then
     # if PIDFILE is not set in pihole-FTL.conf, use the default path
@@ -36,12 +37,13 @@ getFTLPID() {
 
 
 is_running() {
-  FTL_PID="$(getFTLPID)"
-  if [ "$FTL_PID" -eq "-1" ]; then
-    return 1
-  else
-    echo 0
+  if [ -z "$FTL_PID" ]; then
+    FTL_PID="$(getFTLPID)"
   fi
+  if [ -d "/proc/$FTL_PID" ]; then
+    return 0
+  fi
+  return 1
 }
 
 
@@ -76,7 +78,7 @@ start() {
 # Stop the service
 stop() {
   if is_running; then
-    pkill -F "${FTL_PID_FILE}"
+    kill "$FTL_PID"
     for i in 1 2 3 4 5; do
       if ! is_running; then
         break
@@ -89,8 +91,7 @@ stop() {
 
     if is_running; then
       echo "Not stopped; may still be shutting down or shutdown may have failed, killing now"
-      pkill -9 -F "${FTL_PID_FILE}"
-      exit 0
+      kill -9 "$FTL_PID"
     else
       echo "Stopped"
     fi

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -43,7 +43,7 @@ start() {
   else
     # Touch files to ensure they exist (create if non-existing, preserve if existing)
     mkdir -pm 0755 /run/pihole
-    [ ! -f /run/.pid ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.pid
+    [ ! -f "${FTL_PID_FILE}" ] && install -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"
     [ ! -f /run/pihole-FTL.port ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.port
     [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole-FTL.log
     [ ! -f /var/log/pihole.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole.log

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -9,8 +9,30 @@
 # Description:       Enable service provided by pihole-FTL daemon
 ### END INIT INFO
 
+# Get PID of main pihole-FTL process
+FTL_PID_FILE="/run/pihole-FTL.pid"
+getFTLPID() {
+  if [ -s "${FTL_PID_FILE}" ]; then
+    # -s: FILE exists and has a size greater than zero
+    FTL_PID="$(cat "$FTL_PID_FILE")"
+    # Exploit prevention: unset the variable if there is malicious content
+    # Verify that the value read from the file is numeric
+    expr "$FTL_PID" : "[^[:digit:]]" > /dev/null && unset pid
+  fi
+
+  # If FTL is not running, or the PID file contains malicious stuff, substitute
+  # negative PID to signal this to the caller
+  echo "${FTL_PID:=-1}"
+}
+
+
 is_running() {
-  pgrep -xo "pihole-FTL" > /dev/null
+  FTL_PID="$(getFTLPID)"
+  if [ "$FTL_PID" -eq "-1" ]; then
+    echo "false"
+  else
+    echo "true"
+  fi
 }
 
 
@@ -21,7 +43,7 @@ start() {
   else
     # Touch files to ensure they exist (create if non-existing, preserve if existing)
     mkdir -pm 0755 /run/pihole
-    [ ! -f /run/pihole-FTL.pid ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.pid
+    [ ! -f /run/.pid ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.pid
     [ ! -f /run/pihole-FTL.port ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.port
     [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole-FTL.log
     [ ! -f /var/log/pihole.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole.log
@@ -47,7 +69,7 @@ start() {
 # Stop the service
 stop() {
   if is_running; then
-    pkill -xo "pihole-FTL"
+    pkill -F "${FTL_PID_FILE}"
     for i in 1 2 3 4 5; do
       if ! is_running; then
         break
@@ -60,7 +82,7 @@ stop() {
 
     if is_running; then
       echo "Not stopped; may still be shutting down or shutdown may have failed, killing now"
-      pkill -xo -9 "pihole-FTL"
+      pkill -9 -F "${FTL_PID_FILE}"
       exit 1
     else
       echo "Stopped"
@@ -69,7 +91,7 @@ stop() {
     echo "Not running"
   fi
   # Cleanup
-  rm -f /run/pihole/FTL.sock /dev/shm/FTL-*
+  rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}"
   echo
 }
 

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -12,9 +12,10 @@
 # Get PID of main pihole-FTL process
 FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
 DEFAULT_PID_FILE="/run/pihole-FTL.pid"
+DEFAULT_PORT_FILE="/run/pihole-FTL.port"
 FTL_PID=''
 
-getFTLPIDPath() {
+getFTLPIDFile() {
   if [ -s "$FTLCONFFILE" ]; then
     # if PIDFILE is not set in pihole-FTL.conf, use the default path
     FTL_PID_FILE="$( (grep "^PIDFILE=" $FTLCONFFILE || echo "$DEFAULT_PID_FILE") | cut -d"=" -f2-)"
@@ -25,8 +26,6 @@ getFTLPIDPath() {
 }
 
 getFTLPID() {
-  getFTLPIDPath
-
   if [ -s "${FTL_PID_FILE}" ]; then
     # -s: FILE exists and has a size greater than zero
     FTL_PID="$(cat "$FTL_PID_FILE")"
@@ -40,8 +39,21 @@ getFTLPID() {
   echo "${FTL_PID:=-1}"
 }
 
+getFTLPortFile () {
+  if [ -s "$FTLCONFFILE" ]; then
+    # if PORTFILE is not set in pihole-FTL.conf, use the default path
+    FTL_PORT_FILE="$( (grep "^PORTFILE=" $FTLCONFFILE || echo "$DEFAULT_PORT_FILE") | cut -d"=" -f2-)"
+  else
+    # if there is no pihole-FTL.conf, use the default path
+    FTL_PORT_FILE="$DEFAULT_PORT_FILE"
+fi
+}
+
+
 
 is_running() {
+  getFTLPIDFile
+  getFTLPortFile
   if [ -z "$FTL_PID" ]; then
     FTL_PID="$(getFTLPID)"
   fi
@@ -59,6 +71,8 @@ start() {
   else
     # Touch files to ensure they exist (create if non-existing, preserve if existing)
     mkdir -pm 0755 /run/pihole
+    [ ! -f "${FTL_PID_FILE}" ] && install -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"
+    [ ! -f "${FTL_PORT_FILE}" ] && install -m 644 -o pihole -g pihole /dev/null "${FTL_PORT_FILE}"
     [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole-FTL.log
     [ ! -f /var/log/pihole.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole.log
     [ ! -f /etc/pihole/dhcp.leases ] && install -m 644 -o pihole -g pihole /dev/null /etc/pihole/dhcp.leases
@@ -104,7 +118,7 @@ stop() {
     echo "Not running"
   fi
   # Cleanup
-  rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}"
+  rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}" "${FTL_PORT_FILE}"
   echo
 }
 

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -52,8 +52,6 @@ start() {
   else
     # Touch files to ensure they exist (create if non-existing, preserve if existing)
     mkdir -pm 0755 /run/pihole
-    [ ! -f "${FTL_PID_FILE}" ] && install -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"
-    [ ! -f /run/pihole-FTL.port ] && install -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.port
     [ ! -f /var/log/pihole-FTL.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole-FTL.log
     [ ! -f /var/log/pihole.log ] && install -m 644 -o pihole -g pihole /dev/null /var/log/pihole.log
     [ ! -f /etc/pihole/dhcp.leases ] && install -m 644 -o pihole -g pihole /dev/null /etc/pihole/dhcp.leases

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -90,7 +90,7 @@ stop() {
     if is_running; then
       echo "Not stopped; may still be shutting down or shutdown may have failed, killing now"
       pkill -9 -F "${FTL_PID_FILE}"
-      exit 1
+      exit 0
     else
       echo "Stopped"
     fi

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -37,8 +37,8 @@ getFTLPID() {
   fi
 
   # If FTL is not running, or the PID file contains malicious stuff, substitute
-  # negative PID to signal this to the caller
-  echo "${FTL_PID:=-1}"
+  # negative PID to signal this
+  FTL_PID=${FTL_PID:=-1}
 }
 
 # Get the file path of the pihole-FTL.port file

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -29,9 +29,9 @@ getFTLPID() {
 is_running() {
   FTL_PID="$(getFTLPID)"
   if [ "$FTL_PID" -eq "-1" ]; then
-    echo "false"
+    return 1
   else
-    echo "true"
+    echo 0
   fi
 }
 

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -9,22 +9,24 @@
 # Description:       Enable service provided by pihole-FTL daemon
 ### END INIT INFO
 
-# Get PID of main pihole-FTL process
+# Global variables
 FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
 DEFAULT_PID_FILE="/run/pihole-FTL.pid"
 DEFAULT_PORT_FILE="/run/pihole-FTL.port"
 FTL_PID=''
 
+# Get the file path of the pihole-FTL.pid file
 getFTLPIDFile() {
   if [ -s "$FTLCONFFILE" ]; then
     # if PIDFILE is not set in pihole-FTL.conf, use the default path
-    FTL_PID_FILE="$( (grep "^PIDFILE=" $FTLCONFFILE || echo "$DEFAULT_PID_FILE") | cut -d"=" -f2-)"
+    FTL_PID_FILE="$({ grep '^PIDFILE=' "$FTLCONFFILE" || echo "$DEFAULT_PID_FILE"; } | cut -d'=' -f2-)"
   else
     # if there is no pihole-FTL.conf, use the default path
     FTL_PID_FILE="$DEFAULT_PID_FILE"
   fi
 }
 
+# Get the PID of the FTL process based on the content of the pihole-FTL.pid file
 getFTLPID() {
   if [ -s "${FTL_PID_FILE}" ]; then
     # -s: FILE exists and has a size greater than zero
@@ -39,10 +41,11 @@ getFTLPID() {
   echo "${FTL_PID:=-1}"
 }
 
+# Get the file path of the pihole-FTL.port file
 getFTLPortFile () {
   if [ -s "$FTLCONFFILE" ]; then
     # if PORTFILE is not set in pihole-FTL.conf, use the default path
-    FTL_PORT_FILE="$( (grep "^PORTFILE=" $FTLCONFFILE || echo "$DEFAULT_PORT_FILE") | cut -d"=" -f2-)"
+    FTL_PORT_FILE="$({ grep '^PORTFILE=' "$FTLCONFFILE" || echo "$DEFAULT_PID_FILE"; } | cut -d'=' -f2-)"
   else
     # if there is no pihole-FTL.conf, use the default path
     FTL_PORT_FILE="$DEFAULT_PORT_FILE"
@@ -50,10 +53,7 @@ fi
 }
 
 
-
 is_running() {
-  getFTLPIDFile
-  getFTLPortFile
   if [ -z "$FTL_PID" ]; then
     FTL_PID="$(getFTLPID)"
   fi
@@ -135,6 +135,11 @@ status() {
 
 
 ### main logic ###
+
+# Get file paths
+getFTLPIDFile
+getFTLPortFile
+
 case "$1" in
   stop)
         stop

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -17,12 +17,12 @@ FTL_PID=''
 
 # Get the file path of the pihole-FTL.pid file
 getFTLPIDFile() {
-  if [ -s "$FTLCONFFILE" ]; then
+  if [ -s "${FTLCONFFILE}" ]; then
     # if PIDFILE is not set in pihole-FTL.conf, use the default path
-    FTL_PID_FILE="$({ grep '^PIDFILE=' "$FTLCONFFILE" || echo "$DEFAULT_PID_FILE"; } | cut -d'=' -f2-)"
+    FTL_PID_FILE="$({ grep '^PIDFILE=' "${FTLCONFFILE}" || echo "${DEFAULT_PID_FILE}"; } | cut -d'=' -f2-)"
   else
     # if there is no pihole-FTL.conf, use the default path
-    FTL_PID_FILE="$DEFAULT_PID_FILE"
+    FTL_PID_FILE="${DEFAULT_PID_FILE}"
   fi
 }
 
@@ -30,10 +30,10 @@ getFTLPIDFile() {
 getFTLPID() {
   if [ -s "${FTL_PID_FILE}" ]; then
     # -s: FILE exists and has a size greater than zero
-    FTL_PID="$(cat "$FTL_PID_FILE")"
+    FTL_PID="$(cat "${FTL_PID_FILE}")"
     # Exploit prevention: unset the variable if there is malicious content
     # Verify that the value read from the file is numeric
-    expr "$FTL_PID" : "[^[:digit:]]" > /dev/null && unset FTL_PID
+    expr "${FTL_PID}" : "[^[:digit:]]" > /dev/null && unset FTL_PID
   fi
 
   # If FTL is not running, or the PID file contains malicious stuff, substitute
@@ -42,22 +42,22 @@ getFTLPID() {
 }
 
 # Get the file path of the pihole-FTL.port file
-getFTLPortFile () {
-  if [ -s "$FTLCONFFILE" ]; then
+getFTLPortFile() {
+  if [ -s "${FTLCONFFILE}" ]; then
     # if PORTFILE is not set in pihole-FTL.conf, use the default path
-    FTL_PORT_FILE="$({ grep '^PORTFILE=' "$FTLCONFFILE" || echo "$DEFAULT_PID_FILE"; } | cut -d'=' -f2-)"
+    FTL_PORT_FILE="$({ grep '^PORTFILE=' "${FTLCONFFILE}" || echo "${DEFAULT_PORT_FILE}"; } | cut -d'=' -f2-)"
   else
     # if there is no pihole-FTL.conf, use the default path
-    FTL_PORT_FILE="$DEFAULT_PORT_FILE"
+    FTL_PORT_FILE="${DEFAULT_PORT_FILE}"
 fi
 }
 
 
 is_running() {
-  if [ -z "$FTL_PID" ]; then
+  if [ -z "${FTL_PID}" ]; then
     FTL_PID="$(getFTLPID)"
   fi
-  if [ -d "/proc/$FTL_PID" ]; then
+  if [ -d "/proc/${FTL_PID}" ]; then
     return 0
   fi
   return 1
@@ -97,7 +97,7 @@ start() {
 # Stop the service
 stop() {
   if is_running; then
-    kill "$FTL_PID"
+    kill "${FTL_PID}"
     for i in 1 2 3 4 5; do
       if ! is_running; then
         break
@@ -110,7 +110,7 @@ stop() {
 
     if is_running; then
       echo "Not stopped; may still be shutting down or shutdown may have failed, killing now"
-      kill -9 "$FTL_PID"
+      kill -9 "${FTL_PID}"
     else
       echo "Stopped"
     fi

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -13,9 +13,12 @@
 FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
 DEFAULT_PID_FILE="/run/pihole-FTL.pid"
 getFTLPID() {
-  if [ -f "$FTLCONFFILE" ]; then
+  if [ -s "$FTLCONFFILE" ]; then
     # if PIDFILE is not set in pihole-FTL.conf, use the default path
     FTL_PID_FILE="$( (grep "^PIDFILE=" $FTLCONFFILE || echo "$DEFAULT_PID_FILE") | cut -d"=" -f2-)"
+  else
+    # if there is no pihole-FTL.conf, use the default path
+    FTL_PID_FILE="$DEFAULT_PID_FILE"
   fi
 
   if [ -s "${FTL_PID_FILE}" ]; then

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -13,7 +13,8 @@
 FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
 DEFAULT_PID_FILE="/run/pihole-FTL.pid"
 FTL_PID=''
-getFTLPID() {
+
+getFTLPIDPath() {
   if [ -s "$FTLCONFFILE" ]; then
     # if PIDFILE is not set in pihole-FTL.conf, use the default path
     FTL_PID_FILE="$( (grep "^PIDFILE=" $FTLCONFFILE || echo "$DEFAULT_PID_FILE") | cut -d"=" -f2-)"
@@ -21,6 +22,10 @@ getFTLPID() {
     # if there is no pihole-FTL.conf, use the default path
     FTL_PID_FILE="$DEFAULT_PID_FILE"
   fi
+}
+
+getFTLPID() {
+  getFTLPIDPath
 
   if [ -s "${FTL_PID_FILE}" ]; then
     # -s: FILE exists and has a size greater than zero

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -17,7 +17,7 @@ getFTLPID() {
     FTL_PID="$(cat "$FTL_PID_FILE")"
     # Exploit prevention: unset the variable if there is malicious content
     # Verify that the value read from the file is numeric
-    expr "$FTL_PID" : "[^[:digit:]]" > /dev/null && unset pid
+    expr "$FTL_PID" : "[^[:digit:]]" > /dev/null && unset FTL_PID
   fi
 
   # If FTL is not running, or the PID file contains malicious stuff, substitute


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Instead of starting/killing Pi-hole based on it's process name `pihole-FTL`, use the PID file created by the process. 
Fixes https://github.com/pi-hole/pi-hole/issues/4471

~~Please note: the `FTL_PID_FILE` is hardcoded and does not reflect possible user configurations in `pihole-FTL.conf` (https://docs.pi-hole.net/ftldns/configfile/#file_PIDFILE)~~
~~But the service file also did not care before this PR~~

PR now respects custom `PIDFILE` settings in `pihole-FTL.conf`

PR now respects custom `PORTFILE` settings in `pihole-FTL.conf`


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
