### PR TITLE
Fixing texts forgotten after Blocking Page removal

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -815,7 +815,7 @@ check_x_headers() {
     # Similarly, it will show "X-Pi-hole: The Pi-hole Web interface is working!" if you view the header returned
     # when accessing the dashboard (i.e curl -I pi.hole/admin/)
     # server is operating correctly
-    echo_current_diagnostic "Dashboard and block page"
+    echo_current_diagnostic "Dashboard headers"
     # Use curl -I to get the header and parse out just the X-Pi-hole one
     local full_curl_output_dashboard
     local dashboard
@@ -825,7 +825,7 @@ check_x_headers() {
     local dashboard_working
     dashboard_working="X-Pi-hole: The Pi-hole Web interface is working!"
 
-    # Same logic applies to the dashboard as above, if the X-Header matches what a working system should have,
+    # If the X-Header matches what a working system should have,
     if [[ $dashboard == "$dashboard_working" ]]; then
         # then we can show a success
         log_write "$TICK Web interface X-Header: ${COL_GREEN}${dashboard}${COL_NC}"


### PR DESCRIPTION
### What does this PR aim to accomplish?

After Blocking Page removal the diagnostic only checks the dashboard headers.

This PR changes the diagnostic title and an old comment.

### How does this PR accomplish the above?

Changing the text to reflect the current functionality. 

### What documentation changes (if any) are needed to support this PR?

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
