### PR TITLE
Prevent CNAME loop

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -729,7 +729,12 @@ AddCustomCNAMERecord() {
     if [[ -n "${validDomain}" ]]; then
         validTarget="$(checkDomain "${target}")"
         if [[ -n "${validTarget}" ]]; then
-            echo "cname=${validDomain},${validTarget}" >> "${dnscustomcnamefile}"
+            if [ "${validDomain}" = "${validTarget}" ]; then
+                echo "  ${CROSS} Domain and target are the same!"
+                exit 1
+            else
+                echo "cname=${validDomain},${validTarget}" >> "${dnscustomcnamefile}"
+            fi
         else
             echo "  ${CROSS} Invalid Target Passed!"
             exit 1

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -730,7 +730,7 @@ AddCustomCNAMERecord() {
         validTarget="$(checkDomain "${target}")"
         if [[ -n "${validTarget}" ]]; then
             if [ "${validDomain}" = "${validTarget}" ]; then
-                echo "  ${CROSS} Domain and target are the same!"
+                echo "  ${CROSS} Domain and target are the same. This would cause a DNS loop."
                 exit 1
             else
                 echo "cname=${validDomain},${validTarget}" >> "${dnscustomcnamefile}"


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Check when adding CNAME records by `pihole -a addcustomcanme` that domain and target are different. Prevents `FTL` failing with `[2022-10-20 06:41:46.574 22783M] FATAL ERROR in dnsmasq core: CNAME loop involving jesse.chahal`.

Fixes the backend side of https://github.com/pi-hole/AdminLTE/issues/2406


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
