### PR TITLE
Skip web server dialog if --disable-install-webserver has been passed

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1127,8 +1127,8 @@ setAdminFlag() {
             ;;
     esac
 
-    # If the user wants to install the Web admin interface (i.e. it has not been deselected above)
-    if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
+    # If the user wants to install the Web admin interface (i.e. it has not been deselected above) and did not deselect the web server via command-line argument
+    if [[ "${INSTALL_WEB_INTERFACE}" == true && "${INSTALL_WEB_SERVER}" == true ]]; then
         # Get list of required PHP modules, excluding base package (common) and handler (cgi)
         local i php_modules
         for i in "${PIHOLE_WEB_DEPS[@]}"; do [[ $i == 'php'* && $i != *'-common' && $i != *'-cgi' ]] && php_modules+=" ${i#*-}"; done


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

Prior to https://github.com/pi-hole/pi-hole/pull/4772, the web server dialog was skipped if `--disable-install-webserver` was passed (`INSTALL_WEB_SERVER=false`). This behaviour was lost, the dialog is shown despite the flag was passed.


- **How does this PR accomplish the above?:**

This commit restores this behaviour by skipping the dialog if `INSTALL_WEB_SERVER=false` is set.


- **What documentation changes (if any) are needed to support this PR?:**

*Replace this with a detailed list of any necessary changes*


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
