### PR TITLE
Remove check for latest component version in debug log

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -238,14 +238,19 @@ compare_local_version_to_git_version() {
     local git_dir="${1}"
     # The named component of the project (Core or Web)
     local pihole_component="${2}"
+
     # If we are checking the Core versions,
     if [[ "${pihole_component}" == "Core" ]]; then
-        # set the github repo name
-        local repo_name="pi-hole"
+        local remote_version
+        # remote version is taken from /etc/pihole/versions (sourced above)
+        remote_version="${GITHUB_CORE_VERSION}"
     elif [[ "${pihole_component}" == "Web" ]]; then
-        # set the github repo name
-        #shellcheck disable=2034
-        local repo_name="adminlte"
+        local remote_version
+        # remote version is taken from /etc/pihole/versions (sourced above)
+        remote_version="${GITHUB_WEB_VERSION}"
+    fi
+    if [ -z "${remote_version}" ]; then
+        remote_version="N/A"
     fi
     # Display what we are checking
     echo_current_diagnostic "${pihole_component} version"
@@ -270,8 +275,6 @@ compare_local_version_to_git_version() {
             # Status of the repo
             local local_status
             local_status=$(git status -s)
-            local remote_version
-            remote_version=$(curl -s "https://api.github.com/repos/pi-hole/${repo_name}/releases/latest" 2> /dev/null | jq --raw-output .tag_name)
             # echo this information out to the user in a nice format
             # If the current version matches the latest tag, the user is up-to-date
             if [[ "${local_version}" == "${remote_version}" ]]; then
@@ -338,7 +341,11 @@ check_ftl_version() {
     FTL_BRANCH=$(pihole-FTL -vv | grep -m 1 Branch | awk '{printf $2}')
     FTL_COMMIT=$(pihole-FTL -vv | grep -m 1 Commit | awk '{printf $2}')
 
-    remote_version=$(curl -s 'https://api.github.com/repos/pi-hole/ftl/releases/latest' 2> /dev/null | jq --raw-output .tag_name)
+    # remote version is taken from /etc/pihole/versions (sourced above)
+    remote_version="${GITHUB_FTL_VERSION}"
+    if [ -z "${remote_version}" ]; then
+        remote_version="N/A"
+    fi
 
     # Compare the current FTL version to the remote version
     if [[ "${FTL_VERSION}" == "${remote_version}" ]]; then

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -47,7 +47,6 @@ fi
 OBFUSCATED_PLACEHOLDER="<DOMAIN OBFUSCATED>"
 
 # FAQ URLs for use in showing the debug log
-FAQ_UPDATE_PI_HOLE="${COL_CYAN}https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249${COL_NC}"
 FAQ_HARDWARE_REQUIREMENTS="${COL_CYAN}https://docs.pi-hole.net/main/prerequisites/${COL_NC}"
 FAQ_HARDWARE_REQUIREMENTS_PORTS="${COL_CYAN}https://docs.pi-hole.net/main/prerequisites/#ports${COL_NC}"
 FAQ_HARDWARE_REQUIREMENTS_FIREWALLD="${COL_CYAN}https://docs.pi-hole.net/main/prerequisites/#firewalld${COL_NC}"
@@ -239,19 +238,6 @@ compare_local_version_to_git_version() {
     # The named component of the project (Core or Web)
     local pihole_component="${2}"
 
-    # If we are checking the Core versions,
-    if [[ "${pihole_component}" == "Core" ]]; then
-        local remote_version
-        # remote version is taken from /etc/pihole/versions (sourced above)
-        remote_version="${GITHUB_CORE_VERSION}"
-    elif [[ "${pihole_component}" == "Web" ]]; then
-        local remote_version
-        # remote version is taken from /etc/pihole/versions (sourced above)
-        remote_version="${GITHUB_WEB_VERSION}"
-    fi
-    if [ -z "${remote_version}" ]; then
-        remote_version="N/A"
-    fi
     # Display what we are checking
     echo_current_diagnostic "${pihole_component} version"
     # Store the error message in a variable in case we want to change and/or reuse it
@@ -276,15 +262,7 @@ compare_local_version_to_git_version() {
             local local_status
             local_status=$(git status -s)
             # echo this information out to the user in a nice format
-            # If the current version matches the latest tag, the user is up-to-date
-            if [[ "${local_version}" == "${remote_version}" ]]; then
-                log_write "${TICK} Version: ${COL_GREEN}${local_version}${COL_NC} [Latest: ${remote_version}]"
-            # If not,
-            else
-                # echo the current version in yellow, signifying it's something to take a look at, but not a critical error
-                # Also add a URL to an FAQ
-                log_write "${INFO} Version: ${COL_YELLOW}${local_version:-Untagged}${COL_NC} [Latest: ${remote_version}] (${FAQ_UPDATE_PI_HOLE})"
-            fi
+            log_write "${TICK} Version: ${local_version}"
 
             # Print the repo upstreams
             remotes=$(git remote -v)
@@ -334,27 +312,15 @@ compare_local_version_to_git_version() {
 }
 
 check_ftl_version() {
-    local FTL_VERSION FTL_COMMIT FTL_BRANCH remote_version
+    local FTL_VERSION FTL_COMMIT FTL_BRANCH
     echo_current_diagnostic "FTL version"
     # Use the built in command to check FTL's version
     FTL_VERSION=$(pihole-FTL -vv | grep -m 1 Version | awk '{printf $2}')
     FTL_BRANCH=$(pihole-FTL -vv | grep -m 1 Branch | awk '{printf $2}')
     FTL_COMMIT=$(pihole-FTL -vv | grep -m 1 Commit | awk '{printf $2}')
 
-    # remote version is taken from /etc/pihole/versions (sourced above)
-    remote_version="${GITHUB_FTL_VERSION}"
-    if [ -z "${remote_version}" ]; then
-        remote_version="N/A"
-    fi
 
-    # Compare the current FTL version to the remote version
-    if [[ "${FTL_VERSION}" == "${remote_version}" ]]; then
-        # If they are the same, FTL is up-to-date
-        log_write "${TICK} Version: ${COL_GREEN}${FTL_VERSION}${COL_NC} [Latest: ${remote_version}]"
-    else
-        # If not, show it in yellow, signifying there is an update
-        log_write "${INFO} Version: ${COL_YELLOW}${FTL_VERSION}${COL_NC} [Latest: ${remote_version}] (${FAQ_UPDATE_PI_HOLE})"
-    fi
+    log_write "${TICK} Version: ${FTL_VERSION}"
 
     # If they use the master branch, they are on the stable codebase
     if [[ "${FTL_BRANCH}" == "master" ]]; then

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -48,7 +48,6 @@ OBFUSCATED_PLACEHOLDER="<DOMAIN OBFUSCATED>"
 
 # FAQ URLs for use in showing the debug log
 FAQ_UPDATE_PI_HOLE="${COL_CYAN}https://discourse.pi-hole.net/t/how-do-i-update-pi-hole/249${COL_NC}"
-FAQ_CHECKOUT_COMMAND="${COL_CYAN}https://discourse.pi-hole.net/t/the-pihole-command-with-examples/738#checkout${COL_NC}"
 FAQ_HARDWARE_REQUIREMENTS="${COL_CYAN}https://docs.pi-hole.net/main/prerequisites/${COL_NC}"
 FAQ_HARDWARE_REQUIREMENTS_PORTS="${COL_CYAN}https://docs.pi-hole.net/main/prerequisites/#ports${COL_NC}"
 FAQ_HARDWARE_REQUIREMENTS_FIREWALLD="${COL_CYAN}https://docs.pi-hole.net/main/prerequisites/#firewalld${COL_NC}"
@@ -73,7 +72,6 @@ WEB_SERVER_LOG_DIRECTORY="/var/log/lighttpd"
 WEB_SERVER_CONFIG_DIRECTORY="/etc/lighttpd"
 HTML_DIRECTORY="/var/www/html"
 WEB_GIT_DIRECTORY="${HTML_DIRECTORY}/admin"
-#BLOCK_PAGE_DIRECTORY="${HTML_DIRECTORY}/pihole"
 SHM_DIRECTORY="/dev/shm"
 ETC="/etc"
 
@@ -275,7 +273,7 @@ compare_local_version_to_git_version() {
             local remote_version
             remote_version=$(curl -s "https://api.github.com/repos/pi-hole/${repo_name}/releases/latest" 2> /dev/null | jq --raw-output .tag_name)
             # echo this information out to the user in a nice format
-            # If the current version matches the lastest tag, the user is up-to-date
+            # If the current version matches the latest tag, the user is up-to-date
             if [[ "${local_version}" == "${remote_version}" ]]; then
                 log_write "${TICK} Version: ${COL_GREEN}${local_version}${COL_NC} [Latest: ${remote_version}]"
             # If not,
@@ -296,7 +294,7 @@ compare_local_version_to_git_version() {
             # If it is any other branch, they are in a development branch
             else
                 # So show that in yellow, signifying it's something to take a look at, but not a critical error
-                log_write "${INFO} Branch: ${COL_YELLOW}${local_branch:-Detached}${COL_NC} (${FAQ_CHECKOUT_COMMAND})"
+                log_write "${INFO} Branch: ${COL_YELLOW}${local_branch:-Detached}${COL_NC}"
             fi
             # echo the current commit
             log_write "${INFO} Commit: ${local_commit}"
@@ -358,7 +356,7 @@ check_ftl_version() {
         # If it is any other branch, they are in a development branch
     else
         # So show that in yellow, signifying it's something to take a look at, but not a critical error
-        log_write "${INFO} Branch: ${COL_YELLOW}${FTL_BRANCH}${COL_NC} (${FAQ_CHECKOUT_COMMAND})"
+        log_write "${INFO} Branch: ${COL_YELLOW}${FTL_BRANCH}${COL_NC}"
     fi
 
     # echo the current commit


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

1. Remove the check of the latest available version of each component. See discussion blow.
2. Remove the checkout hint. If users are so advances that they are on custom branches they should know how to `checkout` or will ask anyway.


```
*** [ DIAGNOSING ]: Core version
[✓] Version: v5.13
[i] Remotes: origin	https://github.com/pi-hole/pi-hole.git (fetch)
             origin	https://github.com/pi-hole/pi-hole.git (push)
[i] Branch: development
[i] Commit: v5.13-1-g89c0706a

*** [ DIAGNOSING ]: Web version
[✓] Version: v5.16
[i] Remotes: origin	https://github.com/pi-hole/AdminLTE.git (fetch)
             origin	https://github.com/pi-hole/AdminLTE.git (push)
[i] Branch: 99
[i] Commit: v5.16-5-g8abfde2e

*** [ DIAGNOSING ]: FTL version
[✓] Version: vDev-14cffae
[i] Branch: update/dnsmasq
[i] Commit: 14cffae

```



---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
5. I have commented my proposed changes within the code and I have tested my changes.
6. I am willing to help maintain this change if there are issues with it later.
7. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
8. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
