### PR TITLE
Update workflow python to 3.10 and allow any python3 version in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,10 @@ jobs:
       name: Checkout repository
       uses: actions/checkout@v3.0.2
     -
-      name: Set up Python 3.8
+      name: Set up Python 3.10
       uses: actions/setup-python@v4.2.0
       with:
-        python-version: 3.8
+        python-version: '3.10'
     -
       name: Install dependencies
       run: pip install -r test/requirements.txt

--- a/test/setup.py
+++ b/test/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
 
 setup(
+    py_modules=[],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
 )

--- a/test/tox.centos_8.ini
+++ b/test/tox.centos_8.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py3
 
 [testenv]
 whitelist_externals = docker

--- a/test/tox.debian_10.ini
+++ b/test/tox.debian_10.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py3
 
 [testenv]
 whitelist_externals = docker

--- a/test/tox.debian_11.ini
+++ b/test/tox.debian_11.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py3
 
 [testenv]
 whitelist_externals = docker

--- a/test/tox.fedora_34.ini
+++ b/test/tox.fedora_34.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py3
 
 [testenv]
 whitelist_externals = docker

--- a/test/tox.ubuntu_20.ini
+++ b/test/tox.ubuntu_20.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py3
 
 [testenv]
 whitelist_externals = docker

--- a/test/tox.ubuntu_22.ini
+++ b/test/tox.ubuntu_22.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py3
 
 [testenv]
 whitelist_externals = docker


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

1) Bumps the workflow `python` version to `3.10`
2) Set the `envlist`variable of the `tox` test to `py3` instead of `py3.8`. Tox now uses any `python3`.

Background: Recent OS (e.g. Ubnt 22) ship `python3.10` by default and `tox` does not run locally if `py38` is set as requirement.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
