### PR TITLE
Replace deprecated shell commands

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -358,7 +358,7 @@ package_manager_detect() {
         # These variable names match the ones for apt-get. See above for an explanation of what they are for.
         PKG_INSTALL=("${PKG_MANAGER}" install -y)
         # CentOS package manager returns 100 when there are packages to update so we need to || true to prevent the script from exiting.
-        PKG_COUNT="${PKG_MANAGER} check-update | egrep '(.i686|.x86|.noarch|.arm|.src)' | wc -l || true"
+        PKG_COUNT="${PKG_MANAGER} check-update | grep -E '(.i686|.x86|.noarch|.arm|.src)' | wc -l || true"
         OS_CHECK_DEPS=(grep bind-utils)
         INSTALLER_DEPS=(git dialog iproute newt procps-ng which chkconfig ca-certificates)
         PIHOLE_DEPS=(cronie curl findutils sudo unzip libidn2 psmisc libcap nmap-ncat jq)

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2267,7 +2267,7 @@ get_binary_name() {
         local rev
         rev=$(uname -m | sed "s/[^0-9]//g;")
         local lib
-        lib=$(ldd "$(which sh)" | grep -E '^\s*/lib' | awk '{ print $1 }')
+        lib=$(ldd "$(command -v sh)" | grep -E '^\s*/lib' | awk '{ print $1 }')
         if [[ "${lib}" == "/lib/ld-linux-aarch64.so.1" ]]; then
             printf "%b  %b Detected AArch64 (64 Bit ARM) processor\\n" "${OVER}" "${TICK}"
             # set the binary to be used

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -619,10 +619,15 @@ def test_FTL_detect_aarch64_no_errors(host):
     """
     # mock uname to return aarch64 platform
     mock_command("uname", {"-m": ("aarch64", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with aarch64 shared library
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-aarch64.so.1", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux-aarch64.so.1", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux-aarch64.so.1", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -647,10 +652,15 @@ def test_FTL_detect_armv4t_no_errors(host):
     """
     # mock uname to return armv4t platform
     mock_command("uname", {"-m": ("armv4t", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with armv4t shared library
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -675,10 +685,15 @@ def test_FTL_detect_armv5te_no_errors(host):
     """
     # mock uname to return armv5te platform
     mock_command("uname", {"-m": ("armv5te", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with ld-linux shared library
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -704,9 +719,14 @@ def test_FTL_detect_armv6l_no_errors(host):
     # mock uname to return armv6l platform
     mock_command("uname", {"-m": ("armv6l", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -734,9 +754,14 @@ def test_FTL_detect_armv7l_no_errors(host):
     # mock uname to return armv7l platform
     mock_command("uname", {"-m": ("armv7l", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -763,10 +788,15 @@ def test_FTL_detect_armv8a_no_errors(host):
     """
     # mock uname to return armv8a platform
     mock_command("uname", {"-m": ("armv8a", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
+    mock_command(
+        "ldd",
+        {
+            "/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+            "/usr/bin/sh": ("/lib/ld-linux-armhf.so.3", "0"),
+        },
+        host,
+    )
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -789,8 +819,6 @@ def test_FTL_detect_x86_64_no_errors(host):
     """
     confirms only x86_64 package is downloaded for FTL engine
     """
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -813,8 +841,6 @@ def test_FTL_detect_unknown_no_errors(host):
     """confirms only generic package is downloaded for FTL engine"""
     # mock uname to return generic platform
     mock_command("uname", {"-m": ("mips", "0")}, host)
-    # mock `command -v sh` to return `/bin/sh`
-    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -619,8 +619,8 @@ def test_FTL_detect_aarch64_no_errors(host):
     """
     # mock uname to return aarch64 platform
     mock_command("uname", {"-m": ("aarch64", "0")}, host)
-    # mock `which sh` to return `/bin/sh`
-    mock_command("which", {"sh": ("/bin/sh", "0")}, host)
+    # mock `command -v sh` to return `/bin/sh`
+    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with aarch64 shared library
     mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-aarch64.so.1", "0")}, host)
     detectPlatform = host.run(
@@ -647,8 +647,8 @@ def test_FTL_detect_armv4t_no_errors(host):
     """
     # mock uname to return armv4t platform
     mock_command("uname", {"-m": ("armv4t", "0")}, host)
-    # mock `which sh` to return `/bin/sh`
-    mock_command("which", {"sh": ("/bin/sh", "0")}, host)
+    # mock `command -v sh` to return `/bin/sh`
+    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with armv4t shared library
     mock_command("ldd", {"/bin/sh": ("/lib/ld-linux.so.3", "0")}, host)
     detectPlatform = host.run(
@@ -675,8 +675,8 @@ def test_FTL_detect_armv5te_no_errors(host):
     """
     # mock uname to return armv5te platform
     mock_command("uname", {"-m": ("armv5te", "0")}, host)
-    # mock `which sh` to return `/bin/sh`
-    mock_command("which", {"sh": ("/bin/sh", "0")}, host)
+    # mock `command -v sh` to return `/bin/sh`
+    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with ld-linux shared library
     mock_command("ldd", {"/bin/sh": ("/lib/ld-linux.so.3", "0")}, host)
     detectPlatform = host.run(
@@ -704,8 +704,8 @@ def test_FTL_detect_armv6l_no_errors(host):
     # mock uname to return armv6l platform
     mock_command("uname", {"-m": ("armv6l", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    # mock `which sh` to return `/bin/sh`
-    mock_command("which", {"sh": ("/bin/sh", "0")}, host)
+    # mock `command -v sh` to return `/bin/sh`
+    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
     detectPlatform = host.run(
         """
@@ -734,8 +734,8 @@ def test_FTL_detect_armv7l_no_errors(host):
     # mock uname to return armv7l platform
     mock_command("uname", {"-m": ("armv7l", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
-    # mock `which sh` to return `/bin/sh`
-    mock_command("which", {"sh": ("/bin/sh", "0")}, host)
+    # mock `command -v sh` to return `/bin/sh`
+    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
     detectPlatform = host.run(
         """
@@ -763,8 +763,8 @@ def test_FTL_detect_armv8a_no_errors(host):
     """
     # mock uname to return armv8a platform
     mock_command("uname", {"-m": ("armv8a", "0")}, host)
-    # mock `which sh` to return `/bin/sh`
-    mock_command("which", {"sh": ("/bin/sh", "0")}, host)
+    # mock `command -v sh` to return `/bin/sh`
+    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     # mock ldd to respond with ld-linux-armhf shared library
     mock_command("ldd", {"/bin/sh": ("/lib/ld-linux-armhf.so.3", "0")}, host)
     detectPlatform = host.run(
@@ -789,8 +789,8 @@ def test_FTL_detect_x86_64_no_errors(host):
     """
     confirms only x86_64 package is downloaded for FTL engine
     """
-    # mock `which sh` to return `/bin/sh`
-    mock_command("which", {"sh": ("/bin/sh", "0")}, host)
+    # mock `command -v sh` to return `/bin/sh`
+    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh
@@ -813,8 +813,8 @@ def test_FTL_detect_unknown_no_errors(host):
     """confirms only generic package is downloaded for FTL engine"""
     # mock uname to return generic platform
     mock_command("uname", {"-m": ("mips", "0")}, host)
-    # mock `which sh` to return `/bin/sh`
-    mock_command("which", {"sh": ("/bin/sh", "0")}, host)
+    # mock `command -v sh` to return `/bin/sh`
+    mock_command("command", {"-v sh": ("/bin/sh", "0")}, host)
     detectPlatform = host.run(
         """
     source /opt/pihole/basic-install.sh


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Increased compatibility with systems and removal of deprecation warnings.

- **How does this PR accomplish the above?:**

Removes deprecated and nonstandard shell utilities `egrep` and `which` with standardized versions `grep -E` and `command -v`

- **What documentation changes (if any) are needed to support this PR?:**

None.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
