### PR TITLE
Explicit set minor and patch version on used actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,12 +29,12 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     -
       name: Initialize CodeQL
-      uses: github/codeql-action/init@v2.0.0
+      uses: github/codeql-action/init@v2
       with:
         languages: 'python'
     -
       name: Autobuild
-      uses: github/codeql-action/autobuild@v2.0.0
+      uses: github/codeql-action/autobuild@v2
     -
       name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2.0.0
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,16 +25,16 @@ jobs:
     steps:
     -
       name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.0
     # Initializes the CodeQL tools for scanning.
     -
       name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v2.0.0
       with:
         languages: 'python'
     -
       name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v2.0.0
     -
       name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v2.0.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     -
       name: Checkout repository
-      uses: actions/checkout@v3.0.0
+      uses: actions/checkout@v3.0.2
     # Initializes the CodeQL tools for scanning.
     -
       name: Initialize CodeQL

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/stale@v5.0.0
+      - uses: actions/stale@v5.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v5.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30

--- a/.github/workflows/sync-back-to-dev.yml
+++ b/.github/workflows/sync-back-to-dev.yml
@@ -11,7 +11,7 @@ jobs:
     name: Syncing branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.0.
       - name: Opening pull request
         id: pull
         uses: tretuna/sync-branches@1.4.0
@@ -20,7 +20,7 @@ jobs:
           FROM_BRANCH: 'master'
           TO_BRANCH: 'development'
       - name: Label the pull request to ignore for release note generation
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@v1.0.0
         with:
           labels: internal
           repo: ${{ github.repository }}

--- a/.github/workflows/sync-back-to-dev.yml
+++ b/.github/workflows/sync-back-to-dev.yml
@@ -11,7 +11,7 @@ jobs:
     name: Syncing branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.0.
+        uses: actions/checkout@v3.0.2
       - name: Opening pull request
         id: pull
         uses: tretuna/sync-branches@1.4.0
@@ -20,7 +20,7 @@ jobs:
           FROM_BRANCH: 'master'
           TO_BRANCH: 'development'
       - name: Label the pull request to ignore for release note generation
-        uses: actions-ecosystem/action-add-labels@v1.0.0
+        uses: actions-ecosystem/action-add-labels@v1.1.0
         with:
           labels: internal
           repo: ${{ github.repository }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     -
       name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.0
     -
       name: Check scripts in repository are executable
       run: |
@@ -30,7 +30,7 @@ jobs:
         ignore_words_file: .codespellignore
     -
       name: Get editorconfig-checker
-      uses: editorconfig-checker/action-editorconfig-checker@main
+      uses: editorconfig-checker/action-editorconfig-checker@v1.0.0
     -
       name: Run editorconfig-checker
       run: editorconfig-checker
@@ -49,10 +49,10 @@ jobs:
     steps:
     -
       name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.0.0
     -
       name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.0.0
       with:
         python-version: 3.8
     -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     -
       name: Checkout repository
-      uses: actions/checkout@v3.0.0
+      uses: actions/checkout@v3.0.2
     -
       name: Check scripts in repository are executable
       run: |
@@ -30,7 +30,7 @@ jobs:
         ignore_words_file: .codespellignore
     -
       name: Get editorconfig-checker
-      uses: editorconfig-checker/action-editorconfig-checker@v1.0.0
+      uses: editorconfig-checker/action-editorconfig-checker@main # tag v1.0.0 is really out of date
     -
       name: Run editorconfig-checker
       run: editorconfig-checker
@@ -49,10 +49,10 @@ jobs:
     steps:
     -
       name: Checkout repository
-      uses: actions/checkout@v3.0.0
+      uses: actions/checkout@v3.0.2
     -
       name: Set up Python 3.8
-      uses: actions/setup-python@v4.0.0
+      uses: actions/setup-python@v4.1.0
       with:
         python-version: 3.8
     -


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Allow updates for GH `actions` by dependabot also for minor and patch versions. So far, we only specify major versions in our workflows. Therefore, dependabot will only check if new major versions exist and won't update the workflow on new minor or patch versions.

By explicitly setting minor and patch version we allow dependabot to update those as well.

E.g. `action/stale@v5` is currently missing the `close-issue-reason`. This was added in `v5.1.0`. However, dependabot fails to recognize the update atm.

P.S. I expect some dependabot PRs after this has been merged. I did not update the versions manually to get the dependabot changelog.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
