### PR TITLE
Speed up the package check tests

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -306,6 +306,7 @@ package_manager_detect() {
         PKG_INSTALL=("${PKG_MANAGER}" -qq --no-install-recommends install)
         # grep -c will return 1 if there are no matches. This is an acceptable condition, so we OR TRUE to prevent set -e exiting the script.
         PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
+        PKG_CHECK="apt-cache show"
         # Update package cache
         update_package_cache || exit 1
         # Check for and determine version number (major and minor) of current php install
@@ -358,6 +359,7 @@ package_manager_detect() {
         PKG_INSTALL=("${PKG_MANAGER}" install -y)
         # CentOS package manager returns 100 when there are packages to update so we need to || true to prevent the script from exiting.
         PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l || true"
+        PKG_CHECK="${PKG_MANAGER} list"
         OS_CHECK_DEPS=(grep bind-utils)
         INSTALLER_DEPS=(git dialog iproute newt procps-ng which chkconfig ca-certificates)
         PIHOLE_DEPS=(cronie curl findutils sudo unzip libidn2 psmisc libcap nmap-ncat)

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -1104,11 +1104,13 @@ def test_package_manager_has_installer_deps(host):
     output = host.run('''
     source /opt/pihole/basic-install.sh
     package_manager_detect
-    install_dependent_packages ${INSTALLER_DEPS[@]}
+    for i in "${INSTALLER_DEPS[@]}"
+    do
+        ${PKG_CHECK} ${i}
+    done
     ''')
-
-    assert 'No package' not in output.stdout  # centos7 still exits 0...
-    assert output.rc == 0
+    assert 'Unable to locate package' not in output.stdout
+    assert 'No matching Packages to list' not in output.stderr
 
 
 def test_package_manager_has_pihole_deps(host):
@@ -1118,11 +1120,13 @@ def test_package_manager_has_pihole_deps(host):
     source /opt/pihole/basic-install.sh
     package_manager_detect
     select_rpm_php
-    install_dependent_packages ${PIHOLE_DEPS[@]}
+    for i in "${PIHOLE_DEPS[@]}"
+    do
+        ${PKG_CHECK} ${i}
+    done
     ''')
-
-    assert 'No package' not in output.stdout  # centos7 still exits 0...
-    assert output.rc == 0
+    assert 'Unable to locate package' not in output.stdout
+    assert 'No matching Packages to list' not in output.stderr
 
 
 def test_package_manager_has_web_deps(host):
@@ -1132,8 +1136,10 @@ def test_package_manager_has_web_deps(host):
     source /opt/pihole/basic-install.sh
     package_manager_detect
     select_rpm_php
-    install_dependent_packages ${PIHOLE_WEB_DEPS[@]}
+    for i in "${PIHOLE_WEB_DEPS[@]}"
+    do
+        ${PKG_CHECK} ${i}
+    done
     ''')
-
-    assert 'No package' not in output.stdout  # centos7 still exits 0...
-    assert output.rc == 0
+    assert 'Unable to locate package' not in output.stdout
+    assert 'No matching Packages to list' not in output.stderr


### PR DESCRIPTION
Mostly thinking from the point of view of the PHP packages which can take a while to install on the CI (which is why we moved to a pre-built base image on Docker)

Testing locally on my machine for `test_package_manager_has_web_deps`:

before:
```
12.73s call     test_any_automated_install.py::test_package_manager_has_web_deps
0.59s setup    test_any_automated_install.py::test_package_manager_has_web_deps
0.47s teardown test_any_automated_install.py::test_package_manager_has_web_deps
```

after:
```
4.41s call     test_any_automated_install.py::test_package_manager_has_web_deps
0.51s setup    test_any_automated_install.py::test_package_manager_has_web_deps
0.47s teardown test_any_automated_install.py::test_package_manager_has_web_deps
```

Curious to see how that translates on github actions
