### PR TITLE
Add pihole tail [arg] to man page

### DIFF
--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -23,7 +23,7 @@ Pi-hole : A black-hole for internet advertisements
 .br
 pihole -r
 .br
-pihole -t
+\fBpihole\fR \fB-t\fR [arg]
 .br
 pihole -g\fR
 .br
@@ -113,9 +113,13 @@ Available commands and options:
     Reconfigure or Repair Pi-hole subsystems
 .br
 
-\fB-t, tail\fR
+\fB-t, tail\fR [arg]
 .br
     View the live output of the Pi-hole log
+.br
+
+      [arg]             Optional argument to filter the log for
+                        (regular expressions are supported)
 .br
 
 \fB-a, admin\fR [options]


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Adds the optional argument for `pihole -t` to the pihole man page.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
