### PR TITLE
Do not require man pages to be present in test script

### DIFF
--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -211,6 +211,8 @@ def test_installPihole_fresh_install_readableFiles(host):
     maninstalled = True
     if (info_box + " man not installed") in install.stdout:
         maninstalled = False
+    if (info_box + " man pages not installed") in install.stdout:
+        maninstalled = False
     piholeuser = "pihole"
     exit_status_success = 0
     test_cmd = 'su --shell /bin/bash --command "test -{0} {1}" -p {2}'


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We allow the installer to continue installation even when `mandb` or the `man` directory is not present. 

https://github.com/pi-hole/pi-hole/blob/21026d941428bfcb4f405479db470a90bae6aec1/automated%20install/basic-install.sh#L1421-L1429

However, in the test suite, we only allow to skip the test for the man files in case `mandb` is not present
https://github.com/pi-hole/pi-hole/blob/21026d941428bfcb4f405479db470a90bae6aec1/test/test_any_automated_install.py#L211-L213

https://github.com/pi-hole/pi-hole/blob/21026d941428bfcb4f405479db470a90bae6aec1/test/test_any_automated_install.py#L291-L320

This PR allows to skip the man test also when the `man` directory (`/usr/local/share/man`) is not present.

Discovered while working on https://github.com/pi-hole/pi-hole/pull/5027

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
