### PR TITLE
Add initscripts to CentOS8 dockerfile

### DIFF
--- a/test/_centos_8.Dockerfile
+++ b/test/_centos_8.Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/centos/centos:stream8
-RUN yum install -y git
+RUN yum install -y git initscripts
 
 ENV GITDIR /etc/.pihole
 ENV SCRIPTDIR /opt/pihole


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Fixes the current failing tests for all PRs on CentOS 8 Steam which end with

```
[\xe2\x9c\x97] /usr/local/bin/pihole: line 150: service: command not found\n\n  [\xe2\x9c\x97] DNS service is NOT running\
```

Background is likely the same as in https://github.com/pi-hole/pi-hole/pull/4952#issuecomment-1262843403.

However, I have no idea why the test start failing now - two days ago they worked fine.

- **How does this PR accomplish the above?:**

Add `initscripts` to the dockerfile


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
