### PR TITLE
Do not restrict RegEx added from CLI by length

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -100,21 +100,29 @@ Options:
 ValidateDomain() {
     # Convert to lowercase
     domain="${1,,}"
+    local str validDomain
 
     # Check validity of domain (don't check for regex entries)
-    if [[ "${#domain}" -le 253 ]]; then
-        if [[ ( "${typeId}" == "${regex_blacklist}" || "${typeId}" == "${regex_whitelist}" ) && "${wildcard}" == false ]]; then
-            validDomain="${domain}"
-        else
+    if [[ ( "${typeId}" == "${regex_blacklist}" || "${typeId}" == "${regex_whitelist}" ) && "${wildcard}" == false ]]; then
+        validDomain="${domain}"
+    else
+        # Check max length
+        if [[ "${#domain}" -le 253 ]]; then
             validDomain=$(grep -P "^((-|_)*[a-z\\d]((-|_)*[a-z\\d])*(-|_)*)(\\.(-|_)*([a-z\\d]((-|_)*[a-z\\d])*))*$" <<< "${domain}") # Valid chars check
             validDomain=$(grep -P "^[^\\.]{1,63}(\\.[^\\.]{1,63})*$" <<< "${validDomain}") # Length of each label
+            # set error string
+            str="is not a valid argument or domain name!"
+        else
+            validDomain=
+            str="is too long!"
+
         fi
     fi
 
     if [[ -n "${validDomain}" ]]; then
         domList=("${domList[@]}" "${validDomain}")
     else
-        echo -e "  ${CROSS} ${domain} is not a valid argument or domain name!"
+        echo -e "  ${CROSS} ${domain} ${str}"
     fi
 
     domaincount=$((domaincount+1))


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/pi-hole/issues/4785

When users add RegEx via CLI there is currently a length restriction of 253 characters, which aims at the max length of regular domains. This PR removes the restriction for RegEx and wildcard domains.

Note: we also do not apply any length restrictions to RegEx which are added from the web interface

- **How does this PR accomplish the above?:**

Simply changes the order of checks to check for RegEx frist

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
