### PR TITLE
No need to enable accesslog

### DIFF
--- a/advanced/lighttpd.conf.debian
+++ b/advanced/lighttpd.conf.debian
@@ -17,7 +17,6 @@
 
 server.modules = (
     "mod_access",
-    "mod_accesslog",
     "mod_auth",
     "mod_expire",
     "mod_redirect",

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1442,7 +1442,7 @@ installConfigs() {
             fi
             chmod 644 $conf
             if is_command lighty-enable-mod ; then
-                lighty-enable-mod pihole-admin access accesslog redirect fastcgi setenv > /dev/null || true
+                lighty-enable-mod pihole-admin access redirect fastcgi setenv > /dev/null || true
             else
                 # Otherwise, show info about installing them
                 printf "  %b Warning: 'lighty-enable-mod' utility not found\\n" "${INFO}"


### PR DESCRIPTION

**What does this PR aim to accomplish?:**

Don't enable `accesslog` module during installation. Undo a part of https://github.com/pi-hole/pi-hole/pull/5121.
Currently, consecutive updated of `development` will break, because `lighttpd` won't start. It's complaining about

```
sudo lighttpd -tt -f /etc/lighttpd/lighttpd.conf
Duplicate config variable in conditional 0 global: accesslog.filename
2023-01-18 13:54:31: configfile.c.1970) source: /etc/lighttpd/conf-enabled/10-accesslog.conf line: 4 pos: 1 parser failed somehow near here: (EOL)
2023-01-18 13:54:31: configfile.c.1970) source: /etc/lighttpd/lighttpd.conf line: 75 pos: 1 parser failed somehow near here: (EOL)
```

Reason is, with the enabled `accesslog` module, it will enable `10-accesslog.conf` containing two lines

```
server.modules += ( "mod_accesslog" )

accesslog.filename = "/var/log/lighttpd/access.log"

```

However, we already set a `accesslog.filename` in `15-pihole-admin.conf` and PR https://github.com/pi-hole/pi-hole/pull/5121 also added `server.modules +=  "mod_accesslog"` to that config. So I think enabling `accesslog` is not necessary.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
