### PR TITLE
Do not setcap FTL binary when systemd is used

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1385,11 +1385,6 @@ installConfigs() {
     if [[ -d '/run/systemd/system' ]]; then
         install -T -m 0644 "${PI_HOLE_LOCAL_REPO}/advanced/Templates/pihole-FTL.systemd" '/etc/systemd/system/pihole-FTL.service'
 
-        # Set net admin permissions so that FTL can serve DNS, DHCP and IMAP (for DHCPv6). If this does not work, run FTL as root user.
-        if ! setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_IPC_LOCK,CAP_CHOWN+eip '/usr/bin/pihole-FTL'; then
-            sed -i '/^User=/d' '/etc/systemd/system/pihole-FTL.service'
-        fi
-
         # Remove init.d service if present
         if [[ -e '/etc/init.d/pihole-FTL' ]]; then
             rm '/etc/init.d/pihole-FTL'


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

Currently, if e.g. due to limited filesystem features, `setcap` fails to apply capabilities to FTL binary, the systemd unit is edited to start FTL as root user. This however is not required, since the systemd unit uses the `AmbientCapabilities=` setting to grant the required capabilities. If systemd is used, `setcap` could still be used for convenience, to allow users starting FTL as `pihole` (and theoretically other users) from console, e.g. for testing or debugging purpose. But it is not required for the systemd service to successfully start. For best security, this PR aims to skip it completely if systemd is used.

**How does this PR accomplish the above?:**

`setcap` is not applied if systemd is the init system and the systemd unit starts FTL as `pihole` user in every case.

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
