### PR TITLE
Fix static IP not set because of in-line comment

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -829,10 +829,10 @@ It is also possible to use a DHCP reservation, but if you are going to do that, 
 # Configure networking via dhcpcd
 setDHCPCD() {
     # Regex for matching a non-commented static ip address setting
-    local regex="^[ \t]*static ip_address[ \t]*=[ \t]*${IPV4_ADDRESS}[ \t]*$"
+    local regex="^[ \t]*static ip_address[ \t]*=[ \t]*${IPV4_ADDRESS}"
 
     # Check if static IP is already set in file
-    if grep -xq "${regex}" /etc/dhcpcd.conf; then
+    if grep -q "${regex}" /etc/dhcpcd.conf; then
         printf "  %b Static IP already configured\\n" "${INFO}"
     # If it's not,
     else


### PR DESCRIPTION
Signed-off-by: Stephan Pillhofer <43667664+StephanPillhofer@users.noreply.github.com>

- **What does this PR aim to accomplish?:**

Fix a bug which causes the static IP inside the dhcpcd.conf file not be set correctly if inline/trailing comments are used.

- **How does this PR accomplish the above?:**

Adjust the used regex expression.

- **What documentation changes (if any) are needed to support this PR?:**

-

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
