### PR TITLE
Cleanup if startup failed

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -9,11 +9,10 @@
 # Description:       Enable service provided by pihole-FTL daemon
 ### END INIT INFO
 
-#source utils.sh for getFTLPIDFile(), getFTLPID ()
+#source utils.sh for getFTLPIDFile(), getFTLPID()
 PI_HOLE_SCRIPT_DIR="/opt/pihole"
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 . "${utilsfile}"
-
 
 is_running() {
   if [ -d "/proc/${FTL_PID}" ]; then
@@ -23,7 +22,7 @@ is_running() {
 }
 
 cleanup() {
-  rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}" "${FTL_PORT_FILE}"
+    rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}" "${FTL_PORT_FILE}"
 }
 
 # Start the service
@@ -114,6 +113,9 @@ status() {
 
 
 ### main logic ###
+
+# catch sudden termination
+trap 'cleanup; exit 1' INT HUP TERM ABRT
 
 # Get file paths
 FTL_PID_FILE="$(getFTLPIDFile)"

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -22,7 +22,7 @@ is_running() {
 }
 
 cleanup() {
-    rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}" "${FTL_PORT_FILE}"
+    rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}"
 }
 
 # Start the service
@@ -65,9 +65,9 @@ start() {
       /usr/bin/pihole-FTL || ec=$?
     fi
     # Cleanup if startup failed
-    if [ "${ec}" != 0 ]; then
+    if [ -n "${ec}" ] && [ "${ec}" != 0 ]; then
         cleanup
-        exit "${ec}"
+        exit $ec
     fi
     echo
   fi

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -22,6 +22,9 @@ is_running() {
   return 1
 }
 
+cleanup() {
+  rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}" "${FTL_PORT_FILE}"
+}
 
 # Start the service
 start() {
@@ -57,10 +60,15 @@ start() {
     fi
 
     if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_IPC_LOCK,CAP_CHOWN+eip "/usr/bin/pihole-FTL"; then
-      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole || exit $?
+      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole || ec=$?
     else
       echo "Warning: Starting pihole-FTL as root because setting capabilities is not supported on this system"
-      /usr/bin/pihole-FTL || exit $?
+      /usr/bin/pihole-FTL || ec=$?
+    fi
+    # Cleanup if startup failed
+    if [ "${ec}" != 0 ]; then
+        cleanup
+        exit "${ec}"
     fi
     echo
   fi
@@ -89,8 +97,7 @@ stop() {
   else
     echo "Not running"
   fi
-  # Cleanup
-  rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}"
+  cleanup
   echo
 }
 


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Cleanup files if `pihole-FTL` did not start properly after getting invoked by `pihole-FTL.service`.

With https://github.com/pi-hole/pi-hole/pull/4857 we added the exit code, however do not use ist so far. We do now.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
