### PR TITLE
Ensure that the directory /run/lighttpd exists, and that it is owned by www-data

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1403,12 +1403,16 @@ installConfigs() {
         # set permissions on /etc/lighttpd/lighttpd.conf so pihole user (other) can read the file
         chmod o+x /etc/lighttpd
         chmod o+r "${lighttpdConfig}"
+
+        # Ensure /run/lighttpd exists and is owned by lighttpd user
+        # Needed for the php socket
+        mkdir -p /run/lighttpd
+        chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /run/lighttpd
+
         if grep -q -F "FILE AUTOMATICALLY OVERWRITTEN BY PI-HOLE" "${lighttpdConfig}"; then
             # Attempt to preserve backwards compatibility with older versions
             install -D -m 644 -T ${PI_HOLE_LOCAL_REPO}/advanced/${LIGHTTPD_CFG} "${lighttpdConfig}"
             # Make the directories if they do not exist and set the owners
-            mkdir -p /run/lighttpd
-            chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /run/lighttpd
             mkdir -p /var/cache/lighttpd/compress
             chown ${LIGHTTPD_USER}:${LIGHTTPD_GROUP} /var/cache/lighttpd/compress
             mkdir -p /var/cache/lighttpd/uploads


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Since we changed back to using `/run/lighttpd` for the php socket file, we should really be ensuring that this path exists in all cases.

Needed to do this in docker as the path did not exist after creating the latest container https://github.com/pi-hole/docker-pi-hole/pull/1298

Oddly, running a fresh install on a bullseye droplet... the path exists, so this may only have affected Docker, however it does no harm to ensure this path exists, especially as we will be using it for the socket file 

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_