### PR TITLE
Fix Deepsource.io warning message for index.php file

### DIFF
--- a/advanced/index.php
+++ b/advanced/index.php
@@ -29,7 +29,8 @@ if (!empty($_SERVER["FQDN"])) {
 if ($serverName === "pi.hole"
     || (!empty($_SERVER["VIRTUAL_HOST"]) && $serverName === $_SERVER["VIRTUAL_HOST"])) {
     // Redirect to Web Interface
-    exit(header("Location: /admin"));
+    header("Location: /admin");
+    exit();
 } elseif (filter_var($serverName, FILTER_VALIDATE_IP) || in_array($serverName, $authorizedHosts)) {
     // When directly browsing via IP or authorized hostname
     // Render splash/landing page based off presence of $landPage file
@@ -75,6 +76,6 @@ EOT;
     exit($splashPage);
 }
 
-exit(header("HTTP/1.1 404 Not Found"));
-
+header("HTTP/1.1 404 Not Found");
+exit();
 ?>


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix a warning received from Deepsource 

### How does this PR accomplish the above?

Fixing the code. `exit()` command accepts an optional `string` or an `integer`, but it was receiving `void`.
This is generally harmless, but fixed anyway.

### What documentation changes (if any) are needed to support this PR?

None

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
