### PR TITLE
Explicitly create group pihole on installation

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1760,20 +1760,35 @@ create_pihole_user() {
     else
         # If the pihole user doesn't exist,
         printf "%b  %b %s" "${OVER}" "${CROSS}" "${str}"
-        local str="Creating user 'pihole'"
-        printf "%b  %b %s..." "${OVER}" "${INFO}" "${str}"
-        # create her with the useradd command,
+        local str="Checking for group 'pihole'"
+        printf "  %b %s..." "${INFO}" "${str}"
         if getent group pihole > /dev/null 2>&1; then
-            # then add her to the pihole group (as it already exists)
+            # group pihole exists
+            printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+            # then create and add her to the pihole group
+            local str="Creating user 'pihole'"
+            printf "%b  %b %s..." "${OVER}" "${INFO}" "${str}"
             if useradd -r --no-user-group -g pihole -s /usr/sbin/nologin pihole; then
                 printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
             else
                 printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
             fi
         else
-            # add user pihole with default group settings
-            if useradd -r -s /usr/sbin/nologin pihole; then
+            # group pihole does not exist
+            printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+            local str="Creating group 'pihole'"
+            # if group can be created
+            if groupadd pihole; then
                 printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+                # create and add pihole user to the pihole group
+                local str="Creating user 'pihole'"
+                printf "%b  %b %s..." "${OVER}" "${INFO}" "${str}"
+                if useradd -r --no-user-group -g pihole -s /usr/sbin/nologin pihole; then
+                    printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+                else
+                    printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+                fi
+
             else
                 printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
             fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When creating the user `pihole` during installation we rely on the behavior of the `debian` version of `useradd` to create a group with the same name by default.

> By default, a group will also be created for the new user

https://linux.die.net/man/8/useradd

However, as we want to make Pi-hole compatible with other OS, this default group creation by `useradd` can't be implied. E.g. openSUSE does not create a group by default

https://www.unix.com/man-page/suse/8/useradd/

This PR explicitly creates the group `pihole` before it creates the user `pihole`

Discovered while working on https://github.com/pi-hole/pi-hole/pull/5027

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
