### PR TITLE
Fix static IP not set if IP is already present in any way inside dhcpcd.conf

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -828,8 +828,11 @@ It is also possible to use a DHCP reservation, but if you are going to do that, 
 
 # Configure networking via dhcpcd
 setDHCPCD() {
-    # Check if the IP is already in the file
-    if grep -q "${IPV4_ADDRESS}" /etc/dhcpcd.conf; then
+    # Regex for matching a non-commented static ip address setting
+    local regex="^[ \t]*static ip_address[ \t]*=[ \t]*${IPV4_ADDRESS}[ \t]*$"
+
+    # Check if static IP is already set in file
+    if grep -xq "${regex}" /etc/dhcpcd.conf; then
         printf "  %b Static IP already configured\\n" "${INFO}"
     # If it's not,
     else


### PR DESCRIPTION
Signed-off-by: Stephan Pillhofer <43667664+StephanPillhofer@users.noreply.github.com>

- **What does this PR aim to accomplish?:**

This PR solves a bug which prevents the `dhcpcd.conf` file from being changed when the user wants to assign a static IP address to the RaspberryPi. The bug occurs because the target static IP address may already be present in any form in the (default) `dhcpcd.conf` file. (e.g. the IP address may be mentioned in another setting than "static ip_address" or it may be present in a commented example setting)


- **How does this PR accomplish the above?:**

The bug is resolved by utilizing a regular expression for matching a valid non-commented static IP addess entry (e.g. `static ip_address=192.168.10.2/24`)

- **What documentation changes (if any) are needed to support this PR?:**

none


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
