### PR TITLE
Exit init script with error result code if FTL fails to start

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -58,10 +58,10 @@ start() {
     fi
 
     if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_IPC_LOCK,CAP_CHOWN+eip "/usr/bin/pihole-FTL"; then
-      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole
+      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole || exit $?
     else
       echo "Warning: Starting pihole-FTL as root because setting capabilities is not supported on this system"
-      /usr/bin/pihole-FTL
+      /usr/bin/pihole-FTL || exit $?
     fi
     echo
   fi


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Exit init script with error result code if FTL fails to start


- **How does this PR accomplish the above?:**

Exits init script with non-zero result code if FTL fails to start.


- **What documentation changes (if any) are needed to support this PR?:**

Nothing.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
