### PR TITLE
Exit installer if dpkg lock is held for more then 30 seconds

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -262,7 +262,7 @@ os_check() {
 # This function waits for dpkg to unlock, which signals that the previous apt-get command has finished.
 test_dpkg_lock() {
     i=0
-    printf "  %b   Waiting for package manager to finish\\n" "${INFO}"
+    printf "  %b Waiting for package manager to finish\\n" "${INFO}"
     # fuser is a program to show which processes use the named files, sockets, or filesystems
     # So while the lock is held,
     while fuser /var/lib/dpkg/lock >/dev/null 2>&1

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -262,7 +262,7 @@ os_check() {
 # This function waits for dpkg to unlock, which signals that the previous apt-get command has finished.
 test_dpkg_lock() {
     i=0
-    printf "  %b Waiting for package manager to finish\\n" "${INFO}"
+    printf "  %b Waiting for package manager to finish (up to 30 seconds)\\n" "${INFO}"
     # fuser is a program to show which processes use the named files, sockets, or filesystems
     # So while the lock is held,
     while fuser /var/lib/dpkg/lock >/dev/null 2>&1

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -262,6 +262,7 @@ os_check() {
 # This function waits for dpkg to unlock, which signals that the previous apt-get command has finished.
 test_dpkg_lock() {
     i=0
+    printf "  %b   Waiting for package manager to finish\\n" "${INFO}"
     # fuser is a program to show which processes use the named files, sockets, or filesystems
     # So while the lock is held,
     while fuser /var/lib/dpkg/lock >/dev/null 2>&1
@@ -272,7 +273,8 @@ test_dpkg_lock() {
         ((i=i+1))
         # exit if waiting for more then 30 seconds
         if [[ $i -gt 60 ]]; then
-            echo "*** Error: Could not verify package manager finished and released lock. Attempt to install packages manually and retry.";
+            printf "  %b %bError: Could not verify package manager finished and released lock. %b\\n" "${CROSS}" "${COL_LIGHT_RED}" "${COL_NC}"
+            printf "       Attempt to install packages manually and retry.\\n"
             exit 1;
         fi
     done

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -259,6 +259,27 @@ os_check() {
     fi
 }
 
+# This function waits for dpkg to unlock, which signals that the previous apt-get command has finished.
+test_dpkg_lock() {
+    i=0
+    # fuser is a program to show which processes use the named files, sockets, or filesystems
+    # So while the lock is held,
+    while fuser /var/lib/dpkg/lock >/dev/null 2>&1
+    do
+        # we wait half a second,
+        sleep 0.5
+        # increase the iterator,
+        ((i=i+1))
+        # exit if waiting for more then 30 seconds
+        if [[ $i -gt 60 ]]; then
+            echo "*** Error: Could not verify package manager finished and released lock. Attempt to install packages manually and retry.";
+            exit 1;
+        fi
+    done
+    # and then report success once dpkg is unlocked.
+    return 0
+}
+
 # Compatibility
 package_manager_detect() {
     # First check to see if apt-get is installed.
@@ -301,22 +322,6 @@ package_manager_detect() {
         LIGHTTPD_GROUP="www-data"
         # and config file
         LIGHTTPD_CFG="lighttpd.conf.debian"
-
-        # This function waits for dpkg to unlock, which signals that the previous apt-get command has finished.
-        test_dpkg_lock() {
-            i=0
-            # fuser is a program to show which processes use the named files, sockets, or filesystems
-            # So while the lock is held,
-            while fuser /var/lib/dpkg/lock >/dev/null 2>&1
-            do
-                # we wait half a second,
-                sleep 0.5
-                # increase the iterator,
-                ((i=i+1))
-            done
-            # and then report success once dpkg is unlocked.
-            return 0
-        }
 
     # If apt-get is not found, check for rpm.
     elif is_command rpm ; then


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

Please make sure you [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/contributing/).

---
**What does this PR aim to accomplish?:**
Fixes https://github.com/pi-hole/pi-hole/issues/3977.

When installing via `apt` we use a function to check if `dpkg` is holding a lock on `/va/lib/dpkg/lock`. If so we wait...until the lock is lifted. If there is no lifting we wait until forever.
This PR adds a safety check to stop the whole installer if the lock is not lifted within 30 seconds.The original PR https://github.com/pi-hole/pi-hole/pull/1286 already introduced a counter but never used it. We do use it now.

P.S. The PR additionally moves the function `test_dpkg_lock` out of `package_manager_detect` because it is not used in there. (Only later in `install_dependent_packages`)