### PR TITLE
Simplify versions.sh

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -42,11 +42,6 @@ warning1() {
     esac
 }
 
-updateCheckFunc() {
-    /opt/pihole/updatecheck.sh
-    /opt/pihole/updatecheck.sh x remote
-}
-
 checkout() {
     local corebranches
     local webbranches
@@ -169,8 +164,8 @@ checkout() {
             exit 1
         fi
         checkout_pull_branch "${webInterfaceDir}" "${2}"
-        # Force an update of the updatechecker
-        updateCheckFunc
+        # Update local and remote versions via updatechecker
+        /opt/pihole/updatecheck.sh
     elif [[ "${1}" == "ftl" ]] ; then
         local path
         local oldbranch
@@ -185,8 +180,8 @@ checkout() {
             FTLinstall "${binary}"
             restart_service pihole-FTL
             enable_service pihole-FTL
-            # Force an update of the updatechecker
-            updateCheckFunc
+            # Update local and remote versions via updatechecker
+            /opt/pihole/updatecheck.sh
         else
             echo "  ${CROSS} Requested branch \"${2}\" is not available"
             ftlbranches=( $(git ls-remote https://github.com/pi-hole/ftl | grep 'heads' | sed 's/refs\/heads\///;s/ //g' | awk '{print $2}') )

--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -216,9 +216,8 @@ main() {
     fi
 
     if [[ "${FTL_update}" == true || "${core_update}" == true || "${web_update}" == true ]]; then
-        # Force an update of the updatechecker
+        # Update local and remote versions via updatechecker
         /opt/pihole/updatecheck.sh
-        /opt/pihole/updatecheck.sh x remote
         echo -e "  ${INFO} Local version file information updated."
     fi
 

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -20,6 +20,10 @@ function get_local_version() {
     git describe --long --dirty --tags 2> /dev/null || return 1
 }
 
+function get_remote_version() {
+    curl -s "https://api.github.com/repos/pi-hole/${1}/releases/latest" 2> /dev/null | jq --raw-output .tag_name || return 1
+}
+
 # Source the setupvars config file
 # shellcheck disable=SC1091
 . /etc/pihole/setupVars.conf
@@ -52,19 +56,19 @@ if [[ "$2" == "remote" ]]; then
         sleep 30
     fi
 
-    GITHUB_CORE_VERSION="$(curl -s 'https://api.github.com/repos/pi-hole/pi-hole/releases/latest' 2> /dev/null | jq --raw-output .tag_name)"
+    GITHUB_CORE_VERSION="$(get_remote_version pi-hole)"
     addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_VERSION" "${GITHUB_CORE_VERSION}"
 
     if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
-        GITHUB_WEB_VERSION="$(curl -s 'https://api.github.com/repos/pi-hole/AdminLTE/releases/latest' 2> /dev/null | jq --raw-output .tag_name)"
+        GITHUB_WEB_VERSION="$(get_remote_version AdminLTE)"
         addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_VERSION" "${GITHUB_WEB_VERSION}"
     fi
 
-    GITHUB_FTL_VERSION="$(curl -s 'https://api.github.com/repos/pi-hole/FTL/releases/latest' 2> /dev/null | jq --raw-output .tag_name)"
+    GITHUB_FTL_VERSION="$(get_remote_version FTL)"
     addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_FTL_VERSION" "${GITHUB_FTL_VERSION}"
 
     if [[ "${DOCKER_TAG}" ]]; then
-        GITHUB_DOCKER_VERSION="$(curl -s 'https://api.github.com/repos/pi-hole/docker-pi-hole/releases/latest' 2> /dev/null | jq --raw-output .tag_name)"
+        GITHUB_DOCKER_VERSION="$(get_remote_version docker-pi-hole)"
         addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_DOCKER_VERSION" "${GITHUB_DOCKER_VERSION}"
     fi
 

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -49,10 +49,8 @@ rm -f "/etc/pihole/localversions"
 
 # Create new versions file if it does not exist
 VERSION_FILE="/etc/pihole/versions"
-if [ ! -f ${VERSION_FILE} ]; then
-    touch "${VERSION_FILE}"
-    chmod 644 "${VERSION_FILE}"
-fi
+touch "${VERSION_FILE}"
+chmod 644 "${VERSION_FILE}"
 
 # if /pihole.docker.tag file exists, we will use it's value later in this script
 DOCKER_TAG=$(cat /pihole.docker.tag 2>/dev/null)
@@ -68,7 +66,10 @@ if [[ "$1" == "reboot" ]]; then
 fi
 
 
-# get local versions
+# get Core versions
+
+CORE_VERSION="$(get_local_version /etc/.pihole)"
+addOrEditKeyValPair "${VERSION_FILE}" "CORE_VERSION" "${CORE_VERSION}"
 
 CORE_BRANCH="$(get_local_branch /etc/.pihole)"
 addOrEditKeyValPair "${VERSION_FILE}" "CORE_BRANCH" "${CORE_BRANCH}"
@@ -76,13 +77,38 @@ addOrEditKeyValPair "${VERSION_FILE}" "CORE_BRANCH" "${CORE_BRANCH}"
 CORE_HASH="$(get_local_hash /etc/.pihole)"
 addOrEditKeyValPair "${VERSION_FILE}" "CORE_HASH" "${CORE_HASH}"
 
+GITHUB_CORE_VERSION="$(get_remote_version pi-hole)"
+addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_VERSION" "${GITHUB_CORE_VERSION}"
+
+GITHUB_CORE_HASH="$(get_remote_hash pi-hole "${CORE_BRANCH}")"
+addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_HASH" "${GITHUB_CORE_HASH}"
+
+
+# get Web versions
+
 if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
+
+    WEB_VERSION="$(get_local_version /var/www/html/admin)"
+    addOrEditKeyValPair "${VERSION_FILE}" "WEB_VERSION" "${WEB_VERSION}"
+
     WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
     addOrEditKeyValPair "${VERSION_FILE}" "WEB_BRANCH" "${WEB_BRANCH}"
 
     WEB_HASH="$(get_local_hash /var/www/html/admin)"
     addOrEditKeyValPair "${VERSION_FILE}" "WEB_HASH" "${WEB_HASH}"
+
+    GITHUB_WEB_VERSION="$(get_remote_version AdminLTE)"
+    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_VERSION" "${GITHUB_WEB_VERSION}"
+
+    GITHUB_WEB_HASH="$(get_remote_hash AdminLTE "${WEB_BRANCH}")"
+    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_HASH" "${GITHUB_WEB_HASH}"
+
 fi
+
+# get FTL versions
+
+FTL_VERSION="$(pihole-FTL version)"
+addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
 
 FTL_BRANCH="$(pihole-FTL branch)"
 addOrEditKeyValPair "${VERSION_FILE}" "FTL_BRANCH" "${FTL_BRANCH}"
@@ -90,45 +116,18 @@ addOrEditKeyValPair "${VERSION_FILE}" "FTL_BRANCH" "${FTL_BRANCH}"
 FTL_HASH="$(pihole-FTL -v | cut -d "-" -f2)"
 addOrEditKeyValPair "${VERSION_FILE}" "FTL_HASH" "${FTL_HASH}"
 
-CORE_VERSION="$(get_local_version /etc/.pihole)"
-addOrEditKeyValPair "${VERSION_FILE}" "CORE_VERSION" "${CORE_VERSION}"
-
-if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
-    WEB_VERSION="$(get_local_version /var/www/html/admin)"
-    addOrEditKeyValPair "${VERSION_FILE}" "WEB_VERSION" "${WEB_VERSION}"
-fi
-
-FTL_VERSION="$(pihole-FTL version)"
-addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
-
-if [[ "${DOCKER_TAG}" ]]; then
-    addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${DOCKER_TAG}"
-fi
-
-
-# get remote versions
-
-GITHUB_CORE_VERSION="$(get_remote_version pi-hole)"
-addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_VERSION" "${GITHUB_CORE_VERSION}"
-
-GITHUB_CORE_HASH="$(get_remote_hash pi-hole "${CORE_BRANCH}")"
-addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_HASH" "${GITHUB_CORE_HASH}"
-
-if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
-    GITHUB_WEB_VERSION="$(get_remote_version AdminLTE)"
-    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_VERSION" "${GITHUB_WEB_VERSION}"
-
-    GITHUB_WEB_HASH="$(get_remote_hash AdminLTE "${WEB_BRANCH}")"
-    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_HASH" "${GITHUB_WEB_HASH}"
-fi
-
 GITHUB_FTL_VERSION="$(get_remote_version FTL)"
 addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_FTL_VERSION" "${GITHUB_FTL_VERSION}"
 
 GITHUB_FTL_HASH="$(get_remote_hash FTL "${FTL_BRANCH}")"
 addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_FTL_HASH" "${GITHUB_FTL_HASH}"
 
+
+# get Docker versions
+
 if [[ "${DOCKER_TAG}" ]]; then
+    addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${DOCKER_TAG}"
+
     GITHUB_DOCKER_VERSION="$(get_remote_version docker-pi-hole)"
     addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_DOCKER_VERSION" "${GITHUB_DOCKER_VERSION}"
 fi

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -28,7 +28,7 @@ function get_remote_version() {
 # shellcheck disable=SC1091
 . /etc/pihole/setupVars.conf
 
-# Source the utils file
+# Source the utils file for addOrEditKeyValPair()
 # shellcheck disable=SC1091
 . /opt/pihole/utils.sh
 
@@ -50,54 +50,55 @@ if [[ ! "${DOCKER_TAG}" =~ $regex ]]; then
   unset DOCKER_TAG
 fi
 
-if [[ "$2" == "remote" ]]; then
-
-    if [[ "$3" == "reboot" ]]; then
+# used in cronjob
+if [[ "$1" == "reboot" ]]; then
         sleep 30
-    fi
+fi
 
-    GITHUB_CORE_VERSION="$(get_remote_version pi-hole)"
-    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_VERSION" "${GITHUB_CORE_VERSION}"
 
-    if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
-        GITHUB_WEB_VERSION="$(get_remote_version AdminLTE)"
-        addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_VERSION" "${GITHUB_WEB_VERSION}"
-    fi
+# get local versions
 
-    GITHUB_FTL_VERSION="$(get_remote_version FTL)"
-    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_FTL_VERSION" "${GITHUB_FTL_VERSION}"
+CORE_BRANCH="$(get_local_branch /etc/.pihole)"
+addOrEditKeyValPair "${VERSION_FILE}" "CORE_BRANCH" "${CORE_BRANCH}"
 
-    if [[ "${DOCKER_TAG}" ]]; then
-        GITHUB_DOCKER_VERSION="$(get_remote_version docker-pi-hole)"
-        addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_DOCKER_VERSION" "${GITHUB_DOCKER_VERSION}"
-    fi
+if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
+    WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
+    addOrEditKeyValPair "${VERSION_FILE}" "WEB_BRANCH" "${WEB_BRANCH}"
+fi
 
-else
+FTL_BRANCH="$(pihole-FTL branch)"
+addOrEditKeyValPair "${VERSION_FILE}" "FTL_BRANCH" "${FTL_BRANCH}"
 
-    CORE_BRANCH="$(get_local_branch /etc/.pihole)"
-    addOrEditKeyValPair "${VERSION_FILE}" "CORE_BRANCH" "${CORE_BRANCH}"
+CORE_VERSION="$(get_local_version /etc/.pihole)"
+addOrEditKeyValPair "${VERSION_FILE}" "CORE_VERSION" "${CORE_VERSION}"
 
-    if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
-        WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
-        addOrEditKeyValPair "${VERSION_FILE}" "WEB_BRANCH" "${WEB_BRANCH}"
-    fi
+if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
+    WEB_VERSION="$(get_local_version /var/www/html/admin)"
+    addOrEditKeyValPair "${VERSION_FILE}" "WEB_VERSION" "${WEB_VERSION}"
+fi
 
-    FTL_BRANCH="$(pihole-FTL branch)"
-    addOrEditKeyValPair "${VERSION_FILE}" "FTL_BRANCH" "${FTL_BRANCH}"
+FTL_VERSION="$(pihole-FTL version)"
+addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
 
-    CORE_VERSION="$(get_local_version /etc/.pihole)"
-    addOrEditKeyValPair "${VERSION_FILE}" "CORE_VERSION" "${CORE_VERSION}"
+if [[ "${DOCKER_TAG}" ]]; then
+    addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${DOCKER_TAG}"
+fi
 
-    if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
-        WEB_VERSION="$(get_local_version /var/www/html/admin)"
-        addOrEditKeyValPair "${VERSION_FILE}" "WEB_VERSION" "${WEB_VERSION}"
-    fi
 
-    FTL_VERSION="$(pihole-FTL version)"
-    addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
+# get remote versions
 
-    if [[ "${DOCKER_TAG}" ]]; then
-        addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${DOCKER_TAG}"
-    fi
+GITHUB_CORE_VERSION="$(get_remote_version pi-hole)"
+addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_VERSION" "${GITHUB_CORE_VERSION}"
 
+if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
+    GITHUB_WEB_VERSION="$(get_remote_version AdminLTE)"
+    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_VERSION" "${GITHUB_WEB_VERSION}"
+fi
+
+GITHUB_FTL_VERSION="$(get_remote_version FTL)"
+addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_FTL_VERSION" "${GITHUB_FTL_VERSION}"
+
+if [[ "${DOCKER_TAG}" ]]; then
+    GITHUB_DOCKER_VERSION="$(get_remote_version docker-pi-hole)"
+    addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_DOCKER_VERSION" "${GITHUB_DOCKER_VERSION}"
 fi

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -49,8 +49,10 @@ rm -f "/etc/pihole/localversions"
 
 # Create new versions file if it does not exist
 VERSION_FILE="/etc/pihole/versions"
-touch "${VERSION_FILE}"
-chmod 644 "${VERSION_FILE}"
+if [ ! -f ${VERSION_FILE} ]; then
+    touch "${VERSION_FILE}"
+    chmod 644 "${VERSION_FILE}"
+fi
 
 # if /pihole.docker.tag file exists, we will use it's value later in this script
 DOCKER_TAG=$(cat /pihole.docker.tag 2>/dev/null)

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -12,14 +12,14 @@
 # shellcheck disable=SC1091
 . /etc/pihole/setupVars.conf
 
-# Sourece the versions file poupulated by updatechecker.sh
+# Source the versions file poupulated by updatechecker.sh
 cachedVersions="/etc/pihole/versions"
 
 if [ -f ${cachedVersions} ]; then
     # shellcheck disable=SC1090
     . "$cachedVersions"
 else
-    echo "Could not find /etc/pihole/versons. Exiting."
+    echo "Could not find /etc/pihole/versions. Exiting."
     exit 1
 fi
 
@@ -113,7 +113,7 @@ defaultOutput() {
 }
 
 helpFunc() {
-    echo "Usage: piho && lle -v [repo | option] [option]
+    echo "Usage: pihole -v [repo | option] [option]
 Example: 'pihole -v -p -l'
 Show Pi-hole, Admin Console & FTL versions
 

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 # Pi-hole: A black hole for Internet advertisements
 # (c) 2017 Pi-hole, LLC (https://pi-hole.net)
 # Network-wide ad blocking via your own hardware.
@@ -10,7 +10,7 @@
 
 # Source the setupvars config file
 # shellcheck disable=SC1091
-source /etc/pihole/setupVars.conf
+. /etc/pihole/setupVars.conf
 
 # Sourece the versions file poupulated by updatechecker.sh
 cachedVersions="/etc/pihole/versions"
@@ -25,81 +25,76 @@ fi
 
 getLocalVersion() {
     case ${1} in
-        "pi-hole"   )  echo "${CORE_VERSION}";;
-        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${WEB_VERSION}";;
+        "Pi-hole"   )  echo "${CORE_VERSION}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_VERSION}";;
         "FTL"       )  echo "${FTL_VERSION}";;
     esac
-    return 0
 }
 
 getLocalHash() {
     case ${1} in
-        "pi-hole"   )  echo "${CORE_HASH}";;
-        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${WEB_HASH}";;
+        "Pi-hole"   )  echo "${CORE_HASH}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_HASH}";;
         "FTL"       )  echo "${FTL_HASH}";;
     esac
-    return 0
 }
 
 getRemoteHash(){
     case ${1} in
-        "pi-hole"   )  echo "${GITHUB_CORE_HASH}";;
-        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${GITHUB_WEB_HASH}";;
+        "Pi-hole"   )  echo "${GITHUB_CORE_HASH}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${GITHUB_WEB_HASH}";;
         "FTL"       )  echo "${GITHUB_FTL_HASH}";;
     esac
