### PR TITLE
Add mkdown and yaml linters to stickler

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,9 @@
+---
 linters:
   shellcheck:
     shell: bash
   phpcs:
   flake8:
     max-line-length: 120
+  yamllint:
+  remarklint:


### PR DESCRIPTION
This adds stickler linting for markdown and yaml files.

Uses https://pypi.org/project/yamllint/ and https://github.com/remarkjs/remark-lint internally