### PR TITLE
Fix 4898

### DIFF
--- a/pihole
+++ b/pihole
@@ -104,15 +104,15 @@ restartDNS() {
   local svcOption svc str output status pid icon FTL_PID_FILE
   svcOption="${1:-restart}"
 
+  # get the current path to the pihole-FTL.pid
+  FTL_PID_FILE="$(getFTLPIDFile)"
+
   # Determine if we should reload or restart
   if [[ "${svcOption}" =~ "reload-lists" ]]; then
     # Reloading of the lists has been requested
     # Note 1: This will NOT re-read any *.conf files
     # Note 2: We cannot use killall here as it does
     #         not know about real-time signals
-
-    # get the current path to the pihole-FTL.pid
-    FTL_PID_FILE="$(getFTLPIDFile)"
 
     pid="$(getFTLPID ${FTL_PID_FILE})"
     if [[ "$pid" -eq "-1" ]]; then


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/pi-hole/issues/4898.

We need to set `FTL_PID_FILE` outside the `if` to ensure it's set both for `reload-lists` and `reload`. Bug was introduced by https://github.com/pi-hole/pi-hole/pull/4839

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
