### PR TITLE
Exit installer if no valid PHP version is found

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -301,8 +301,8 @@ package_manager_detect() {
         local phpVer="php"
         if is_command php ; then
             printf "  %b Existing PHP installation detected : PHP version %s\\n" "${INFO}" "$(php <<< "<?php echo PHP_VERSION ?>")"
-            printf -v phpInsMajor "$(php <<< "<?php echo PHP_MAJOR_VERSION ?>")"
-            printf -v phpInsMinor "$(php <<< "<?php echo PHP_MINOR_VERSION ?>")"
+            printf -v phpInsMajor "%s" "$(php <<< "<?php echo PHP_MAJOR_VERSION ?>")"
+            printf -v phpInsMinor "%s" "$(php <<< "<?php echo PHP_MINOR_VERSION ?>")"
             if [[ "$phpInsMajor" =~ [^[:digit:]] || "$phpInsMinor" =~ [^[:digit:]]  ]]; then
                  printf "  %b No valid PHP version detected\\n" "${CROSS}"
                 # so exit the installer

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -298,7 +298,7 @@ package_manager_detect() {
         # Update package cache
         update_package_cache || exit 1
         # Check for and determine version number (major and minor) of current php install
-        local phpVer
+        local phpVer="php"
         if is_command php ; then
             phpVer="$(php -v 2> /dev/null | head -n1 | cut -d '-' -f1 | cut -d ' ' -f2)"
             # Check if the first character of the string is numeric

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -298,17 +298,21 @@ package_manager_detect() {
         # Update package cache
         update_package_cache || exit 1
         # Check for and determine version number (major and minor) of current php install
-        local phpVer="php"
+        local phpVer
         if is_command php ; then
-            printf "  %b Existing PHP installation detected : PHP version %s\\n" "${INFO}" "$(php <<< "<?php echo PHP_VERSION ?>")"
-            printf -v phpInsMajor "%s" "$(php <<< "<?php echo PHP_MAJOR_VERSION ?>")"
-            printf -v phpInsMinor "%s" "$(php <<< "<?php echo PHP_MINOR_VERSION ?>")"
-            if [[ "$phpInsMajor" =~ [^[:digit:]] || "$phpInsMinor" =~ [^[:digit:]]  ]]; then
-                 printf "  %b No valid PHP version detected\\n" "${CROSS}"
-                # so exit the installer
-                exit
+            phpVer="$(php -v 2> /dev/null | head -n1 | cut -d '-' -f1 | cut -d ' ' -f2)"
+            # Check if the first character of the string is numeric
+            if [[ ${phpVer:0:1} =~ [1-9] ]]; then
+                printf "  %b Existing PHP installation detected : PHP version %s\\n" "${INFO}" "${phpVer}"
+                printf -v phpInsMajor "%d" "$(php <<< "<?php echo PHP_MAJOR_VERSION ?>")"
+                printf -v phpInsMinor "%d" "$(php <<< "<?php echo PHP_MINOR_VERSION ?>")"
+                phpVer="php$phpInsMajor.$phpInsMinor"
+            else
+                printf "  %b No valid PHP installation detected!\\n" "${CROSS}"
+                printf "  %b PHP version : %s\\n" "${INFO}" "${phpVer}"
+                printf "  %b Aborting installation.\\n" "${CROSS}"
+                exit 1
             fi
-            phpVer="php$phpInsMajor.$phpInsMinor"
         fi
         # Packages required to perfom the os_check (stored as an array)
         OS_CHECK_DEPS=(grep dnsutils)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -301,8 +301,13 @@ package_manager_detect() {
         local phpVer="php"
         if is_command php ; then
             printf "  %b Existing PHP installation detected : PHP version %s\\n" "${INFO}" "$(php <<< "<?php echo PHP_VERSION ?>")"
-            printf -v phpInsMajor "%d" "$(php <<< "<?php echo PHP_MAJOR_VERSION ?>")"
-            printf -v phpInsMinor "%d" "$(php <<< "<?php echo PHP_MINOR_VERSION ?>")"
+            printf -v phpInsMajor "$(php <<< "<?php echo PHP_MAJOR_VERSION ?>")"
+            printf -v phpInsMinor "$(php <<< "<?php echo PHP_MINOR_VERSION ?>")"
+            if [[ "$phpInsMajor" =~ [^[:digit:]] || "$phpInsMinor" =~ [^[:digit:]]  ]]; then
+                 printf "  %b No valid PHP version detected\\n" "${CROSS}"
+                # so exit the installer
+                exit
+            fi
             phpVer="php$phpInsMajor.$phpInsMinor"
         fi
         # Packages required to perfom the os_check (stored as an array)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -300,7 +300,7 @@ package_manager_detect() {
         # Check for and determine version number (major and minor) of current php install
         local phpVer="php"
         if is_command php ; then
-            phpVer="$(php -v 2> /dev/null | head -n1 | cut -d '-' -f1 | cut -d ' ' -f2)"
+            phpVer="$(php <<< "<?php echo PHP_VERSION ?>")"
             # Check if the first character of the string is numeric
             if [[ ${phpVer:0:1} =~ [1-9] ]]; then
                 printf "  %b Existing PHP installation detected : PHP version %s\\n" "${INFO}" "${phpVer}"


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Exit the installer if the detected PHP version is not a number. This was reported here: https://github.com/pi-hole/pi-hole/issues/4751


- **How does this PR accomplish the above?:**

Check if `$phpInsMajor` and `$phpInsMinor` are `[:digit:]`


- **What documentation changes (if any) are needed to support this PR?:**

None.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
[x] I have read the above and my PR is ready for review. _Check this box to confirm_
