### PR TITLE
Test lighttpd was build with lua support

### DIFF
--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -1161,3 +1161,23 @@ def test_package_manager_has_web_deps(host):
 
     assert "No package" not in output.stdout
     assert output.rc == 0
+
+
+def test_lighttpd_lua_support(host):
+    """Confirms lighttpd installed has LUA support"""
+    mock_command("dialog", {"*": ("", "0")}, host)
+    host.run(
+        """
+    source /opt/pihole/basic-install.sh
+    package_manager_detect
+    install_dependent_packages ${PIHOLE_WEB_DEPS[@]}
+    """
+    )
+
+    lua_support = host.run(
+        """
+    /usr/sbin/lighttpd -V | grep -o '+ LUA support'
+    """
+    )
+    expected_stdout = "+ LUA support"
+    assert expected_stdout in lua_support.stdout


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Adds a test to check if the installed `lighttpd`was compiled with `lua` support. In the light of possible upcoming changes regarding `lighttpd`, this test might become useful


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
