### PR TITLE
Bump actions/setup-python from 4.2.0 to 4.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
As https://github.com/pi-hole/pi-hole/pull/4979, but at `master` - in order to test the sync-back-to-dev action