### PR TITLE
Do not hardcode webroot dir for teleporter

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -650,7 +650,8 @@ Teleporter() {
         host="${host//./_}"
         filename="pi-hole-${host:-noname}-teleporter_${datetimestamp}.tar.gz"
     fi
-    php /var/www/html/admin/scripts/pi-hole/php/teleporter.php > "${filename}"
+    # webroot is sourced from basic-install above
+    php "${webroot}/admin/scripts/pi-hole/php/teleporter.php" > "${filename}"
 }
 
 checkDomain()


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

Do not hard-code the web root dir when calling the teleporter script.
Fixes https://github.com/pi-hole/pi-hole/issues/3042


- **How does this PR accomplish the above?:**

Using "${webroot}" we already source from `basic-install.sh` within the `webpage.sh`


- **What documentation changes (if any) are needed to support this PR?:**

None.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
[x] I have read the above and my PR is ready for review. _Check this box to confirm_
