### PR TITLE
Changed ldd binary check for better compatibility

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2216,7 +2216,7 @@ get_binary_name() {
         local rev
         rev=$(uname -m | sed "s/[^0-9]//g;")
         local lib
-        lib=$(ldd $(which sh) | grep -E '^\s*/lib' | awk '{ print $1 }')
+        lib=$(ldd "$(which sh)" | grep -E '^\s*/lib' | awk '{ print $1 }')
         if [[ "${lib}" == "/lib/ld-linux-aarch64.so.1" ]]; then
             printf "%b  %b Detected AArch64 (64 Bit ARM) processor\\n" "${OVER}" "${TICK}"
             # set the binary to be used

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2216,7 +2216,7 @@ get_binary_name() {
         local rev
         rev=$(uname -m | sed "s/[^0-9]//g;")
         local lib
-        lib=$(ldd /bin/bash | grep -E '^\s*/lib' | awk '{ print $1 }')
+        lib=$(ldd $(which sh) | grep -E '^\s*/lib' | awk '{ print $1 }')
         if [[ "${lib}" == "/lib/ld-linux-aarch64.so.1" ]]; then
             printf "%b  %b Detected AArch64 (64 Bit ARM) processor\\n" "${OVER}" "${TICK}"
             # set the binary to be used

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2216,7 +2216,7 @@ get_binary_name() {
         local rev
         rev=$(uname -m | sed "s/[^0-9]//g;")
         local lib
-        lib=$(ldd /bin/ls | grep -E '^\s*/lib' | awk '{ print $1 }')
+        lib=$(ldd /bin/bash | grep -E '^\s*/lib' | awk '{ print $1 }')
         if [[ "${lib}" == "/lib/ld-linux-aarch64.so.1" ]]; then
             printf "%b  %b Detected AArch64 (64 Bit ARM) processor\\n" "${OVER}" "${TICK}"
             # set the binary to be used

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -675,17 +675,10 @@ def test_FTL_detect_aarch64_no_errors(host):
     '''
     # mock uname to return aarch64 platform
     mock_command('uname', {'-m': ('aarch64', '0')}, host)
+    # mock `which sh` to return `/bin/sh`
+    mock_command('which', {'sh': ('/bin/sh', '0')}, host)
     # mock ldd to respond with aarch64 shared library
-    mock_command(
-        'ldd',
-        {
-            '/bin/bash': (
-                '/lib/ld-linux-aarch64.so.1',
-                '0'
-            )
-        },
-        host
-    )
+    mock_command('ldd', {'/bin/sh': ('/lib/ld-linux-aarch64.so.1', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -708,8 +701,10 @@ def test_FTL_detect_armv4t_no_errors(host):
     '''
     # mock uname to return armv4t platform
     mock_command('uname', {'-m': ('armv4t', '0')}, host)
-    # mock ldd to respond with ld-linux shared library
-    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux.so.3', '0')}, host)
+    # mock `which sh` to return `/bin/sh`
+    mock_command('which', {'sh': ('/bin/sh', '0')}, host)
+    # mock ldd to respond with armv4t shared library
+    mock_command('ldd', {'/bin/sh': ('/lib/ld-linux.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -732,8 +727,10 @@ def test_FTL_detect_armv5te_no_errors(host):
     '''
     # mock uname to return armv5te platform
     mock_command('uname', {'-m': ('armv5te', '0')}, host)
+    # mock `which sh` to return `/bin/sh`
+    mock_command('which', {'sh': ('/bin/sh', '0')}, host)
     # mock ldd to respond with ld-linux shared library
-    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux.so.3', '0')}, host)
+    mock_command('ldd', {'/bin/sh': ('/lib/ld-linux.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -757,7 +754,9 @@ def test_FTL_detect_armv6l_no_errors(host):
     # mock uname to return armv6l platform
     mock_command('uname', {'-m': ('armv6l', '0')}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux-armhf.so.3', '0')}, host)
+    # mock `which sh` to return `/bin/sh`
+    mock_command('which', {'sh': ('/bin/sh', '0')}, host)
+    mock_command('ldd', {'/bin/sh': ('/lib/ld-linux-armhf.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -782,7 +781,9 @@ def test_FTL_detect_armv7l_no_errors(host):
     # mock uname to return armv7l platform
     mock_command('uname', {'-m': ('armv7l', '0')}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux-armhf.so.3', '0')}, host)
+    # mock `which sh` to return `/bin/sh`
+    mock_command('which', {'sh': ('/bin/sh', '0')}, host)
+    mock_command('ldd', {'/bin/sh': ('/lib/ld-linux-armhf.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -806,8 +807,10 @@ def test_FTL_detect_armv8a_no_errors(host):
     '''
     # mock uname to return armv8a platform
     mock_command('uname', {'-m': ('armv8a', '0')}, host)
+    # mock `which sh` to return `/bin/sh`
+    mock_command('which', {'sh': ('/bin/sh', '0')}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux-armhf.so.3', '0')}, host)
+    mock_command('ldd', {'/bin/sh': ('/lib/ld-linux-armhf.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -828,6 +831,8 @@ def test_FTL_detect_x86_64_no_errors(host):
     '''
     confirms only x86_64 package is downloaded for FTL engine
     '''
+    # mock `which sh` to return `/bin/sh`
+    mock_command('which', {'sh': ('/bin/sh', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -848,6 +853,8 @@ def test_FTL_detect_unknown_no_errors(host):
     ''' confirms only generic package is downloaded for FTL engine '''
     # mock uname to return generic platform
     mock_command('uname', {'-m': ('mips', '0')}, host)
+    # mock `which sh` to return `/bin/sh`
+    mock_command('which', {'sh': ('/bin/sh', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -679,7 +679,7 @@ def test_FTL_detect_aarch64_no_errors(host):
     mock_command(
         'ldd',
         {
-            '/bin/ls': (
+            '/bin/bash': (
                 '/lib/ld-linux-aarch64.so.1',
                 '0'
             )
@@ -709,7 +709,7 @@ def test_FTL_detect_armv4t_no_errors(host):
     # mock uname to return armv4t platform
     mock_command('uname', {'-m': ('armv4t', '0')}, host)
     # mock ldd to respond with ld-linux shared library
-    mock_command('ldd', {'/bin/ls': ('/lib/ld-linux.so.3', '0')}, host)
+    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -733,7 +733,7 @@ def test_FTL_detect_armv5te_no_errors(host):
     # mock uname to return armv5te platform
     mock_command('uname', {'-m': ('armv5te', '0')}, host)
     # mock ldd to respond with ld-linux shared library
-    mock_command('ldd', {'/bin/ls': ('/lib/ld-linux.so.3', '0')}, host)
+    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -757,7 +757,7 @@ def test_FTL_detect_armv6l_no_errors(host):
     # mock uname to return armv6l platform
     mock_command('uname', {'-m': ('armv6l', '0')}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    mock_command('ldd', {'/bin/ls': ('/lib/ld-linux-armhf.so.3', '0')}, host)
+    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux-armhf.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -782,7 +782,7 @@ def test_FTL_detect_armv7l_no_errors(host):
     # mock uname to return armv7l platform
     mock_command('uname', {'-m': ('armv7l', '0')}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    mock_command('ldd', {'/bin/ls': ('/lib/ld-linux-armhf.so.3', '0')}, host)
+    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux-armhf.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user
@@ -807,7 +807,7 @@ def test_FTL_detect_armv8a_no_errors(host):
     # mock uname to return armv8a platform
     mock_command('uname', {'-m': ('armv8a', '0')}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    mock_command('ldd', {'/bin/ls': ('/lib/ld-linux-armhf.so.3', '0')}, host)
+    mock_command('ldd', {'/bin/bash': ('/lib/ld-linux-armhf.so.3', '0')}, host)
     detectPlatform = host.run('''
     source /opt/pihole/basic-install.sh
     create_pihole_user


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**
https://github.com/pi-hole/pi-hole/issues/4697

The basic-install.sh script checks which architecture it is running on so it downloads the correct pihole-FTL binary file. It uses a simple command, `ldd /bin/ls` to determine which libraries the underlying system is using. The problem comes in when using the aarch64 container version of CentOS 8 (also RHEL 8, AlmaLinux 8, and all RHEL clones). These container images do not have 'ls' or some of the other core utilities. They use '/usr/bin/coreutils' with a argument to invoke 'ls'.


**How does this PR accomplish the above?:**
This change is simple, instead of using '/bin/ls' as the binary check - we use '/bin/bash instead'. This should not break any compatibility and after all the script is being invoked by bash.


**What documentation changes (if any) are needed to support this PR?:**
No documentation changes needed.


---
* You must follow the template instructions. Failure to do so will result in your pull request being closed.
* Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