-    return 0
 }
 
 getRemoteVersion(){
     case ${1} in
-        "pi-hole"   )  echo "${GITHUB_CORE_VERSION}";;
-        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${GITHUB_WEB_VERSION}";;
+        "Pi-hole"   )  echo "${GITHUB_CORE_VERSION}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${GITHUB_WEB_VERSION}";;
         "FTL"       )  echo "${GITHUB_FTL_VERSION}";;
     esac
-    return 0
 }
 
 getLocalBranch(){
     case ${1} in
-        "pi-hole"   )  echo "${CORE_BRANCH}";;
-        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${WEB_BRANCH}";;
+        "Pi-hole"   )  echo "${CORE_BRANCH}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_BRANCH}";;
         "FTL"       )  echo "${FTL_BRANCH}";;
     esac
-    return 0
 }
 
 versionOutput() {
-    if [[ "$1" == "AdminLTE" && "${INSTALL_WEB_INTERFACE}" != true ]]; then
+    if [ "$1" = "AdminLTE" ] && [ "${INSTALL_WEB_INTERFACE}" != true ]; then
         echo "  WebAdmin not installed"
         return 1
     fi
 
-    [[ "$2" == "-c" ]] || [[ "$2" == "--current" ]] || [[ -z "$2" ]] && current=$(getLocalVersion "${1}") && branch=$(getLocalBranch "${1}")
-    [[ "$2" == "-l" ]] || [[ "$2" == "--latest" ]] || [[ -z "$2" ]] && latest=$(getRemoteVersion "${1}")
-    if [[ "$2" == "-h" ]] || [[ "$2" == "--hash" ]]; then
-        [[ "$3" == "-c" ]] || [[ "$3" == "--current" ]] || [[ -z "$3" ]] && curHash=$(getLocalHash "${1}") && branch=$(getLocalBranch "${1}")
-        [[ "$3" == "-l" ]] || [[ "$3" == "--latest" ]] || [[ -z "$3" ]] && latHash=$(getRemoteHash "${1}")
+    [ "$2" = "-c" ] || [ "$2" = "--current" ] || [ -z "$2" ] && current=$(getLocalVersion "${1}") && branch=$(getLocalBranch "${1}")
+    [ "$2" = "-l" ] || [ "$2" = "--latest" ] || [ -z "$2" ] && latest=$(getRemoteVersion "${1}")
+    if [ "$2" = "--hash" ]; then
+        [ "$3" = "-c" ] || [ "$3" = "--current" ] || [ -z "$3" ] && curHash=$(getLocalHash "${1}") && branch=$(getLocalBranch "${1}")
+        [ "$3" = "-l" ] || [ "$3" = "--latest" ] || [ -z "$3" ] && latHash=$(getRemoteHash "${1}")
     fi
-    if [[ -n "$current" ]] && [[ -n "$latest" ]]; then
-        output="${1^} version is $branch $current (Latest: $latest)"
-    elif [[ -n "$current" ]] && [[ -z "$latest" ]]; then
-        output="Current ${1^} version is $branch $current (Latest: N/A)"
-    elif [[ -z "$current" ]] && [[ -n "$latest" ]]; then
-        output="Latest ${1^} version is $latest (Current: N/A)"
-    elif [[ -z "$curHash" ]] && [[ -z "$latHash" ]]; then
-        output="No hash info available"
-    elif [[ -n "$curHash" ]] && [[ -n "$latHash" ]]; then
-        output="Local ${1^} hash of branch $branch is $curHash (Remote: $latHash)"
-    elif [[ -n "$curHash" ]] && [[ -z "$latHash" ]]; then
-        output="Current local ${1^} hash of branch $branch is $curHash (Remote: N/A)"
-    elif [[ -z "$curHash" ]] && [[ -n "$latHash" ]]; then
-        output="Latest remote ${1^} hash of branch $branch is $latHash (Local: N/A)"
+    if [ -n "$current" ] && [ -n "$latest" ]; then
+        output="${1} version is $branch $current (Latest: $latest)"
+    elif [ -n "$current" ] && [ -z "$latest" ]; then
+        output="Current ${1} version is $branch $current"
+    elif [ -z "$current" ] && [ -n "$latest" ]; then
+        output="Latest ${1} version is $latest"
+    elif [ -n "$curHash" ] && [ -n "$latHash" ]; then
+        output="Local ${1} hash of branch $branch is $curHash (Remote: $latHash)"
+    elif [ -n "$curHash" ] && [ -z "$latHash" ]; then
+        output="Current local ${1} hash of branch $branch is $curHash"
+    elif [ -z "$curHash" ] && [ -n "$latHash" ]; then
+        output="Latest remote ${1} hash of branch $branch is $latHash"
+    elif [ -z "$curHash" ] && [ -z "$latHash" ]; then
+        output="Hashes for ${1} not available"
     else
         errorOutput
         return 1
     fi
 
-    [[ -n "$output" ]] && echo "  $output"
+    [ -n "$output" ] && echo "  $output"
 }
 
 errorOutput() {
@@ -108,9 +103,9 @@ errorOutput() {
 }
 
 defaultOutput() {
-    versionOutput "pi-hole" "$@"
+    versionOutput "Pi-hole" "$@"
 
-    if [[ "${INSTALL_WEB_INTERFACE}" == true ]]; then
+    if [ "${INSTALL_WEB_INTERFACE}" = true ]; then
         versionOutput "AdminLTE" "$@"
     fi
 
@@ -118,7 +113,7 @@ defaultOutput() {
 }
 
 helpFunc() {
-    echo "Usage: pihole -v [repo | option] [option]
+    echo "Usage: piho && lle -v [repo | option] [option]
 Example: 'pihole -v -p -l'
 Show Pi-hole, Admin Console & FTL versions
 
@@ -136,7 +131,7 @@ Options:
 }
 
 case "${1}" in
-    "-p" | "--pihole"    ) shift; versionOutput "pi-hole" "$@";;
+    "-p" | "--pihole"    ) shift; versionOutput "Pi-hole" "$@";;
     "-a" | "--admin"     ) shift; versionOutput "AdminLTE" "$@";;
     "-f" | "--ftl"       ) shift; versionOutput "FTL" "$@";;
     "-h" | "--help"      ) helpFunc;;

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -8,140 +8,63 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
-# Variables
-DEFAULT="-1"
-COREGITDIR="/etc/.pihole/"
-WEBGITDIR="/var/www/html/admin/"
-
 # Source the setupvars config file
 # shellcheck disable=SC1091
 source /etc/pihole/setupVars.conf
 
