### PR TITLE
Fix default DHCPv4 leasetime value

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -395,11 +395,6 @@ ProcessDHCPSettings() {
         elif [[ "${DHCP_LEASETIME}" == "" ]]; then
             leasetime="24h"
             addOrEditKeyValPair "${setupVars}" "DHCP_LEASETIME" "24"
-        elif [[ "${DHCP_LEASETIME}" == "24h" ]]; then
-            #Installation is affected by known bug, introduced in a previous version.
-            #This will automatically clean up setupVars.conf and remove the unnecessary "h"
-            leasetime="24h"
-            addOrEditKeyValPair "${setupVars}" "DHCP_LEASETIME" "24"
         else
             leasetime="${DHCP_LEASETIME}h"
         fi

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -393,13 +393,13 @@ ProcessDHCPSettings() {
         if [[ "${DHCP_LEASETIME}" == "0" ]]; then
             leasetime="infinite"
         elif [[ "${DHCP_LEASETIME}" == "" ]]; then
-            leasetime="24"
-            addOrEditKeyValPair "${setupVars}" "DHCP_LEASETIME" "${leasetime}"
+            leasetime="24h"
+            addOrEditKeyValPair "${setupVars}" "DHCP_LEASETIME" "24"
         elif [[ "${DHCP_LEASETIME}" == "24h" ]]; then
             #Installation is affected by known bug, introduced in a previous version.
             #This will automatically clean up setupVars.conf and remove the unnecessary "h"
-            leasetime="24"
-            addOrEditKeyValPair "${setupVars}" "DHCP_LEASETIME" "${leasetime}"
+            leasetime="24h"
+            addOrEditKeyValPair "${setupVars}" "DHCP_LEASETIME" "24"
         else
             leasetime="${DHCP_LEASETIME}h"
         fi


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Reported here: https://github.com/pi-hole/pi-hole/issues/4957

Originally introduced by myself back in 2017 😬https://github.com/pi-hole/pi-hole/pull/1646

Discussed indirectly here: https://github.com/pi-hole/pi-hole/issues/4142#issuecomment-827066762

This fixes it by ensuring that the `leasetime` local variable is set to a valid value before it is applied to the DHCP config. It is still stored in `setupVars.conf` as an integer value


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_