### PR TITLE
Clean consecutive mkdir

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2797,8 +2797,7 @@ main() {
     stop_service pihole-FTL &> /dev/null
 
     if [ ! -d /var/log/pihole/ ]; then
-        mkdir /var/log/pihole/
-        chmod 0775 /var/log/pihole/
+        mkdir -m 0755 /var/log/pihole/
     fi
 
     # Special handling for pihole-FTL.log -> pihole/FTL.log
@@ -2814,7 +2813,6 @@ main() {
 
     # Remaining log files
     if [ -f /var/log/pihole.log ] && [ ! -L /var/log/pihole.log ]; then
-        mkdir -p /var/log/pihole/
         mv /var/log/pihole*.* /var/log/pihole/ 2>/dev/null
     fi
 


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/pi-hole/issues/4803.

Yesterday two PRs (https://github.com/pi-hole/pi-hole/pull/4792 and https://github.com/pi-hole/pi-hole/pull/4794) addressed the missing new log dir `/var/log/pihole`. 
The introduced code can be cleaned a bit.
On L2800 it combines creation and permission setting. L2817 is not necessary because the check above already guarantees that the log dir exists.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
