### PR TITLE
store & use etags

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -640,33 +640,31 @@ gravity_DownloadBlocklistFromUrl() {
     echo -ne "  ${INFO} ${str} Pending..."
     cmd_ext="--resolve $domain:$port:$ip $cmd_ext"
   fi
- 
 
-  if [ -f "${piholeDir}/list.${id}.${domain}.etag" ]
+  if [ -f "${piholeDir}/list.${id}.${domain}.header" ]
 	then
-	  currentetag=$(<"${piholeDir}/list.${id}.${domain}.etag")
+	  currentetag=$(sed -n 's/^etag: //Ip' < "${piholeDir}/list.${id}.${domain}.header")
 	else
 	  currentetag=$""
   fi
 
   #echo -e "\n current Etag: " "$currentetag"
 
-
   # shellcheck disable=SC2086
-if [ -z "$currentetag" ]
+  if [ -z "$currentetag" ]
 	then
-		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${patternBuffer}" 2> /dev/null)
+		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${patternBuffer}" -D "${piholeDir}/list.${id}.${domain}.header" 2> /dev/null)
 	else
-		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} --header "If-None-Match: ${currentetag}" -w "%{http_code}" -A "${agent}" "${url}" -o "${patternBuffer}" 2> /dev/null)
- fi
+		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} --header "If-None-Match: ${currentetag}" -w "%{http_code}" -A "${agent}" "${url}" -o "${patternBuffer}" -D "${piholeDir}/list.${id}.${domain}.header" 2>> /dev/null)
+  fi
 
 # shellcheck disable=SC2086
   curl -sI "${url}" -L ${compression} ${cmd_ext} ${heisenbergCompensator} -A "${agent}" | sed -n 's/^etag: //Ip' > "${piholeDir}/list.${id}.${domain}.etag"
 
-# if [ "${httpCode}" != 304 ]
-# then
+#  if [ "${httpCode}" != 304 ]
+#	then
 #	echo -e "\n statuscode: " "$httpCode"
-#	newetag=$(<"${piholeDir}/list.${id}.${domain}.etag")
+#	newetag=$(cat "${piholeDir}/list.${id}.${domain}.header"|sed -n 's/^etag: //Ip')
 #	echo -e "\n new Etag:     " "$newetag"
 #  fi
 


### PR DESCRIPTION
Signed-off-by: Yoshimo <yoshimo@users.noreply.github.com>

- **What does this PR aim to accomplish?:**

It tries to save bandwith by avoiding unneccessary downloads of files that haven't changed on the remote location since we last downloaded them.


- **How does this PR accomplish the above?:**
If the remote server supplies an etag header we store it for every list locally.
When we refresh a list we check if there is an etag stored for this entry and if we have an etag we add a "if-none-match: <etag>" header to the request.
The remote server compares our etag with its local database and if the conclusion is, that there hasn't been any change on the file, it will send us back a 304 not-modified status code.
We then use our local copy, avoid an unneccessary re-download and move on to the next entry on our list.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
