### PR TITLE
[utils.sh] Split `addOrEditKeyValuePair` to do `addKey` in a separate function

### DIFF
--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -17,43 +17,49 @@
 #  - New functions must have a test added for them in test/test_any_utils.py
 
 #######################
-# Takes either
-#   - Three arguments: file, key, and value.
-#   - Two arguments: file, and key.
+# Takes Three arguments: file, key, and value.
 #
 # Checks the target file for the existence of the key
 #   - If it exists, it changes the value
 #   - If it does not exist, it adds the value
 #
 # Example usage:
-# addOrEditKeyValuePair "/etc/pihole/setupVars.conf" "BLOCKING_ENABLED" "true"
+# addOrEditKeyValPair "/etc/pihole/setupVars.conf" "BLOCKING_ENABLED" "true"
 #######################
 addOrEditKeyValPair() {
   local file="${1}"
   local key="${2}"
   local value="${3}"
 
-  if [ "${value}" != "" ]; then
-    # value has a value, so it is a key-value pair
-    if grep -q "^${key}=" "${file}"; then
+  if grep -q "^${key}=" "${file}"; then
       # Key already exists in file, modify the value
       sed -i "/^${key}=/c\\${key}=${value}" "${file}"
-    else
-      # Key does not already exist, add it and it's value
-      echo "${key}=${value}" >> "${file}"
-    fi
   else
-    # value has no value, so it is just a key. Add it if it does not already exist
-    if ! grep -q "^${key}" "${file}"; then
-      # Key does not exist, add it.
-      echo "${key}" >> "${file}"
-    fi
+    # Key does not already exist, add it and it's value
+    echo "${key}=${value}" >> "${file}"
   fi
 }
 
 #######################
-# Takes two arguments file, and key.
-# Deletes a key from target file
+# Takes two arguments: file, and key.
+# Adds a key to target file
+#
+# Example usage:
+# addKey "/etc/dnsmasq.d/01-pihole.conf" "log-queries"
+#######################
+addKey(){
+  local file="${1}"
+  local key="${2}"
+
+  if ! grep -q "^${key}" "${file}"; then
+      # Key does not exist, add it.
+      echo "${key}" >> "${file}"
+  fi
+}
+
+#######################
+# Takes two arguments: file, and key.
+# Deletes a key or key/value pair from target file
 #
 # Example usage:
 # removeKey "/etc/pihole/setupVars.conf" "PIHOLE_DNS_1"

--- a/pihole
+++ b/pihole
@@ -260,7 +260,7 @@ Options:
     exit 0
   elif [[ "${1}" == "off" ]]; then
     # Disable logging
-    addOrEditKeyValPair /etc/dnsmasq.d/01-pihole.conf "log-queries"
+    addKey /etc/dnsmasq.d/01-pihole.conf "log-queries"
     addOrEditKeyValPair "${setupVars}" "QUERY_LOGGING" "false"
     if [[ "${2}" != "noflush" ]]; then
       # Flush logs

--- a/pihole
+++ b/pihole
@@ -260,7 +260,7 @@ Options:
     exit 0
   elif [[ "${1}" == "off" ]]; then
     # Disable logging
-    addKey /etc/dnsmasq.d/01-pihole.conf "log-queries"
+    removeKey /etc/dnsmasq.d/01-pihole.conf "log-queries"
     addOrEditKeyValPair "${setupVars}" "QUERY_LOGGING" "false"
     if [[ "${2}" != "noflush" ]]; then
       # Flush logs
@@ -270,7 +270,7 @@ Options:
     local str="Logging has been disabled!"
   elif [[ "${1}" == "on" ]]; then
     # Enable logging
-    removeKey /etc/dnsmasq.d/01-pihole.conf "log-queries"
+    addKey /etc/dnsmasq.d/01-pihole.conf "log-queries"    
     addOrEditKeyValPair "${setupVars}" "QUERY_LOGGING" "true"
     echo -e "  ${INFO} Enabling logging..."
     local str="Logging has been enabled!"

--- a/test/test_any_utils.py
+++ b/test/test_any_utils.py
@@ -6,8 +6,8 @@ def test_key_val_replacement_works(host):
     addOrEditKeyValPair "./testoutput" "KEY_TWO" "value2"
     addOrEditKeyValPair "./testoutput" "KEY_ONE" "value3"
     addOrEditKeyValPair "./testoutput" "KEY_FOUR" "value4"
-    addOrEditKeyValPair "./testoutput" "KEY_FIVE_NO_VALUE"
-    addOrEditKeyValPair "./testoutput" "KEY_FIVE_NO_VALUE"
+    addKey "./testoutput" "KEY_FIVE_NO_VALUE"
+    addKey "./testoutput" "KEY_FIVE_NO_VALUE"
     ''')
     output = host.run('''
     cat ./testoutput


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Having a function with a variable number of arguments in this case was too complicated for something that is only really used once