### PR TITLE
Allow pihole restart via systemctl

### DIFF
--- a/pihole
+++ b/pihole
@@ -139,7 +139,12 @@ restartDNS() {
     fi
   else
     # A full restart has been requested
-    svc="service pihole-FTL restart"
+    if command -v systemctl >/dev/null 2>&1 ; then
+        svc="systemctl restart pihole-FTL"
+    else
+        svc="service pihole-FTL restart"
+    fi
+
     str="Restarting DNS server"
     icon="${TICK}"
   fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

PR https://github.com/pi-hole/pi-hole/pull/4924 added a native systemd service file. Usually, we check if `systemctl` is available for handling services and fall back to `service` if it is not present, However, there was one command that did not check for the availability of `systemctl` 

https://github.com/pi-hole/pi-hole/blob/0034538794a3754ab532a53480da39d3fd13d7ed/pihole#L141-L144

**How does this PR accomplish the above?:**

Adds a check for `systemctl`and uses this if the command is available. 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
