### PR TITLE
Remove option to set static IP address if DHCPCD is installed

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -500,9 +500,6 @@ find_IPv4_information() {
     # disabled as we intentionally want to split on whitespace and have printf populate
     # the variable with just the first field.
     printf -v IPv4bare "$(printf ${route#*src })"
-    # Get the default gateway IPv4 address (the way to reach the Internet)
-    # shellcheck disable=SC2059,SC2086
-    printf -v IPv4gw "$(printf ${route#*via })"
 
     if ! valid_ip "${IPv4bare}" ; then
         IPv4bare="127.0.0.1"
@@ -663,133 +660,9 @@ find_IPv6_information() {
 # A function to collect IPv4 and IPv6 information of the device
 collect_v4andv6_information() {
     find_IPv4_information
-    # Echo the information to the user
     printf "  %b IPv4 address: %s\\n" "${INFO}" "${IPV4_ADDRESS}"
-    # if `dhcpcd` is used offer to set this as static IP for the device
-    if [[ -f "/etc/dhcpcd.conf" ]]; then
-        # configure networking via dhcpcd
-        getStaticIPv4Settings
-    fi
     find_IPv6_information
     printf "  %b IPv6 address: %s\\n" "${INFO}" "${IPV6_ADDRESS}"
-}
-
-getStaticIPv4Settings() {
-    # Local, named variables
-    local ipSettingsCorrect
-    local DHCPChoice
-    # Ask if the user wants to use DHCP settings as their static IP
-    # This is useful for users that are using DHCP reservations; we can use the information gathered
-    DHCPChoice=$(dialog --no-shadow --keep-tite --output-fd 1 \
-        --cancel-label "Exit" --ok-label "Continue" \
-        --backtitle "Calibrating network interface" \
-        --title "Static IP Address" \
-        --menu "Do you want to use your current network settings as a static address?\\n \
-            IP address:    ${IPV4_ADDRESS}\\n \
-            Gateway:       ${IPv4gw}\\n" \
-            "${r}" "${c}" 3 \
-                "Yes" "Set static IP using current values" \
-                "No" "Set static IP using custom values" \
-                "Skip" "I will set a static IP later, or have already done so")
-
-        result=$?
-        case ${result} in
-            "${DIALOG_CANCEL}" | "${DIALOG_ESC}")
-            printf "  %b Cancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"
-            exit 1
-            ;;
-        esac
-
-        case ${DHCPChoice} in
-            "Skip")
-                return
-                ;;
-            "Yes")
-            # If they choose yes, let the user know that the IP address will not be available via DHCP and may cause a conflict.
-            dialog --no-shadow --keep-tite \
-                --cancel-label "Exit" \
-                --backtitle "IP information" \
-                --title "FYI: IP Conflict" \
-                --msgbox "\\nIt is possible your router could still try to assign this IP to a device, which would cause a conflict, \
-but in most cases the router is smart enough to not do that.\n\n\
-If you are worried, either manually set the address, or modify the DHCP reservation pool so it does not include the IP you want.\n\n\
-It is also possible to use a DHCP reservation, but if you are going to do that, you might as well set a static address."\
-                "${r}" "${c}" && result=0 || result=$?
-
-                case ${result} in
-                    "${DIALOG_CANCEL}" | "${DIALOG_ESC}")
-                    printf "  %b Cancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"
-                    exit 1
-                    ;;
-                esac
-            ;;
-
-            "No")
-            # Otherwise, we need to ask the user to input their desired settings.
-            # Start by getting the IPv4 address (pre-filling it with info gathered from DHCP)
-            # Start a loop to let the user enter their information with the chance to go back and edit it if necessary
-            ipSettingsCorrect=false
-            until [[ "${ipSettingsCorrect}" = True ]]; do
-
-                # Ask for the IPv4 address
-                _staticIPv4Temp=$(dialog --no-shadow --keep-tite --output-fd 1 \
-                    --cancel-label "Exit" \
-                    --ok-label "Continue" \
-                    --backtitle "Calibrating network interface" \
-                    --title "IPv4 Address" \
-                    --form "\\nEnter your desired IPv4 address" \
-                    "${r}" "${c}" 0 \
-                        "IPv4 Address:" 1 1 "${IPV4_ADDRESS}" 1 15 19 0 \
-                        "IPv4 Gateway:" 2 1 "${IPv4gw}" 2 15 19 0)
-
-                result=$?
-                case ${result} in
-                    "${DIALOG_CANCEL}" | "${DIALOG_ESC}")
-                    printf "  %b Cancel was selected, exiting installer%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"
-                    exit 1
-                    ;;
-                esac
-
-                IPV4_ADDRESS=${_staticIPv4Temp%$'\n'*}
-                IPv4gw=${_staticIPv4Temp#*$'\n'}
-
-                # Give the user a chance to review their settings before moving on
-                dialog --no-shadow --keep-tite \
-                    --no-label "Edit IP" \
-                    --backtitle "Calibrating network interface" \
-                    --title "Static IP Address" \
-                    --defaultno \
-                    --yesno "Are these settings correct?
-                        IP address: ${IPV4_ADDRESS}
-                        Gateway:    ${IPv4gw}" \
-                    "${r}" "${c}" && ipSettingsCorrect=True
-            done
-            ;;
-       esac
-       setDHCPCD
-}
-
-# Configure networking via dhcpcd
-setDHCPCD() {
-    # Regex for matching a non-commented static ip address setting
-    local regex="^[ \t]*static ip_address[ \t]*=[ \t]*${IPV4_ADDRESS}"
-
-    # Check if static IP is already set in file
-    if grep -q "${regex}" /etc/dhcpcd.conf; then
-        printf "  %b Static IP already configured\\n" "${INFO}"
-    # If it's not,
-    else
-        # we can append these lines to dhcpcd.conf to enable a static IP
-        echo "interface ${PIHOLE_INTERFACE}
-        static ip_address=${IPV4_ADDRESS}
-        static routers=${IPv4gw}
-        static domain_name_servers=${PIHOLE_DNS_1} ${PIHOLE_DNS_2}" | tee -a /etc/dhcpcd.conf >/dev/null
-        # Then use the ip command to immediately set the new address
-        ip addr replace dev "${PIHOLE_INTERFACE}" "${IPV4_ADDRESS}"
-        # Also give a warning that the user may need to reboot their system
-        printf "  %b Set IP address to %s\\n" "${TICK}" "${IPV4_ADDRESS%/*}"
-        printf "  %b You may need to restart after the install is complete\\n" "${INFO}"
-    fi
 }
 
 # Check an IP address to see if it is a valid one


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

In August 2021 we dropped `dhcpcd5` as a requirement for Pi-hole. We continued to offer users on systems with **pre-installed** `dhcpcd5` to set a static IP address during the installation. This was meant to lower the entry barrier for new users on e.g. Raspbian. However, Raspbian ([is going) to switch to `network manager` as network system tool](https://github.com/pi-hole/pi-hole/issues/4902). 
We decided internally to remove the ability to set a static IP assignment during installations.

**How does this PR accomplish the above?:**

Remove the whole part offering to set a static IP during installation.

**Link documentation PRs if any are needed to support this PR:**

https://github.com/pi-hole/docs/pull/842

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
