### PR TITLE
Disable a few commands if installed in (official) docker containers

### DIFF
--- a/pihole
+++ b/pihole
@@ -23,6 +23,9 @@ source "${colfile}"
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 source "${utilsfile}"
 
+versionsfile="/etc/pihole/versions"
+source "${versionsfile}"
+
 webpageFunc() {
   source "${PI_HOLE_SCRIPT_DIR}/webpage.sh"
   main "$@"
@@ -63,14 +66,22 @@ arpFunc() {
 }
 
 updatePiholeFunc() {
-  shift
-  "${PI_HOLE_SCRIPT_DIR}"/update.sh "$@"
-  exit 0
+  if [ -n "${DOCKER_VERSION}" ]; then
+    unsupportedFunc
+  else
+    shift
+    "${PI_HOLE_SCRIPT_DIR}"/update.sh "$@"
+    exit 0
+  fi
 }
 
 reconfigurePiholeFunc() {
-  /etc/.pihole/automated\ install/basic-install.sh --reconfigure
-  exit 0;
+  if [ -n "${DOCKER_VERSION}" ]; then
+    unsupportedFunc
+  else
+    /etc/.pihole/automated\ install/basic-install.sh --reconfigure
+    exit 0;
+  fi
 }
 
 updateGravityFunc() {
@@ -91,8 +102,12 @@ chronometerFunc() {
 
 
 uninstallFunc() {
-  "${PI_HOLE_SCRIPT_DIR}"/uninstall.sh
-  exit 0
+  if [ -n "${DOCKER_VERSION}" ]; then
+    unsupportedFunc
+  else
+    "${PI_HOLE_SCRIPT_DIR}"/uninstall.sh
+    exit 0
+  fi
 }
 
 versionFunc() {
@@ -426,6 +441,11 @@ tricorderFunc() {
 
 updateCheckFunc() {
   "${PI_HOLE_SCRIPT_DIR}"/updatecheck.sh "$@"
+  exit 0
+}
+
+unsupportedFunc(){
+  echo "Function not supported in Docker images"
   exit 0
 }
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Removes the need for the following monkeypatch in the Docker Repo:

https://github.com/pi-hole/docker-pi-hole/blob/41aa699aab8346e7a9a32574d9ec168fc54490cc/src/s6/debian-root/usr/local/bin/install.sh#L78-L87

When a user runs `pihole checkout <whatever>` inside a running docker container, those patches are removed. Ideally a user would not be running `pihole checkout`, but it is useful for debugging and testing new branches of FTL and adminLTE (and core to an extent)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_