### PR TITLE
Add param to relocate blocklist files

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -39,6 +39,9 @@ GRAVITYDB="${gravityDBfile_default}"
 gravityDBschema="${piholeGitDir}/advanced/Templates/gravity.db.sql"
 gravityDBcopy="${piholeGitDir}/advanced/Templates/gravity_copy.sql"
 
+# BLOCKLIST_STORAGE_DIR may be overwritten by source pihole-FTL.conf below
+BLOCKLIST_STORAGE_DIR="${piholeDir}"
+
 domainsExtension="domains"
 
 # Source setupVars from install script
@@ -436,7 +439,7 @@ gravity_DownloadBlocklists() {
     id="${sourceIDs[$i]}"
 
     # Save the file as list.#.domain
-    saveLocation="${piholeDir}/list.${id}.${domain}.${domainsExtension}"
+    saveLocation="${BLOCKLIST_STORAGE_DIR}/list.${id}.${domain}.${domainsExtension}"
     activeDomains[$i]="${saveLocation}"
 
     # Default user-agent (for Cloudflare's Browser Integrity Check: https://support.cloudflare.com/hc/en-us/articles/200170086-What-does-the-Browser-Integrity-Check-do-)


### PR DESCRIPTION
Signed-off-by: Ben Batschelet <bartleby84@gmail.com>

## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

—
- **What does this PR aim to accomplish?:**

Allow users to relocate the downloaded blocklist. This should mean the contents of `$piholeDir` will not change frequently and thus let `/etc` remain basically static.

- **How does this PR accomplish the above?:**

Added `BLOCKLIST_STORAGE_DIR` with a default value of `$piholeDir`.

- **What documentation changes (if any) are needed to support this PR?:**

Documentation for the variable would have to be added to [ftldns/configfile.md](https://github.com/pi-hole/docs/blob/master/docs/ftldns/configfile.md). I’m happy to create a pull request there as well if y’all’d like.


—
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

—
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
