### PR TITLE
Fix for epel mirror timeouts

### DIFF
--- a/test/_centos_7.Dockerfile
+++ b/test/_centos_7.Dockerfile
@@ -9,6 +9,7 @@ ADD . $GITDIR
 RUN cp $GITDIR/advanced/Scripts/*.sh $GITDIR/gravity.sh $GITDIR/pihole $GITDIR/automated\ install/*.sh $SCRIPTDIR/
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$SCRIPTDIR
 
+ADD test/centos7.epel.override /etc/yum/pluginconf.d/fastestmirror.conf
 RUN true && \
     chmod +x $SCRIPTDIR/*
 

--- a/test/centos7.epel.override
+++ b/test/centos7.epel.override
@@ -1,0 +1,7 @@
+[main]
+verbose = 0
+socket_timeout = 3
+enabled = 1
+hostfilepath = /var/cache/yum/timedhosts.txt
+maxhostfileage = 1
+exclude=.edu


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

EPEL mirror is timing out. Override to use fastestmirror and remove .edu from the options.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