+# Sourece the versions file poupulated by updatechecker.sh
+cachedVersions="/etc/pihole/versions"
+
+if [ -f ${cachedVersions} ]; then
+    # shellcheck disable=SC1090
+    . "$cachedVersions"
+else
+    echo "Could not find /etc/pihole/versons. Exiting."
+    exit 1
+fi
+
 getLocalVersion() {
-    # FTL requires a different method
-    if [[ "$1" == "FTL" ]]; then
-        pihole-FTL version
-        return 0
-    fi
-
-    # Get the tagged version of the local repository
-    local directory="${1}"
-    local version
-
-    cd "${directory}" 2> /dev/null || { echo "${DEFAULT}"; return 1; }
-    version=$(git describe --tags --always || echo "$DEFAULT")
-    if [[ "${version}" =~ ^v ]]; then
-        echo "${version}"
-    elif [[ "${version}" == "${DEFAULT}" ]]; then
-        echo "ERROR"
-        return 1
-    else
-        echo "Untagged"
-    fi
+    case ${1} in
+        "pi-hole"   )  echo "${CORE_VERSION}";;
+        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${WEB_VERSION}";;
+        "FTL"       )  echo "${FTL_VERSION}";;
+    esac
     return 0
 }
 
 getLocalHash() {
-    # Local FTL hash does not exist on filesystem
-    if [[ "$1" == "FTL" ]]; then
-        echo "N/A"
-        return 0
-    fi
-
-    # Get the short hash of the local repository
-    local directory="${1}"
-    local hash
-
-    cd "${directory}" 2> /dev/null || { echo "${DEFAULT}"; return 1; }
-    hash=$(git rev-parse --short HEAD || echo "$DEFAULT")
-    if [[ "${hash}" == "${DEFAULT}" ]]; then
-        echo "ERROR"
-        return 1
-    else
-        echo "${hash}"
-    fi
+    case ${1} in
+        "pi-hole"   )  echo "${CORE_HASH}";;
+        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${WEB_HASH}";;
+        "FTL"       )  echo "${FTL_HASH}";;
+    esac
     return 0
 }
 
 getRemoteHash(){
-    # Remote FTL hash is not applicable
-    if [[ "$1" == "FTL" ]]; then
-        echo "N/A"
-        return 0
-    fi
-
-    local daemon="${1}"
-    local branch="${2}"
-
-    hash=$(git ls-remote --heads "https://github.com/pi-hole/${daemon}" | \
-        awk -v bra="$branch" '$0~bra {print substr($0,0,8);exit}')
-    if [[ -n "$hash" ]]; then
-        echo "$hash"
-    else
-        echo "ERROR"
-        return 1
-    fi
+    case ${1} in
+        "pi-hole"   )  echo "${GITHUB_CORE_HASH}";;
+        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${GITHUB_WEB_HASH}";;
+        "FTL"       )  echo "${GITHUB_FTL_HASH}";;
+    esac
     return 0
 }
 
 getRemoteVersion(){
-    # Get the version from the remote origin
-    local daemon="${1}"
-    local version
-    local cachedVersions
-    cachedVersions="/etc/pihole/versions"
-
-    #If the above file exists, then we can read from that. Prevents overuse of GitHub API
-    if [[ -f "$cachedVersions" ]]; then
-
-        # shellcheck disable=SC1090
-        . "$cachedVersions"
-
-        case $daemon in
-            "pi-hole"   )  echo "${GITHUB_CORE_VERSION}";;
-            "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${GITHUB_WEB_VERSION}";;
-            "FTL"       )  echo "${GITHUB_FTL_VERSION}";;
-        esac
-
-        return 0
-    fi
-
-    version=$(curl --silent --fail "https://api.github.com/repos/pi-hole/${daemon}/releases/latest" | \
-        awk -F: '$1 ~/tag_name/ { print $2 }' | \
-        tr -cd '[[:alnum:]]._-')
-    if [[ "${version}" =~ ^v ]]; then
-        echo "${version}"
-    else
-        echo "ERROR"
-        return 1
-    fi
+    case ${1} in
+        "pi-hole"   )  echo "${GITHUB_CORE_VERSION}";;
+        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${GITHUB_WEB_VERSION}";;
+        "FTL"       )  echo "${GITHUB_FTL_VERSION}";;
+    esac
     return 0
 }
 
 getLocalBranch(){
-    # Get the checked out branch of the local directory
-    local directory="${1}"
-    local branch
-
-    # Local FTL btranch is stored in /etc/pihole/ftlbranch
-    if [[ "$1" == "FTL" ]]; then
-        branch="$(pihole-FTL branch)"
-    else
-        cd "${directory}" 2> /dev/null || { echo "${DEFAULT}"; return 1; }
-        branch=$(git rev-parse --abbrev-ref HEAD || echo "$DEFAULT")
-    fi
-    if [[ ! "${branch}" =~ ^v ]]; then
-        if [[ "${branch}" == "master" ]]; then
-            echo ""
-        elif [[ "${branch}" == "HEAD" ]]; then
-            echo "in detached HEAD state at "
-        else
-            echo "${branch} "
-        fi
-    else
-        # Branch started in "v"
-        echo "release "
-    fi
+    case ${1} in
+        "pi-hole"   )  echo "${CORE_BRANCH}";;
+        "AdminLTE"  )  [[ "${INSTALL_WEB_INTERFACE}" == true ]] && echo "${WEB_BRANCH}";;
+        "FTL"       )  echo "${FTL_BRANCH}";;
+    esac
     return 0
 }
 
