### PR TITLE
Export LC_ALL and LC_NUMERIC in chronometer.sh.

### DIFF
--- a/advanced/Scripts/chronometer.sh
+++ b/advanced/Scripts/chronometer.sh
@@ -8,8 +8,8 @@
 #
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
-LC_ALL=C
-LC_NUMERIC=C
+export LC_ALL=C
+export LC_NUMERIC=C
 
 # Retrieve stats from FTL engine
 pihole-FTL() {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**
Fix chronometer.sh so that it doesn't err on locales that don't use `.` as the decimal point char.

E.g. I get errors like this:
```
/opt/pihole/chronometer.sh: line 324: printf: 43,47: invalid number
/opt/pihole/chronometer.sh: line 400: printf: 28,9544: invalid number
```

**How does this PR accomplish the above?:**
Some functions are executed in a subshell. As such, they don't inherit LC_ALL and LC_NUMERIC from chronometer.sh.
By exporting the variables in the script, we make sure that they will be picked up by subshells and any processes they launch.



Signed-off-by: Manolis Stamatogiannakis <mstamat@gmail.com>

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
