### PR TITLE
Fix odd behaviour introduced into new version checking script

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -314,9 +314,9 @@ check_ftl_version() {
     local FTL_VERSION FTL_COMMIT FTL_BRANCH
     echo_current_diagnostic "FTL version"
     # Use the built in command to check FTL's version
-    FTL_VERSION=$(pihole-FTL -vv | grep -m 1 Version | awk '{printf $2}')
-    FTL_BRANCH=$(pihole-FTL -vv | grep -m 1 Branch | awk '{printf $2}')
-    FTL_COMMIT=$(pihole-FTL -vv | grep -m 1 Commit | awk '{printf $2}')
+    FTL_VERSION=$(pihole-FTL version)
+    FTL_BRANCH=$(pihole-FTL branch)
+    FTL_COMMIT=$(pihole-FTL --hash)
 
 
     log_write "${TICK} Version: ${FTL_VERSION}"

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -17,7 +17,7 @@ function get_local_branch() {
 function get_local_version() {
     # Return active version
     cd "${1}" 2> /dev/null || return 1
-    git describe --long --dirty --tags 2> /dev/null || return 1
+    git describe --tags --always 2> /dev/null || return 1
 }
 
 function get_local_hash() {

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -31,7 +31,7 @@ function get_remote_version() {
 
 
 function get_remote_hash(){
-    git ls-remote "https://github.com/pi-hole/${1}" --tags "${2}" | awk '{print substr($0, 0,9);}' || return 1
+    git ls-remote "https://github.com/pi-hole/${1}" --tags "${2}" | awk '{print substr($0, 0,8);}' || return 1
 }
 
 # Source the setupvars config file
@@ -113,7 +113,7 @@ addOrEditKeyValPair "${VERSION_FILE}" "FTL_VERSION" "${FTL_VERSION}"
 FTL_BRANCH="$(pihole-FTL branch)"
 addOrEditKeyValPair "${VERSION_FILE}" "FTL_BRANCH" "${FTL_BRANCH}"
 
-FTL_HASH="$(pihole-FTL -v | cut -d "-" -f2)"
+FTL_HASH="$(pihole-FTL --hash)"
 addOrEditKeyValPair "${VERSION_FILE}" "FTL_HASH" "${FTL_HASH}"
 
 GITHUB_FTL_VERSION="$(get_remote_version FTL)"

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -77,18 +77,27 @@ versionOutput() {
         [ "$3" = "-c" ] || [ "$3" = "--current" ] || [ -z "$3" ] && curHash=$(getLocalHash "${1}") && branch=$(getLocalBranch "${1}")
         [ "$3" = "-l" ] || [ "$3" = "--latest" ] || [ -z "$3" ] && latHash=$(getRemoteHash "${1}") && branch=$(getLocalBranch "${1}")
     fi
+
+    # We do not want to show the branch name when we are on master,
+    # blank out the variable in this case
+    if [ "$branch" = "master" ]; then
+        branch=""
+    else
+        branch="$branch "
+    fi
+
     if [ -n "$current" ] && [ -n "$latest" ]; then
-        output="${1} version is $branch $current (Latest: $latest)"
+        output="${1} version is $branch$current (Latest: $latest)"
     elif [ -n "$current" ] && [ -z "$latest" ]; then
-        output="Current ${1} version is $branch $current"
+        output="Current ${1} version is $branch$current"
     elif [ -z "$current" ] && [ -n "$latest" ]; then
         output="Latest ${1} version is $latest"
     elif [ -n "$curHash" ] && [ -n "$latHash" ]; then
-        output="Local ${1} hash of branch $branch is $curHash (Remote: $latHash)"
+        output="Local ${1} hash is $curHash (Remote: $latHash)"
     elif [ -n "$curHash" ] && [ -z "$latHash" ]; then
-        output="Current local ${1} hash of branch $branch is $curHash"
+        output="Current local ${1} hash is $curHash"
     elif [ -z "$curHash" ] && [ -n "$latHash" ]; then
-        output="Latest remote ${1} hash of branch $branch is $latHash"
+        output="Latest remote ${1} hash is $latHash"
     elif [ -z "$curHash" ] && [ -z "$latHash" ]; then
         output="Hashes for ${1} not available"
     else


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Before:
```
pi@raspberrypi:/etc/.pihole $ pihole -v
  Pi-hole version is master v5.14-0-g3c86af0e (Latest: v5.14)
  AdminLTE version is master v5.17-0-gda2764e5 (Latest: v5.17)
  FTL version is master v5.19 (Latest: v5.19)
```

After:
```
pi@raspberrypi:/etc/.pihole $ pihole -v
  Pi-hole version is v5.14 (Latest: v5.14)
  AdminLTE version is v5.17 (Latest: v5.17)
  FTL version is v5.19 (Latest: v5.19)
```

Pointed at master to release as hotfix

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_