### PR TITLE
Tweak get_directories_recursive

### DIFF
--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -136,15 +136,9 @@ def test_installPiholeWeb_fresh_install_no_errors(host):
 def get_directories_recursive(host, directory):
     if directory is None:
         return directory
-    ls = host.run("ls -d {}".format(directory + "/*/"))
-    directories = list(filter(bool, ls.stdout.splitlines()))
-    dirs = directories
-    for dirval in directories:
-        dir_rec = get_directories_recursive(host, dirval)
-        if isinstance(dir_rec, str):
-            dirs.extend([dir_rec])
-        else:
-            dirs.extend(dir_rec)
+    # returns all non-hidden subdirs of 'directory'
+    dirs_raw = host.run("find {} -type d -not -path '*/.*'".format(directory))
+    dirs = list(filter(bool, dirs_raw.stdout.splitlines()))
     return dirs
 
 
@@ -520,7 +514,7 @@ def test_installPihole_fresh_install_readableBlockpage(host, test_webpage):
     check_admin = test_cmd.format("x", webroot + "/admin", webuser)
     actual_rc = host.run(check_admin).rc
     assert exit_status_success == actual_rc
-    directories = get_directories_recursive(host, webroot + "/admin/*/")
+    directories = get_directories_recursive(host, webroot + "/admin/")
     for directory in directories:
         check_pihole = test_cmd.format("r", directory, webuser)
         actual_rc = host.run(check_pihole).rc


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Tweaks to `get_directories_recursive()` function within the test suite.
Currently we use a recursive `ls` approach to get all subdirs within the passed directory.

https://github.com/pi-hole/pi-hole/blob/8d2e023ec0a2c52c309fd7971d76eeaef124ad65/test/test_any_automated_install.py#L148-L160

However, this syntax is not correct and can constructs a wrong directory path

```
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//bootstrap//js//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//bootstrap//js//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//font-awesome//*/'", exit_status=0, stdout=b'/var/www/html/admin/style/vendor//font-awesome//js/\n', stderr=None)
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//font-awesome//js//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//font-awesome//js//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//fonts//*/'", exit_status=0, stdout=b'/var/www/html/admin/style/vendor//fonts//antonio/\n/var/www/html/admin/style/vendor//fonts//ubuntu-mono/\n', stderr=None)
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//fonts//antonio//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//fonts//antonio//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//fonts//ubuntu-mono//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//fonts//ubuntu-mono//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//bootstrap//css//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//bootstrap//css//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//bootstrap//fonts//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//bootstrap//fonts//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//bootstrap//js//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//bootstrap//js//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//font-awesome//js//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//font-awesome//js//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//fonts//antonio//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//fonts//antonio//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/style/vendor//fonts//ubuntu-mono//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/style/vendor//fonts//ubuntu-mono//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/scripts/pi-hole//js//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/scripts/pi-hole//js//*/': No such file or directory\n")
DEBUG    testinfra:base.py:288 RUN CommandResult(command=b"docker exec 8ea661e1dd27c3ae6a5bc887c888dea495e0b0f35d04e9cdb32723d98b6e1a1d /bin/bash -c 'ls -d /var/www/html/admin/scripts/pi-hole//php//*/'", exit_status=2, stdout=None, stderr=b"ls: cannot access '/var/www/html/admin/scripts/pi-hole//php//*/': No such file or directory\n")
```

As seen in https://github.com/pi-hole/pi-hole/actions/runs/3832672464/jobs/6523265525

The tests never fails so far, because we did not check any return code of this function.

The changed code uses a much simpler `find` command to return a list of subdirectories. As we used to ignore hidden dirs so far,  I kept the behavior.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
