### PR TITLE
Touch files before addKey or addOrEditKeyValPair

### DIFF
--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -31,6 +31,9 @@ addOrEditKeyValPair() {
   local key="${2}"
   local value="${3}"
 
+  # touch file to prevent grep error if file does not exist yet
+  touch "${file}"
+
   if grep -q "^${key}=" "${file}"; then
     # Key already exists in file, modify the value
     sed -i "/^${key}=/c\\${key}=${value}" "${file}"
@@ -50,6 +53,9 @@ addOrEditKeyValPair() {
 addKey(){
   local file="${1}"
   local key="${2}"
+
+  # touch file to prevent grep error if file does not exist yet
+  touch "${file}"
 
   if ! grep -q "^${key}" "${file}"; then
     # Key does not exist, add it.

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1785,6 +1785,9 @@ create_pihole_user() {
 finalExports() {
     # set or update the variables in the file
 
+    # create the file if it does not exist
+    touch "${setupVars}"
+
     addOrEditKeyValPair "${setupVars}" "PIHOLE_INTERFACE" "${PIHOLE_INTERFACE}"
     addOrEditKeyValPair "${setupVars}" "PIHOLE_DNS_1" "${PIHOLE_DNS_1}"
     addOrEditKeyValPair "${setupVars}" "PIHOLE_DNS_2" "${PIHOLE_DNS_2}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1785,9 +1785,6 @@ create_pihole_user() {
 finalExports() {
     # set or update the variables in the file
 
-    # create the file if it does not exist
-    touch "${setupVars}"
-
     addOrEditKeyValPair "${setupVars}" "PIHOLE_INTERFACE" "${PIHOLE_INTERFACE}"
     addOrEditKeyValPair "${setupVars}" "PIHOLE_DNS_1" "${PIHOLE_DNS_1}"
     addOrEditKeyValPair "${setupVars}" "PIHOLE_DNS_2" "${PIHOLE_DNS_2}"


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Fixes a bug introduced by https://github.com/pi-hole/pi-hole/pull/4872.
Using `addOrEditKeyValPair` in `finalExports()` will result in an `grep` error that `setupVars.conf` could not be found if `setupVars.conf` does not exist, when this is the first run of `finalExports()`. Reason is, that `addOrEditKeyValPair` does not check if the file exists before `greping` for the "key".
https://github.com/pi-hole/pi-hole/blob/e773e3302ca66a6d918a40c8a8c6282f223d4906/advanced/Scripts/utils.sh#L29-L40

Before https://github.com/pi-hole/pi-hole/pull/4872 we simply `echo`ed the (new) content of `setupVars.conf`, which created the file if it did not exist.


- **How does this PR accomplish the above?:**

~~Create `setupVars.conf` before running `addOrEditKeyValPair` on it by `touching` it.~~
Touch files before `addKey` or `addOrEditKeyValPair`

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
