### PR TITLE
Set connection timeout for curl

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -40,6 +40,7 @@ gravityDBschema="${piholeGitDir}/advanced/Templates/gravity.db.sql"
 gravityDBcopy="${piholeGitDir}/advanced/Templates/gravity_copy.sql"
 
 domainsExtension="domains"
+curl_connect_timeout=10
 
 # Source setupVars from install script
 setupVars="${piholeDir}/setupVars.conf"
@@ -641,7 +642,7 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   # shellcheck disable=SC2086
-  httpCode=$(curl --connect-timeout 10 -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${patternBuffer}" 2> /dev/null)
+  httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${patternBuffer}" 2> /dev/null)
 
   case $url in
     # Did we "download" a local file?

--- a/gravity.sh
+++ b/gravity.sh
@@ -641,7 +641,7 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   # shellcheck disable=SC2086
-  httpCode=$(curl -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${patternBuffer}" 2> /dev/null)
+  httpCode=$(curl --connect-timeout 10 -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${patternBuffer}" 2> /dev/null)
 
   case $url in
     # Did we "download" a local file?


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Sets the `--connection-timeout` for the gravity curl (downloading adlists) to 10 seconds. 
From the man pages:

```
       --connect-timeout <seconds>
              Maximum  time  in  seconds  that  you allow curl's connection to
              take.  This only limits the connection phase, so  if  curl  con‐
              nects  within the given period it will continue - if not it will
              exit.  Since version 7.32.0, this option accepts decimal values.

              If this option is used several times, the last one will be used.

              See also -m, --max-time.
```
This should speed up speed up gravity runs with a lot of inaccessible adlists. This was discussed on discourse: https://discourse.pi-hole.net/t/gravity-update-timeout/57391

The default timeout is 5 minutes.
https://github.com/curl/curl/blob/e43c3b3e3e6c2d58084d8c98f8e9640e09c0a05e/lib/connect.h#L47
```
#define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
```

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
