### PR TITLE
Fix git indention

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2126,7 +2126,7 @@ checkout_pull_branch() {
 
     git_pull=$(git pull --no-rebase || return 1)
 
-    if [[ "$git_pull" == *"up-to-date"* ]]; then
+    if [[ "$git_pull" == *"up to date"* ]]; then
         printf "  %b %s\\n" "${INFO}" "${git_pull}"
     else
         printf "%s\\n" "$git_pull"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2126,11 +2126,7 @@ checkout_pull_branch() {
 
     git_pull=$(git pull --no-rebase || return 1)
 
-    if [[ "$git_pull" == *"up to date"* ]]; then
-        printf "  %b %s\\n" "${INFO}" "${git_pull}"
-    else
-        printf "%s\\n" "$git_pull"
-    fi
+    printf "  %b %s\\n" "${INFO}" "${git_pull}"
 
     return 0
 }


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Fixes the indention shown when switching branches and the branch is "Already up to date"

![Bildschirmfoto zu 2022-08-06 19-01-06](https://user-images.githubusercontent.com/26622301/183264055-067e3dd8-aa5c-4f24-893f-34c380866a4f.png)


- **How does this PR accomplish the above?:**

The check for the output string was checking for the wrong string: it checked for "up-to-date", while `git` outputs `Already up to date` (without hyphens) since https://github.com/git/git/commit/7560f547e614244fe1d4648598d4facf7ed33a56

This PR fixes this by removing the check completely and always indent the output.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
