### PR TITLE
Escape dots in local DNS records/CNAMES before removing them

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -629,6 +629,8 @@ checkDomain()
 
 escapeDots()
 {
+    # shellcheck disable=SC2001
+    # SH suggest bashism ${variable//search/replace}
     escaped=$(sed 's/\./\\./g' <<< "$1" )
     echo "${escaped}"
 }

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -629,9 +629,9 @@ checkDomain()
 
 escapeDots()
 {
+    # SC suggest bashism ${variable//search/replace}
     # shellcheck disable=SC2001
-    # SH suggest bashism ${variable//search/replace}
-    escaped=$(sed 's/\./\\./g' <<< "$1" )
+    escaped=$(echo "$1" | sed 's/\./\\./g')
     echo "${escaped}"
 }
 

--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -627,6 +627,12 @@ checkDomain()
     echo "${validDomain}"
 }
 
+escapeDots()
+{
+    escaped=$(sed 's/\./\\./g' <<< "$1" )
+    echo "${escaped}"
+}
+
 addAudit()
 {
     shift # skip "-a"
@@ -702,6 +708,7 @@ RemoveCustomDNSAddress() {
     validHost="$(checkDomain "${host}")"
     if [[ -n "${validHost}" ]]; then
         if valid_ip "${ip}" || valid_ip6 "${ip}" ; then
+            validHost=$(escapeDots "${validHost}")
             sed -i "/^${ip} ${validHost}$/Id" "${dnscustomfile}"
         else
             echo -e "  ${CROSS} Invalid IP has been passed"
@@ -755,7 +762,9 @@ RemoveCustomCNAMERecord() {
     if [[ -n "${validDomain}" ]]; then
         validTarget="$(checkDomain "${target}")"
         if [[ -n "${validTarget}" ]]; then
-            sed -i "/cname=${validDomain},${validTarget}$/Id" "${dnscustomcnamefile}"
+            validDomain=$(escapeDots "${validDomain}")
+            validTarget=$(escapeDots "${validTarget}")
+            sed -i "/^cname=${validDomain},${validTarget}$/Id" "${dnscustomcnamefile}"
         else
             echo "  ${CROSS} Invalid Target Passed!"
             exit 1


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Fixes a bug in our code when we remove local DNS records/CNAMEs. We use `sed` to remove the entry from the relevant file, but don't escape dots, leading to a bug described in https://github.com/pi-hole/pi-hole/issues/4989


- **How does this PR accomplish the above?:**

Escapes dots before removing them by `sed`


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
