### PR TITLE
Correctly identify process status in debug script on docker

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -925,10 +925,21 @@ process_status(){
         else
             # Otherwise, use the service command and mock the output of `systemctl is-active`
             local status_of_process
-            if service "${i}" status | grep -E 'is\srunning' &> /dev/null; then
-                status_of_process="active"
+
+            # If DOCKER_VERSION is set, the output is slightly different (s6 init system on Docker)
+            if [ -n "${DOCKER_VERSION}" ]; then
+                if service "${i}" status | grep -E '^up' &> /dev/null; then
+                    status_of_process="active"
+                else
+                    status_of_process="inactive"
+                fi
             else
-                status_of_process="inactive"
+            # non-Docker system
+                if service "${i}" status | grep -E 'is\srunning' &> /dev/null; then
+                    status_of_process="active"
+                else
+                    status_of_process="inactive"
+                fi
             fi
         fi
         # and print it out to the user


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

So far, the debug scripts fails to identify the status of the "pihole processes" (`lighttpd`and `pihole-FTL`) correctly on docker when tested within the debug script. Reason is, that the output of the `s6`init system's `status` is different than the regular `service` ones.

Before:

```
*** [ DIAGNOSING ]: Pi-hole processes
[✗] lighttpd daemon is inactive
[✗] pihole-FTL daemon is inacti
```

After

```
*** [ DIAGNOSING ]: Pi-hole processes
[✓] lighttpd daemon is active
[✓] pihole-FTL daemon is active
```

**How does this PR accomplish the above?:**

If `DOCKER_VERSION` is set, `grep` for another output to determine if the service is up.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
