### PR TITLE
Cleanup if startup failed

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -38,15 +38,16 @@ start() {
     sh "${PI_HOLE_SCRIPT_DIR}/pihole-FTL-prestart.sh"
 
     if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_IPC_LOCK,CAP_CHOWN+eip "/usr/bin/pihole-FTL"; then
-      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole || ec=$?
+      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole
     else
       echo "Warning: Starting pihole-FTL as root because setting capabilities is not supported on this system"
-      /usr/bin/pihole-FTL || ec=$?
+      /usr/bin/pihole-FTL
     fi
+    rc=$?
     # Cleanup if startup failed
-    if [ -n "${ec}" ] && [ "${ec}" != 0 ]; then
+    if [ "${rc}" != 0 ]; then
         cleanup
-        exit $ec
+        exit $rc
     fi
     echo
   fi

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -23,6 +23,11 @@ is_running() {
   return 1
 }
 
+cleanup() {
+    # Run post-stop script, which does cleanup among runtime files
+    sh "${PI_HOLE_SCRIPT_DIR}/pihole-FTL-poststop.sh"
+}
+
 
 # Start the service
 start() {
@@ -33,10 +38,15 @@ start() {
     sh "${PI_HOLE_SCRIPT_DIR}/pihole-FTL-prestart.sh"
 
     if setcap CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_IPC_LOCK,CAP_CHOWN+eip "/usr/bin/pihole-FTL"; then
-      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole || exit $?
+      su -s /bin/sh -c "/usr/bin/pihole-FTL" pihole || ec=$?
     else
       echo "Warning: Starting pihole-FTL as root because setting capabilities is not supported on this system"
-      /usr/bin/pihole-FTL || exit $?
+      /usr/bin/pihole-FTL || ec=$?
+    fi
+    # Cleanup if startup failed
+    if [ -n "${ec}" ] && [ "${ec}" != 0 ]; then
+        cleanup
+        exit $ec
     fi
     echo
   fi
@@ -65,8 +75,7 @@ stop() {
   else
     echo "Not running"
   fi
-  # Run post-stop script, which does cleanup among runtime files
-  sh "${PI_HOLE_SCRIPT_DIR}/pihole-FTL-poststop.sh"
+  cleanup
   echo
 }
 
@@ -83,6 +92,9 @@ status() {
 
 
 ### main logic ###
+
+# catch sudden termination
+trap 'cleanup; exit 1' INT HUP TERM ABRT
 
 # Get FTL's PID file path
 FTL_PID_FILE="$(getFTLPIDFile)"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Cleanup files if `pihole-FTL` did not start properly after getting invoked by `pihole-FTL.service`.

With https://github.com/pi-hole/pi-hole/pull/4857 we added the exit code, however do not use ist so far. Now we do.

**This is a re-implementation of https://github.com/pi-hole/pi-hole/pull/4887 after https://github.com/pi-hole/pi-hole/pull/4924 has been merged**

**How does this PR accomplish the above?:**

Run the `pihole-FTL-poststop.sh` if `pihole-FTL` started with a non-zero exit code or we `trap` `INT HUP TERM ABRT`

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
