### PR TITLE
Read docker tag from file in root, not the previously set environment variable

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -37,6 +37,8 @@ rm -f "/etc/pihole/localversions"
 VERSION_FILE="/etc/pihole/versions"
 touch "${VERSION_FILE}"
 chmod 644 "${VERSION_FILE}"
+# if /pihole.docker.tag file exists, we will use it's value later in this script
+DOCKER_TAG=$(cat file 2>/dev/null)
 
 if [[ "$2" == "remote" ]]; then
 
@@ -55,7 +57,7 @@ if [[ "$2" == "remote" ]]; then
     GITHUB_FTL_VERSION="$(curl -s 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null | jq --raw-output .tag_name)"
     addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_FTL_VERSION" "${GITHUB_FTL_VERSION}"
 
-    if [[ "${PIHOLE_DOCKER_TAG}" ]]; then
+    if [[ "${DOCKER_TAG}" ]]; then
         GITHUB_DOCKER_VERSION="$(curl -s 'https://api.github.com/repos/pi-hole/docker-pi-hole/releases/latest' 2> /dev/null | jq --raw-output .tag_name)"
         addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_DOCKER_VERSION" "${GITHUB_DOCKER_VERSION}"
     fi
@@ -84,9 +86,8 @@ else
     FTL_VERSION="$(pihole-FTL version)"
     addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
 
-    # PIHOLE_DOCKER_TAG is set as env variable only on docker installations
-    if [[ "${PIHOLE_DOCKER_TAG}" ]]; then
-        addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${PIHOLE_DOCKER_TAG}"
+    if [[ "${DOCKER_TAG}" ]]; then
+        addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${DOCKER_TAG}"
     fi
 
 fi

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -37,8 +37,14 @@ rm -f "/etc/pihole/localversions"
 VERSION_FILE="/etc/pihole/versions"
 touch "${VERSION_FILE}"
 chmod 644 "${VERSION_FILE}"
+
 # if /pihole.docker.tag file exists, we will use it's value later in this script
-DOCKER_TAG=$(cat file 2>/dev/null)
+DOCKER_TAG=$(cat /pihole.docker.tag 2>/dev/null)
+regex='^([0-9]+\.){1,2}(\*|[0-9]+)(-.*)?$|(^nightly$)|(^dev.*$)'
+if [[ ! "${DOCKER_TAG}" =~ $regex ]]; then
+  # DOCKER_TAG does not match the pattern (see https://regex101.com/r/RsENuz/1), so unset it.
+  unset DOCKER_TAG
+fi
 
 if [[ "$2" == "remote" ]]; then
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Changes required to reflect the changes made in https://github.com/pi-hole/docker-pi-hole/pull/1212

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_