### PR TITLE
Require sudo for pihole -t

### DIFF
--- a/pihole
+++ b/pihole
@@ -503,7 +503,7 @@ case "${1}" in
   "-c" | "chronometer"          ) chronometerFunc "$@";;
   "-q" | "query"                ) queryFunc "$@";;
   "status"                      ) statusFunc "$2";;
-  "-t" | "tail"                 ) tailFunc "$2";;
+
   "tricorder"                   ) tricorderFunc;;
 
   # we need to add all arguments that require sudo power to not trigger the * argument
@@ -527,6 +527,7 @@ case "${1}" in
   "checkout"                    ) ;;
   "updatechecker"               ) ;;
   "arpflush"                    ) ;;
+  "-t" | "tail"                 ) ;;
   *                             ) helpFunc;;
 esac
 
@@ -563,4 +564,5 @@ case "${1}" in
   "checkout"                    ) piholeCheckoutFunc "$@";;
   "updatechecker"               ) updateCheckFunc "$@";;
   "arpflush"                    ) arpFunc "$@";;
+  "-t" | "tail"                 ) tailFunc "$2";;
 esac


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Add on to https://github.com/pi-hole/pi-hole/pull/4760.

PR https://github.com/pi-hole/pi-hole/pull/4663 removed the need for elevated privs for some `pihole COMMAND`. Now, PR https://github.com/pi-hole/pi-hole/pull/4760 removed the read permissions for `others` from `/var/log/pihole/pihole.log`. `pihole -t` (tail function) now fails for users other than `pihole` (or within group `pihole`), because they can't read that file.

This PR adds the `sudo` call back to `pihole -t`

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
