### PR TITLE
Remove unnecessary file types from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,27 +12,3 @@ indent_size = tab
 tab_width = 4
 charset = utf-8
 trim_trailing_whitespace = true
-
-# Matches multiple files with brace expansion notation
-# Set default charset
-[*.{js,py}]
-charset = utf-8
-
-# 4 space indentation
-[*.py]
-indent_style = space
-indent_size = 4
-
-# Tab indentation (no size specified)
-[Makefile]
-indent_style = tab
-
-# Indentation override for all JS under lib directory
-[scripts/**.js]
-indent_style = space
-indent_size = 2
-
-# Matches the exact files either package.json or .travis.yml
-[{package.json,.travis.yml}]
-indent_style = space
-indent_size = 2


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Removes unnecessary file types from `.editorconfig`. It's confusing to see definitions for file types that are not part of this repo.
`.editorconfig` was added by https://github.com/pi-hole/pi-hole/pull/1349 and it states

> I just grabbed the default ruleset and only modified the general clauses. 

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
