### PR TITLE
Add spinner for long processes running during debug log

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1230,7 +1230,7 @@ check_dhcp_servers() {
     OLD_IFS="$IFS"
     IFS=$'\n'
     local entries=()
-    mapfile -t entries < <(pihole-FTL dhcp-discover)
+    mapfile -t entries < <(pihole-FTL dhcp-discover & spinner)
 
     for line in "${entries[@]}"; do
         log_write "   ${line}"
@@ -1309,7 +1309,7 @@ database_integrity_check(){
     local database="${1}"
 
     log_write "${INFO} Checking integrity of ${database} ... (this can take several minutes)"
-    result="$(pihole-FTL "${database}" "PRAGMA integrity_check" 2>&1)"
+    result="$(pihole-FTL "${database}" "PRAGMA integrity_check" 2>&1 & spinner)"
     if [[ ${result} = "ok" ]]; then
       log_write "${TICK} Integrity of ${database} intact"
 
@@ -1345,6 +1345,34 @@ check_database_integrity() {
     database_integrity_check "${PIHOLE_FTL_DB_FILE}"
 }
 
+# Show a text spinner during a long process run
+#
+spinner(){
+    local PID=$!  # PID of the most recent background process
+    local spin="/-\|"
+    local start=0
+    local elapsed=0
+    local i=1
+
+    start=$(date +%s) # Start the counter
+
+    tput civis > /dev/tty # Hide the cursor
+    trap 'tput cnorm > /dev/tty' EXIT # ensures cursor is visible again, in case of premature exit
+
+    while [ -d /proc/$PID ]; do
+        elapsed=$(( $(date +%s) - start ))
+        # print the spinner only on screen (tty) - use hours only if needed
+        if [ "$elapsed" -lt 3600 ]; then
+            printf "\r${spin:i++%${#spin}:1} %02d:%02d" $((elapsed/60)) $((elapsed%60)) >"$(tty)"
+        else
+            printf "\r${spin:i++%${#spin}:1} %02d:%02d:%02d" $((elapsed/3600)) $(((elapsed/60)%60)) $((elapsed%60)) >"$(tty)"
+        fi
+        sleep 0.25
+    done
+
+    printf "\r" >"$(tty)" # Return to the begin of the line after completion (the spinner will be overwritten)
+    tput cnorm > /dev/tty # Restore cursor visibility
+}
 
 obfuscated_pihole_log() {
   local pihole_log=("$@")

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1316,7 +1316,7 @@ database_integrity_check(){
 
       log_write "${INFO} Checking foreign key constraints of ${database} ... (this can take several minutes)"
       unset result
-      result="$(pihole-FTL sqlite3 "${database}" -cmd ".headers on" -cmd ".mode column" "PRAGMA foreign_key_check" 2>&1)"
+      result="$(pihole-FTL sqlite3 "${database}" -cmd ".headers on" -cmd ".mode column" "PRAGMA foreign_key_check" 2>&1 & spinner)"
       if [[ -z ${result} ]]; then
         log_write "${TICK} No foreign key errors in ${database}"
       else


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

After #4745 the debug log can take a long time to execute the `integrity_check`, specially on slower machines.
During long processes like this, the debug log appears frozen. Adding a spinner will make it clear that the log is still running.

- **How does this PR accomplish the above?:**

Adding a spinner function to the `PRAGMA integrity_check` and `pihole-FTL dhcp-discover`. 

- **What documentation changes (if any) are needed to support this PR?:**

*Replace this with a detailed list of any necessary changes*


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
