### PR TITLE
Store versions as key/value pairs rather than space delimeted values

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -41,33 +41,19 @@ function get_local_version() {
 # shellcheck disable=SC1091
 . /etc/pihole/setupVars.conf
 
-utilsfile="/opt/pihole/utils.sh"
-source "${utilsfile}"
+# Source the utils file
+# shellcheck disable=SC1091
+. /opt/pihole/utils.sh
 
 # Remove the below three legacy files if they exist
-GITHUB_VERSION_FILE="/etc/pihole/GitHubVersions"
-LOCAL_BRANCH_FILE="/etc/pihole/localbranches"
-LOCAL_VERSION_FILE="/etc/pihole/localversions"
-
-if [ -f "${GITHUB_VERSION_FILE}" ]; then
-    rm "${GITHUB_VERSION_FILE}"
-fi
-
-if [ -f "${LOCAL_BRANCH_FILE}" ]; then
-    rm "${LOCAL_BRANCH_FILE}"
-fi
-
-if [ -f "${LOCAL_VERSION_FILE}" ]; then
-    rm "${LOCAL_VERSION_FILE}"
-fi
+rm -f "/etc/pihole/GitHubVersions"
+rm -f "/etc/pihole/localbranches"
+rm -f "/etc/pihole/localversions"
 
 # Create new versions file if it does not exist
 VERSION_FILE="/etc/pihole/versions"
-
-if [ ! -f "${VERSION_FILE}" ]; then
-    touch "${VERSION_FILE}"
-    chmod 644 "${VERSION_FILE}"
-fi
+touch "${VERSION_FILE}"
+chmod 644 "${VERSION_FILE}"
 
 if [[ "$2" == "remote" ]]; then
 

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -41,54 +41,78 @@ function get_local_version() {
 # shellcheck disable=SC1091
 . /etc/pihole/setupVars.conf
 
+utilsfile="/opt/pihole/utils.sh"
+source "${utilsfile}"
+
+# Remove the below three legacy files if they exist
+GITHUB_VERSION_FILE="/etc/pihole/GitHubVersions"
+LOCAL_BRANCH_FILE="/etc/pihole/localbranches"
+LOCAL_VERSION_FILE="/etc/pihole/localversions"
+
+if [ -f "${GITHUB_VERSION_FILE}" ]; then
+    rm "${GITHUB_VERSION_FILE}"
+fi
+
+if [ -f "${LOCAL_BRANCH_FILE}" ]; then
+    rm "${LOCAL_BRANCH_FILE}"
+fi
+
+if [ -f "${LOCAL_VERSION_FILE}" ]; then
+    rm "${LOCAL_VERSION_FILE}"
+fi
+
+# Create new versions file if it does not exist
+VERSION_FILE="/etc/pihole/versions"
+
+if [ ! -f "${VERSION_FILE}" ]; then
+    touch "${VERSION_FILE}"
+    chmod 644 "${VERSION_FILE}"
+fi
+
 if [[ "$2" == "remote" ]]; then
 
     if [[ "$3" == "reboot" ]]; then
         sleep 30
     fi
 
-    GITHUB_VERSION_FILE="/etc/pihole/GitHubVersions"
-
     GITHUB_CORE_VERSION="$(json_extract tag_name "$(curl -s 'https://api.github.com/repos/pi-hole/pi-hole/releases/latest' 2> /dev/null)")"
-    echo -n "${GITHUB_CORE_VERSION}" > "${GITHUB_VERSION_FILE}"
-    chmod 644 "${GITHUB_VERSION_FILE}"
+    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_VERSION" "${GITHUB_CORE_VERSION}"
 
     if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
         GITHUB_WEB_VERSION="$(json_extract tag_name "$(curl -s 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null)")"
-        echo -n " ${GITHUB_WEB_VERSION}" >> "${GITHUB_VERSION_FILE}"
+        addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_VERSION" "${GITHUB_WEB_VERSION}"
     fi
 
     GITHUB_FTL_VERSION="$(json_extract tag_name "$(curl -s 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null)")"
-    echo -n " ${GITHUB_FTL_VERSION}" >> "${GITHUB_VERSION_FILE}"
+    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_FTL_VERSION" "${GITHUB_FTL_VERSION}"
+
+    if [[ "${PIHOLE_DOCKER_TAG}" ]]; then
+        GITHUB_DOCKER_VERSION="$(json_extract tag_name "$(curl -s 'https://api.github.com/repos/pi-hole/docker-pi-hole/releases/latest' 2> /dev/null)")"
+        addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_DOCKER_VERSION" "${GITHUB_DOCKER_VERSION}"
+    fi
 
 else
 
-    LOCAL_BRANCH_FILE="/etc/pihole/localbranches"
-
     CORE_BRANCH="$(get_local_branch /etc/.pihole)"
-    echo -n "${CORE_BRANCH}" > "${LOCAL_BRANCH_FILE}"
-    chmod 644 "${LOCAL_BRANCH_FILE}"
+    addOrEditKeyValPair "${VERSION_FILE}" "CORE_BRANCH" "${CORE_BRANCH}"
 
     if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
         WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
-        echo -n " ${WEB_BRANCH}" >> "${LOCAL_BRANCH_FILE}"
+        addOrEditKeyValPair "${VERSION_FILE}" "WEB_BRANCH" "${WEB_BRANCH}"
     fi
 
     FTL_BRANCH="$(pihole-FTL branch)"
-    echo -n " ${FTL_BRANCH}" >> "${LOCAL_BRANCH_FILE}"
-
-    LOCAL_VERSION_FILE="/etc/pihole/localversions"
+    addOrEditKeyValPair "${VERSION_FILE}" "FTL_BRANCH" "${FTL_BRANCH}"
 
     CORE_VERSION="$(get_local_version /etc/.pihole)"
-    echo -n "${CORE_VERSION}" > "${LOCAL_VERSION_FILE}"
-    chmod 644 "${LOCAL_VERSION_FILE}"
+    addOrEditKeyValPair "${VERSION_FILE}" "CORE_VERSION" "${CORE_VERSION}"
 
     if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
         WEB_VERSION="$(get_local_version /var/www/html/admin)"
-        echo -n " ${WEB_VERSION}" >> "${LOCAL_VERSION_FILE}"
+        addOrEditKeyValPair "${VERSION_FILE}" "WEB_VERSION" "${WEB_VERSION}"
     fi
 
     FTL_VERSION="$(pihole-FTL version)"
-    echo -n " ${FTL_VERSION}" >> "${LOCAL_VERSION_FILE}"
+    addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
 
 fi

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -90,16 +90,17 @@ getRemoteVersion(){
     local version
     local cachedVersions
     local arrCache
-    cachedVersions="/etc/pihole/GitHubVersions"
+    cachedVersions="/etc/pihole/versions"
 
     #If the above file exists, then we can read from that. Prevents overuse of GitHub API
     if [[ -f "$cachedVersions" ]]; then
-        IFS=' ' read -r -a arrCache < "$cachedVersions"
+
+        source "$cachedVersions"
 
         case $daemon in
-            "pi-hole"   )  echo "${arrCache[0]}";;
-            "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${arrCache[1]}";;
-            "FTL"       )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${arrCache[2]}" || echo "${arrCache[1]}";;
+            "pi-hole"   )  echo "${GITHUB_CORE_VERSION}";;
+            "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${GITHUB_WEB_VERSION}";;
+            "FTL"       )  echo "${GITHUB_FTL_VERSION}";;
         esac
 
         return 0

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -89,13 +89,13 @@ getRemoteVersion(){
     local daemon="${1}"
     local version
     local cachedVersions
-    local arrCache
     cachedVersions="/etc/pihole/versions"
 
     #If the above file exists, then we can read from that. Prevents overuse of GitHub API
     if [[ -f "$cachedVersions" ]]; then
 
-        source "$cachedVersions"
+        # shellcheck disable=SC1090
+        . "$cachedVersions"
 
         case $daemon in
             "pi-hole"   )  echo "${GITHUB_CORE_VERSION}";;

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -239,24 +239,14 @@ def test_installPihole_fresh_install_readableFiles(host):
         'r', '/etc/pihole/dns-servers.conf', piholeuser)
     actual_rc = host.run(check_servers).rc
     assert exit_status_success == actual_rc
