### PR TITLE
Add OS_CHECK_DEPS to uninstall script

### DIFF
--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -44,8 +44,8 @@ source "${setupVars}"
 # package_manager_detect() sourced from basic-install.sh
 package_manager_detect
 
-# Install packages used by the Pi-hole
-DEPS=("${INSTALLER_DEPS[@]}" "${PIHOLE_DEPS[@]}")
+# Uninstall packages used by the Pi-hole
+DEPS=("${INSTALLER_DEPS[@]}" "${PIHOLE_DEPS[@]}" "${OS_CHECK_DEPS[@]}")
 if [[ "${INSTALL_WEB_SERVER}" == true ]]; then
     # Install the Web dependencies
     DEPS+=("${PIHOLE_WEB_DEPS[@]}")


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Adds `OS_CHECK_DEPS[@]` to the packages that should be removed during uninstallation. (At the moment `grep` and `dnsutils`). Of course, users should still check if they really want to remove those packages...

Fixes https://github.com/pi-hole/pi-hole/issues/2136#issuecomment-1199819590

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
