### PR TITLE
Store docker version in versions file (If `PIHOLE_DOCKER_TAG` variable is set) 

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -41,6 +41,9 @@ else
     #OVER="\r\033[K"
 fi
 
+# shellcheck disable=SC1091
+. /etc/pihole/versions
+
 OBFUSCATED_PLACEHOLDER="<DOMAIN OBFUSCATED>"
 
 # FAQ URLs for use in showing the debug log
@@ -465,8 +468,8 @@ diagnose_operating_system() {
     # Display the current test that is running
     echo_current_diagnostic "Operating system"
 
-    # If the PIHOLE_DOCKER_TAG variable is set, include this information in the debug output
-    [ -n "${PIHOLE_DOCKER_TAG}" ] && log_write "${INFO} Pi-hole Docker Container: ${PIHOLE_DOCKER_TAG}"
+    # If DOCKER_VERSION is set (Sourced from /etc/pihole/versions at start of script), include this information in the debug output
+    [ -n "${DOCKER_VERSION}" ] && log_write "${INFO} Pi-hole Docker Container: ${DOCKER_VERSION}"
 
     # If there is a /etc/*release file, it's probably a supported operating system, so we can
     if ls /etc/*release 1> /dev/null 2>&1; then
@@ -802,7 +805,7 @@ check_networking() {
     ping_gateway "6"
     # Skip the following check if installed in docker container. Unpriv'ed containers do not have access to the information required
     # to resolve the service name listening - and the container should not start if there was a port conflict anyway
-    [ -z "${PIHOLE_DOCKER_TAG}" ] && check_required_ports
+    [ -z "${DOCKER_VERSION}" ] && check_required_ports
 }
 
 check_x_headers() {

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -84,6 +84,7 @@ else
     FTL_VERSION="$(pihole-FTL version)"
     addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
 
+    # PIHOLE_DOCKER_TAG is set as env variable only on docker installations
     if [[ "${PIHOLE_DOCKER_TAG}" ]]; then
         addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${PIHOLE_DOCKER_TAG}"
     fi

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -84,4 +84,8 @@ else
     FTL_VERSION="$(pihole-FTL version)"
     addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
 
+    if [[ "${PIHOLE_DOCKER_TAG}" ]]; then
+        addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${PIHOLE_DOCKER_TAG}"
+    fi
+
 fi


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

First step towards making the `PIHOLE_DOCKER_TAG`  value more accessible. Only really used for the debug script. As it currently stands, if you run a debug log from the web interface on docker - the variable is not available to that environment and so the debug log is run as though it is a bare metal install.

The debug log script has been updated to read from `DOCKER_VERSION` in `/etc/pihole/versions` instead of the `PIHOLE_DOCKER_TAG) environment variable

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_