@@ -151,30 +74,26 @@ versionOutput() {
         return 1
     fi
 
-    [[ "$1" == "pi-hole" ]] && GITDIR=$COREGITDIR
-    [[ "$1" == "AdminLTE" ]] && GITDIR=$WEBGITDIR
-    [[ "$1" == "FTL" ]] && GITDIR="FTL"
-
-    [[ "$2" == "-c" ]] || [[ "$2" == "--current" ]] || [[ -z "$2" ]] && current=$(getLocalVersion $GITDIR) && branch=$(getLocalBranch $GITDIR)
-    [[ "$2" == "-l" ]] || [[ "$2" == "--latest" ]] || [[ -z "$2" ]] && latest=$(getRemoteVersion "$1")
+    [[ "$2" == "-c" ]] || [[ "$2" == "--current" ]] || [[ -z "$2" ]] && current=$(getLocalVersion "${1}") && branch=$(getLocalBranch "${1}")
+    [[ "$2" == "-l" ]] || [[ "$2" == "--latest" ]] || [[ -z "$2" ]] && latest=$(getRemoteVersion "${1}")
     if [[ "$2" == "-h" ]] || [[ "$2" == "--hash" ]]; then
-        [[ "$3" == "-c" ]] || [[ "$3" == "--current" ]] || [[ -z "$3" ]] && curHash=$(getLocalHash "$GITDIR") && branch=$(getLocalBranch $GITDIR)
-        [[ "$3" == "-l" ]] || [[ "$3" == "--latest" ]] || [[ -z "$3" ]] && latHash=$(getRemoteHash "$1" "$(cd "$GITDIR" 2> /dev/null && git rev-parse --abbrev-ref HEAD)")
+        [[ "$3" == "-c" ]] || [[ "$3" == "--current" ]] || [[ -z "$3" ]] && curHash=$(getLocalHash "${1}") && branch=$(getLocalBranch "${1}")
+        [[ "$3" == "-l" ]] || [[ "$3" == "--latest" ]] || [[ -z "$3" ]] && latHash=$(getRemoteHash "${1}")
     fi
     if [[ -n "$current" ]] && [[ -n "$latest" ]]; then
-        output="${1^} version is $branch$current (Latest: $latest)"
+        output="${1^} version is $branch $current (Latest: $latest)"
     elif [[ -n "$current" ]] && [[ -z "$latest" ]]; then
-        output="Current ${1^} version is $branch$current"
+        output="Current ${1^} version is $branch $current (Latest: N/A)"
     elif [[ -z "$current" ]] && [[ -n "$latest" ]]; then
-        output="Latest ${1^} version is $latest"
-    elif [[ "$curHash" == "N/A" ]] || [[ "$latHash" == "N/A" ]]; then
-        output="${1^} hash is not applicable"
+        output="Latest ${1^} version is $latest (Current: N/A)"
+    elif [[ -z "$curHash" ]] && [[ -z "$latHash" ]]; then
+        output="No hash info available"
     elif [[ -n "$curHash" ]] && [[ -n "$latHash" ]]; then
-        output="${1^} hash is $curHash (Latest: $latHash)"
+        output="Local ${1^} hash of branch $branch is $curHash (Remote: $latHash)"
     elif [[ -n "$curHash" ]] && [[ -z "$latHash" ]]; then
-        output="Current ${1^} hash is $curHash"
+        output="Current local ${1^} hash of branch $branch is $curHash (Remote: N/A)"
     elif [[ -z "$curHash" ]] && [[ -n "$latHash" ]]; then
-        output="Latest ${1^} hash is $latHash"
+        output="Latest remote ${1^} hash of branch $branch is $latHash (Local: N/A)"
     else
         errorOutput
         return 1

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -25,41 +25,41 @@ fi
 
 getLocalVersion() {
     case ${1} in
-        "Pi-hole"   )  echo "${CORE_VERSION}";;
-        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_VERSION}";;
-        "FTL"       )  echo "${FTL_VERSION}";;
+        "Pi-hole"   )  echo "${CORE_VERSION:=N/A}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_VERSION:=N/A}";;
+        "FTL"       )  echo "${FTL_VERSION:=N/A}";;
     esac
 }
 
 getLocalHash() {
     case ${1} in
-        "Pi-hole"   )  echo "${CORE_HASH}";;
-        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_HASH}";;
-        "FTL"       )  echo "${FTL_HASH}";;
+        "Pi-hole"   )  echo "${CORE_HASH:=N/A}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_HASH:=N/A}";;
+        "FTL"       )  echo "${FTL_HASH:=N/A}";;
     esac
 }
 
 getRemoteHash(){
     case ${1} in
-        "Pi-hole"   )  echo "${GITHUB_CORE_HASH}";;
-        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${GITHUB_WEB_HASH}";;
-        "FTL"       )  echo "${GITHUB_FTL_HASH}";;
+        "Pi-hole"   )  echo "${GITHUB_CORE_HASH:=N/A}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${GITHUB_WEB_HASH:=N/A}";;
+        "FTL"       )  echo "${GITHUB_FTL_HASH:=N/A}";;
     esac
 }
 
 getRemoteVersion(){
     case ${1} in
-        "Pi-hole"   )  echo "${GITHUB_CORE_VERSION}";;
-        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${GITHUB_WEB_VERSION}";;
-        "FTL"       )  echo "${GITHUB_FTL_VERSION}";;
+        "Pi-hole"   )  echo "${GITHUB_CORE_VERSION:=N/A}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${GITHUB_WEB_VERSION:=N/A}";;
+        "FTL"       )  echo "${GITHUB_FTL_VERSION:=N/A}";;
     esac
 }
 
 getLocalBranch(){
     case ${1} in
-        "Pi-hole"   )  echo "${CORE_BRANCH}";;
-        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_BRANCH}";;
-        "FTL"       )  echo "${FTL_BRANCH}";;
+        "Pi-hole"   )  echo "${CORE_BRANCH:=N/A}";;
+        "AdminLTE"  )  [ "${INSTALL_WEB_INTERFACE}" = true ] && echo "${WEB_BRANCH:=N/A}";;
+        "FTL"       )  echo "${FTL_BRANCH:=N/A}";;
     esac
 }
 
