### PR TITLE
Run updatechecker after gravity

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2717,11 +2717,11 @@ main() {
 
     restart_service pihole-FTL
 
-    # Update local and remote versions via updatechecker
-    /opt/pihole/updatecheck.sh
-
     # Download and compile the aggregated block list
     runGravity
+
+    # Update local and remote versions via updatechecker
+    /opt/pihole/updatecheck.sh
 
     if [[ "${useUpdateVars}" == false ]]; then
         displayFinalMessage "${pw}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Runs the `updatechecker` after `gravity` at the end of the installer script. Reason is that we restart `FTL` right before this operation and `FTL` could signal it's up to the init system despite the DNS resolution is not fully ready. This is an issue for the `updatechecker` which would fail to get the data from github in case **Pi-hole is the hosts DNS server**.  This was reported here: https://discourse.pi-hole.net/t/latest-version-check-returns-n-a-for-pi-hole/60387

Gravity runs a function to check for DNS availability a few times, giving `FTL` a little more time to start.

Fixes https://github.com/pi-hole/pi-hole/issues/5136

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