-    # readable GitHubVersions
-    check_version = test_cmd.format(
-        'r', '/etc/pihole/GitHubVersions', piholeuser)
-    actual_rc = host.run(check_version).rc
-    assert exit_status_success == actual_rc
     # readable install.log
     check_install = test_cmd.format(
         'r', '/etc/pihole/install.log', piholeuser)
     actual_rc = host.run(check_install).rc
     assert exit_status_success == actual_rc
-    # readable localbranches
-    check_localbranch = test_cmd.format(
-        'r', '/etc/pihole/localbranches', piholeuser)
-    actual_rc = host.run(check_localbranch).rc
-    assert exit_status_success == actual_rc
-    # readable localversions
+    # readable versions
     check_localversion = test_cmd.format(
-        'r', '/etc/pihole/localversions', piholeuser)
+        'r', '/etc/pihole/versions', piholeuser)
     actual_rc = host.run(check_localversion).rc
     assert exit_status_success == actual_rc
     # readable logrotate


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Store Pi-hole component versions as key/value pairs in a single file. Storing as space delimited may save (a small amount of) space, but it can get complicated to ensure you are using the correct index when reading it out to an array.

This makes things a lot clearer.

AdminLTE will need to be updated to reflect this change too (@rdwebdesign said he would look at that)

This additionally adds the value of `GITHUB_DOCKER_TAG` into the mix so that updates to the docker container are visible, too.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_