### PR TITLE
Add stale-issue-reason: not planned

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,3 +23,4 @@ jobs:
         exempt-issue-labels: 'Internal, Fixed in next release, Bug: Confirmed, Documentation Needed'
         exempt-all-issue-assignees: true
         operations-per-run: 300
+        stale-issue-reason: 'not_planned'


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Github recently added the `issue-closed-reason` feature (https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/), which can be `complete` and `not-planned`. The latter is meant, among others, for `stale`. 
This PR https://github.com/actions/stale/pull/764 added the option `close-issue-stale` for the GH action `stale` to allow setting the `issue-closed-reason`.

This PR adds `close-issue-stale: not_planned` to our action.

**Target: master branch**

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
