### PR TITLE
Add security-related headers to Pi-hole web interface

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -78,10 +78,21 @@ include_shell "find /etc/lighttpd/conf-enabled -name '*.conf' -a ! -name 'letsen
 
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
-    # Create a response header for debugging using curl -I
+    # X-Pi-hole is a response header for debugging using curl -I
+    # X-Frame-Options prevents clickjacking attacks and helps ensure your content is not embedded into other sites via < frame >, < iframe > or < object >.
+    # X-XSS-Protection sets the configuration for the cross-site scripting filters built into most browsers. This is important because it tells the browser to block the response if a malicious script has been inserted from a user input.
+    # X-Content-Type-Options stops a browser from trying to MIME-sniff the content type and forces it to stick with the declared content-type. This is important because the browser will only load external resources if their content-type matches what is expected, and not malicious hidden code.
+    # Content-Security-Policy tells the browser where resources are allowed to be loaded and if it’s allowed to parse/run inline styles or Javascript. This is important because it prevents content injection attacks, such as Cross Site Scripting (XSS).
+    # X-Permitted-Cross-Domain-Policies is an XML document that grants a web client, such as Adobe Flash Player or Adobe Acrobat (though not necessarily limited to these), permission to handle data across domains.
+    # Referrer-Policy allows control/restriction of the amount of information present in the referral header for links away from your page—the URL path or even if the header is sent at all.
     setenv.add-response-header = (
         "X-Pi-hole" => "The Pi-hole Web interface is working!",
-        "X-Frame-Options" => "DENY"
+        "X-Frame-Options" => "DENY",
+        "X-XSS-Protection" => "1; mode=block",
+        "X-Content-Type-Options" => "nosniff",
+        "Content-Security-Policy" => "default-src 'self' 'unsafe-inline';",
+        "X-Permitted-Cross-Domain-Policies" => "none",
+        "Referrer-Policy" => "same-origin"
     )
 }
 

--- a/advanced/lighttpd.conf.fedora
+++ b/advanced/lighttpd.conf.fedora
@@ -86,10 +86,21 @@ fastcgi.server = (
 
 # If the URL starts with /admin, it is the Web interface
 $HTTP["url"] =~ "^/admin/" {
-    # Create a response header for debugging using curl -I
+    # X-Pi-hole is a response header for debugging using curl -I
+    # X-Frame-Options prevents clickjacking attacks and helps ensure your content is not embedded into other sites via < frame >, < iframe > or < object >.
+    # X-XSS-Protection sets the configuration for the cross-site scripting filters built into most browsers. This is important because it tells the browser to block the response if a malicious script has been inserted from a user input.
+    # X-Content-Type-Options stops a browser from trying to MIME-sniff the content type and forces it to stick with the declared content-type. This is important because the browser will only load external resources if their content-type matches what is expected, and not malicious hidden code.
+    # Content-Security-Policy tells the browser where resources are allowed to be loaded and if it’s allowed to parse/run inline styles or Javascript. This is important because it prevents content injection attacks, such as Cross Site Scripting (XSS).
+    # X-Permitted-Cross-Domain-Policies is an XML document that grants a web client, such as Adobe Flash Player or Adobe Acrobat (though not necessarily limited to these), permission to handle data across domains.
+    # Referrer-Policy allows control/restriction of the amount of information present in the referral header for links away from your page—the URL path or even if the header is sent at all.
     setenv.add-response-header = (
         "X-Pi-hole" => "The Pi-hole Web interface is working!",
-        "X-Frame-Options" => "DENY"
+        "X-Frame-Options" => "DENY",
+        "X-XSS-Protection" => "1; mode=block",
+        "X-Content-Type-Options" => "nosniff",
+        "Content-Security-Policy" => "default-src 'self' 'unsafe-inline';",
+        "X-Permitted-Cross-Domain-Policies" => "none",
+        "Referrer-Policy" => "same-origin"
     )
 }
 


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

Add security-related headers to Pi-hole web interface. Justification for the additions:
- [`Content-Security-Policy`](https://content-security-policy.com/) tells the browser where resources are allowed to be
  loaded and if it’s allowed to parse/run inline styles or Javascript. This is
  important because it prevents content injection attacks, such as Cross Site
  Scripting (XSS).
  - We set the `default-src` directive (defines the default policy for fetching
    resources such as JavaScript, Images, CSS, Fonts, AJAX requests, Frames,
    HTML5 Media) to `self` which allows loading resources from the same origin
    (same scheme, host and port) only.
  - We add `'unsafe-inline'` inline source elements such as style attribute,
    onclick, or script tag bodies.
- `X-XSS-Protection` sets the configuration for the cross-site scripting filters
  built into most browsers. This is important because it tells the browser to
  block the response if a malicious script has been inserted from a user input.
- `X-Content-Type-Options` stops a browser from trying to MIME-sniff the content
  type and forces it to stick with the declared content-type. This is important
  because the browser will only load external resources if their content-type
  matches what is expected, and not malicious hidden code.
- `X-Permitted-Cross-Domain-Policies` is an XML document that grants a web client,
  such as Adobe Flash Player or Adobe Acrobat (though not necessarily limited to
  these), permission to handle data across domains.
- `Referrer-Policy` allows control/restriction of the amount of information present
  in the referral header for links away from your page - the URL path or even if the
  header is sent at all.

- **How does this PR accomplish the above?:**

Modify the installed `lighttpd` configuration files.

- **What documentation changes (if any) are needed to support this PR?:**

None

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [X] I have read the above and my PR is ready for review. _Check this box to confirm_
