### PR TITLE
Include mod_accesslog with new config

### DIFF
--- a/advanced/pihole-admin.conf
+++ b/advanced/pihole-admin.conf
@@ -79,4 +79,4 @@ $HTTP["host"] == "pi.hole" {
 }
 
 # (keep this on one line for basic-install.sh filtering during install)
-server.modules += ( "mod_access", "mod_redirect", "mod_fastcgi", "mod_setenv" )
+server.modules += ( "mod_access", "mod_accesslog", "mod_redirect", "mod_fastcgi", "mod_setenv" )

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1442,7 +1442,7 @@ installConfigs() {
             fi
             chmod 644 $conf
             if is_command lighty-enable-mod ; then
-                lighty-enable-mod pihole-admin access redirect fastcgi setenv > /dev/null || true
+                lighty-enable-mod pihole-admin access accesslog redirect fastcgi setenv > /dev/null || true
             else
                 # Otherwise, show info about installing them
                 printf "  %b Warning: 'lighty-enable-mod' utility not found\\n" "${INFO}"


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Prevents the following from occuring in the error log on fresh installs on debian-based distros (and by extension docker builds)
```
2023-01-16 10:20:01: configfile.c.1142) WARNING: unknown config-key: accesslog.filename (ignored)
2023-01-16 10:20:01: configfile.c.1142) WARNING: unknown config-key: accesslog.format (ignored)
```

This does not occur on upgrades because in those cases the old `lighttpd.conf` that we provided is not overwritten

https://github.com/pi-hole/docker-pi-hole/issues/1273

Fedora/centos are unaffected 

This could be fixed by running `lighttpd-enable-mod accesslog` in the docker container build script, but it is bound to show up here eventually.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_