### PR TITLE
Remove leftover from query.sh

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -77,7 +77,7 @@ fi
 
 # Strip valid options, leaving only the domain and invalid options
 # This allows users to place the options before or after the domain
-options=$(sed -E 's/ ?-(adlists?|all|exact) ?//g' <<< "${options}")
+options=$(sed -E 's/ ?-(all|exact) ?//g' <<< "${options}")
 
 # Handle remaining options
 # If $options contain non ASCII characters, convert to punycode


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Cleans `query.sh` from a single leftover. The `-adlist` option was removed by https://github.com/pi-hole/pi-hole/pull/3035

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