@@ -73,7 +73,7 @@ versionOutput() {
     [ "$2" = "-l" ] || [ "$2" = "--latest" ] || [ -z "$2" ] && latest=$(getRemoteVersion "${1}")
     if [ "$2" = "--hash" ]; then
         [ "$3" = "-c" ] || [ "$3" = "--current" ] || [ -z "$3" ] && curHash=$(getLocalHash "${1}") && branch=$(getLocalBranch "${1}")
-        [ "$3" = "-l" ] || [ "$3" = "--latest" ] || [ -z "$3" ] && latHash=$(getRemoteHash "${1}")
+        [ "$3" = "-l" ] || [ "$3" = "--latest" ] || [ -z "$3" ] && latHash=$(getRemoteHash "${1}") && branch=$(getLocalBranch "${1}")
     fi
     if [ -n "$current" ] && [ -n "$latest" ]; then
         output="${1} version is $branch $current (Latest: $latest)"

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -19,8 +19,10 @@ if [ -f ${cachedVersions} ]; then
     # shellcheck disable=SC1090
     . "$cachedVersions"
 else
-    echo "Could not find /etc/pihole/versions. Exiting."
-    exit 1
+    echo "Could not find /etc/pihole/versions. Running update now."
+    pihole updatechecker
+    # shellcheck disable=SC1090
+    . "$cachedVersions"
 fi
 
 getLocalVersion() {

--- a/advanced/Templates/pihole.cron
+++ b/advanced/Templates/pihole.cron
@@ -28,6 +28,6 @@
 
 @reboot root /usr/sbin/logrotate --state /var/lib/logrotate/pihole /etc/pihole/logrotate
 
-# Pi-hole: Grab remote version every 24 hours
-59 17  * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker remote
-@reboot root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker remote reboot
+# Pi-hole: Grab remote and local version every 24 hours
+59 17  * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker
+@reboot root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker reboot

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2694,9 +2694,8 @@ main() {
     # Download and compile the aggregated block list
     runGravity
 
-    # Force an update of the updatechecker
+    # Update local and remote versions via updatechecker
     /opt/pihole/updatecheck.sh
-    /opt/pihole/updatecheck.sh x remote
 
     if [[ "${useUpdateVars}" == false ]]; then
         displayFinalMessage "${pw}"


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Simplifies `version.sh`. Rationale: PR https://github.com/pi-hole/pi-hole/pull/4663 removed the need for `sudo` powers if `pihole -v` is called. However, this leads to issues with newer `git` versions (seen in https://github.com/pi-hole/pi-hole/issues/4759) as `version.sh` uses some `git` commands to get the local version and branches. Without `sudo`, `git` complains now about `fatal: unsafe repository ('/var/www/html/admin' is owned by someone else)`. 
Since PR https://github.com/pi-hole/pi-hole/pull/4875 we store local and remote version (and branch) info in `/etc/pihole/versions`. This PR moves the remaining functions from `version.sh` to `updatechecker.sh`. The latter is always called with `sudo` powers and therefore does not run into the described `git` issue. The remaining `version.sh` does nothing else than to print the requested output of `/etc/pihole/versions`.

Fixes: https://github.com/pi-hole/pi-hole/issues/4759


- **How does this PR accomplish the above?:**

1. Add a new function `get_remote_version()` to `updatechecker.sh`
2. Removes the distinction between updating the remote and local info from `updatechecker`. That way, we can be sure, that the local branch is updated before we get the remote hash of the the current branch. If you look at the current code, there was only one occurrence where `local` and `remote` were not called consecutively: the daily cron job. We just agreed to remove the local update from the cron job (https://github.com/pi-hole/pi-hole/pull/4939), but this was about updating every 10 minutes. I think updating once every 24h should be fine. We already ensure that `updatechecker` is called at every relevant place: after a fresh install, after each `pihole -up` and after each `checkout`.
3. Move the `hash` functions to `updatechecker.sh`
4. Let `pihole -v` gather everything from `/etc/pihole/versions`

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
5. I have commented my proposed changes within the code and I have tested my changes.
6. I am willing to help maintain this change if there are issues with it later.
7. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
8. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
