### PR TITLE
Only source versions file if the file exits

### DIFF
--- a/pihole
+++ b/pihole
@@ -24,7 +24,12 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 source "${utilsfile}"
 
 versionsfile="/etc/pihole/versions"
-source "${versionsfile}"
+if [ -f "${versionsfile}" ]; then
+    # Only source versionsfile if the file exits
+    # fixes a warning during installation where versionsfile does not exist yet
+    # but gravity calls `pihole -status` and thereby sourcing the file
+    source "${versionsfile}"
+fi
 
 webpageFunc() {
   source "${PI_HOLE_SCRIPT_DIR}/webpage.sh"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes warnings during first time installation that `/etc/pihole/versions` does not exists. I already fixed this with https://github.com/pi-hole/pi-hole/pull/5097 but accidentally reverted that change by https://github.com/pi-hole/pi-hole/pull/5137.

This PR should fix both issues: run `gravity` before `updatechecker` and suppress warning during first time installations.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
