### PR TITLE
Check `versions` file on the debug log

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -91,6 +91,7 @@ PIHOLE_LOGROTATE_FILE="${PIHOLE_DIRECTORY}/logrotate"
 PIHOLE_SETUP_VARS_FILE="${PIHOLE_DIRECTORY}/setupVars.conf"
 PIHOLE_FTL_CONF_FILE="${PIHOLE_DIRECTORY}/pihole-FTL.conf"
 PIHOLE_CUSTOM_HOSTS_FILE="${PIHOLE_DIRECTORY}/custom.list"
+PIHOLE_VERSIONS_FILE="${PIHOLE_DIRECTORY}/versions"
 
 # Read the value of an FTL config key. The value is printed to stdout.
 #
@@ -162,7 +163,8 @@ REQUIRED_FILES=("${PIHOLE_CRON_FILE}"
 "${PIHOLE_WEB_SERVER_ERROR_LOG_FILE}"
 "${RESOLVCONF}"
 "${DNSMASQ_CONF}"
-"${PIHOLE_CUSTOM_HOSTS_FILE}")
+"${PIHOLE_CUSTOM_HOSTS_FILE}"
+"${PIHOLE_VERSIONS_FILE}")
 
 DISCLAIMER="This process collects information from your Pi-hole, and optionally uploads it to a unique and random directory on tricorder.pi-hole.net.
 


### PR DESCRIPTION
### What does this PR aim to accomplish?

Add info about `versions` file to the debug log.

Context:
Recently we introduced `versions` file to `/etc/pihole` directory. 
We use this file in a lot of places, but a check for this file was never included in the debug log.

Including this check will show extra info: file last update time, file permissions and file content:

```
-rw-r--r-- 1 root pihole 291 Oct 13 20:24 /etc/pihole/versions
   CORE_BRANCH=development
   WEB_BRANCH=topboxlink
   FTL_BRANCH=development
   CORE_VERSION=v5.12.2-43-g997a771
   WEB_VERSION=v5.15.1-32-g16823707
   FTL_VERSION=vDev-2de12e2
   DOCKER_VERSION=nightly
   GITHUB_CORE_VERSION=v5.13
   GITHUB_WEB_VERSION=v5.16
   GITHUB_FTL_VERSION=v5.18.2
   GITHUB_DOCKER_VERSION=2022.10
```

### How does this PR accomplish the above?

Adding `versions` file to the REQUIRED_FILES list.

### What documentation changes (if any) are needed to support this PR?

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
