### PR TITLE
Fix `pihole -r` dialog exit

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2022,9 +2022,8 @@ update_dialogs() {
 \\n($strAdd)"\
                     "${r}" "${c}" 2 \
     "${opt1a}"  "${opt1b}" \
-    "${opt2a}"  "${opt2b}" || true)
+    "${opt2a}"  "${opt2b}") || result=$?
 
-    result=$?
     case ${result} in
         "${DIALOG_CANCEL}" | "${DIALOG_ESC}")
             printf "  %b Cancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"


### PR DESCRIPTION
### What does this PR aim to accomplish?

This PR fixes an error that happens if an user starts a repair (`pihole -r`) and decides to select **exit** option or press <kbd>ESC</kbd>. The script should exit, but it simply continues.

### How does this PR accomplish the above?

Removing `|| true` from the code.

### What documentation changes (if any) are needed to support this PR?

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
