### PR TITLE
Don't fail if Alma or Rocky are detected

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -381,7 +381,7 @@ select_rpm_php(){
         # all required packages should be available by default with the latest fedora release
         : # continue
     # or if host OS is CentOS,
-    elif grep -qiE 'centos|scientific' /etc/redhat-release; then
+    elif grep -qiE 'centos|scientific|alma|rocky' /etc/redhat-release; then
         # Pi-Hole currently supports CentOS 7+ with PHP7+
         SUPPORTED_CENTOS_VERSION=7
         SUPPORTED_CENTOS_PHP_VERSION=7
@@ -413,11 +413,7 @@ select_rpm_php(){
             printf "  %b EPEL repository already installed\\n" "${TICK}"
         else
             # CentOS requires the EPEL repository to gain access to Fedora packages
-            if [[ CURRENT_CENTOS_VERSION -eq 7 ]]; then
-                EPEL_PKG="https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-            elif [[ CURRENT_CENTOS_VERSION -eq 8 ]]; then
-                EPEL_PKG="https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-            fi
+            EPEL_PKG="https://dl.fedoraproject.org/pub/epel/epel-release-latest-${CURRENT_CENTOS_VERSION}.noarch.rpm"
             printf "  %b Enabling EPEL package repository (https://fedoraproject.org/wiki/EPEL)\\n" "${INFO}"
             "${PKG_INSTALL[@]}" ${EPEL_PKG}
             printf "  %b Installed %s\\n" "${TICK}" "${EPEL_PKG}"


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

We don't support Alma or Rocky linux officially (as no developer runs it). However, users reported it is working without issues (after `PIHOLE_SKIP_OS_CHECK=true`) and only fails at the centos breakpoint.

This PR adds `alma` and `rocky` to this check, removing obstacles for users running this system.

Additionally, it makes the EPEL download URL dependent on `CURRENT_CENTOS_VERSION` so we don't need to adjust this again if a new OS version is released. (E.g. Rocky just released version 9)

Fixes https://github.com/pi-hole/pi-hole/issues/4393 and https://discourse.pi-hole.net/t/unable-to-do-scripted-upgrade-since-5-11-3/56410/1


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
