### PR TITLE
Install wheel before other python packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies
-        run: pip install -r test/requirements.txt
+        run:  pip install wheel && pip install -r test/requirements.txt
 
       - name: Test with tox
         run: tox -c test/tox.${DISTRO}.ini

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install wheel
+        run:  pip install wheel
+
       - name: Install dependencies
-        run:  pip install wheel && pip install -r test/requirements.txt
+        run: pip install -r test/requirements.txt
 
       - name: Test with tox
         run: tox -c test/tox.${DISTRO}.ini


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We use `pip` to install the necessary packages for the distro tests.

https://github.com/pi-hole/pi-hole/blob/0034538794a3754ab532a53480da39d3fd13d7ed/.github/workflows/test.yml#L72-L73

Some of the required packages have dependencies themselves. Not for all of those pre-packed binary exists ("wheel"), so they need to be compiled during installation. However, they sometimes lack a `pyproject.toml` to define the builtd environment. Hence, we get a deprecation warning which will be a hard error once `pip` reaches v23.1.

```
  DEPRECATION: docopt is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559
```

This PR fixes the issue as suggested by the warning: we install `wheel` before all other requirements. It would be easy to add `wheel` to our `requirements.txt`, however, this does not work (`wheel` is not used when installed at the same time). See https://stackoverflow.com/questions/59104686/wheel-installation-from-within-requirements-txt

Therefore, we need a two-step approach.

**How does this PR accomplish the above?:**

Install `wheel` by `pip` before all other dependencies.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
