### PR TITLE
Print all SELINUX output in lowercase

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2050,22 +2050,22 @@ checkSelinux() {
         DEFAULT_SELINUX=$(awk -F= '/^SELINUX=/ {print $2}' /etc/selinux/config)
         case "${DEFAULT_SELINUX,,}" in
             enforcing)
-                printf "  %b %bDefault SELinux: %s%b\\n" "${CROSS}" "${COL_RED}" "${DEFAULT_SELINUX}" "${COL_NC}"
+                printf "  %b %bDefault SELinux: %s%b\\n" "${CROSS}" "${COL_RED}" "${DEFAULT_SELINUX,,}" "${COL_NC}"
                 SELINUX_ENFORCING=1
                 ;;
             *)  # 'permissive' and 'disabled'
-                printf "  %b %bDefault SELinux: %s%b\\n" "${TICK}" "${COL_GREEN}" "${DEFAULT_SELINUX}" "${COL_NC}"
+                printf "  %b %bDefault SELinux: %s%b\\n" "${TICK}" "${COL_GREEN}" "${DEFAULT_SELINUX,,}" "${COL_NC}"
                 ;;
         esac
         # Check the current state of SELinux
         CURRENT_SELINUX=$(getenforce)
         case "${CURRENT_SELINUX,,}" in
             enforcing)
-                printf "  %b %bCurrent SELinux: %s%b\\n" "${CROSS}" "${COL_RED}" "${CURRENT_SELINUX}" "${COL_NC}"
+                printf "  %b %bCurrent SELinux: %s%b\\n" "${CROSS}" "${COL_RED}" "${CURRENT_SELINUX,,}" "${COL_NC}"
                 SELINUX_ENFORCING=1
                 ;;
             *)  # 'permissive' and 'disabled'
-                printf "  %b %bCurrent SELinux: %s%b\\n" "${TICK}" "${COL_GREEN}" "${CURRENT_SELINUX}" "${COL_NC}"
+                printf "  %b %bCurrent SELinux: %s%b\\n" "${TICK}" "${COL_GREEN}" "${CURRENT_SELINUX,,}" "${COL_NC}"
                 ;;
         esac
     else

--- a/test/test_centos_fedora_common_support.py
+++ b/test/test_centos_fedora_common_support.py
@@ -30,7 +30,7 @@ def test_selinux_enforcing_exit(host):
     source /opt/pihole/basic-install.sh
     checkSelinux
     ''')
-    expected_stdout = cross_box + ' Current SELinux: Enforcing'
+    expected_stdout = cross_box + ' Current SELinux: enforcing'
     assert expected_stdout in check_selinux.stdout
     expected_stdout = 'SELinux Enforcing detected, exiting installer'
     assert expected_stdout in check_selinux.stdout
@@ -46,7 +46,7 @@ def test_selinux_permissive(host):
     source /opt/pihole/basic-install.sh
     checkSelinux
     ''')
-    expected_stdout = tick_box + ' Current SELinux: Permissive'
+    expected_stdout = tick_box + ' Current SELinux: permissive'
     assert expected_stdout in check_selinux.stdout
     assert check_selinux.rc == 0
 
@@ -60,6 +60,6 @@ def test_selinux_disabled(host):
     source /opt/pihole/basic-install.sh
     checkSelinux
     ''')
-    expected_stdout = tick_box + ' Current SELinux: Disabled'
+    expected_stdout = tick_box + ' Current SELinux: disabled'
     assert expected_stdout in check_selinux.stdout
     assert check_selinux.rc == 0


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Prints the output for current and default SELINUX state in lowercase.

Prevents output like this:

![Bildschirmfoto zu 2022-07-10 12-55-40](https://user-images.githubusercontent.com/26622301/178142439-3cef7e75-3e8e-4424-9f0d-674d2b6bf2a1.png)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
