### PR TITLE
Use buildx to create docker test images

### DIFF
--- a/test/tox.centos_8.ini
+++ b/test/tox.centos_8.ini
@@ -4,5 +4,5 @@ envlist = py3
 [testenv:py3]
 allowlist_externals = docker
 deps = -rrequirements.txt
-commands =  docker build -f _centos_8.Dockerfile -t pytest_pihole:test_container ../
+commands =  docker buildx build --load --progress plain -f _centos_8.Dockerfile -t pytest_pihole:test_container ../
             pytest {posargs:-vv -n auto} ./test_any_automated_install.py ./test_any_utils.py ./test_centos_fedora_common_support.py ./test_centos_common_support.py

--- a/test/tox.centos_9.ini
+++ b/test/tox.centos_9.ini
@@ -4,5 +4,5 @@ envlist = py3
 [testenv:py3]
 allowlist_externals = docker
 deps = -rrequirements.txt
-commands = docker build -f _centos_9.Dockerfile -t pytest_pihole:test_container ../
+commands = docker buildx build --load --progress plain -f _centos_9.Dockerfile -t pytest_pihole:test_container ../
            pytest {posargs:-vv -n auto} ./test_any_automated_install.py ./test_any_utils.py ./test_centos_fedora_common_support.py ./test_centos_common_support.py

--- a/test/tox.debian_10.ini
+++ b/test/tox.debian_10.ini
@@ -4,5 +4,5 @@ envlist = py3
 [testenv:py3]
 allowlist_externals = docker
 deps = -rrequirements.txt
-commands = docker build -f _debian_10.Dockerfile -t pytest_pihole:test_container ../
+commands = docker buildx build --load --progress plain -f _debian_10.Dockerfile -t pytest_pihole:test_container ../
            pytest {posargs:-vv -n auto} ./test_any_automated_install.py ./test_any_utils.py

--- a/test/tox.debian_11.ini
+++ b/test/tox.debian_11.ini
@@ -4,5 +4,5 @@ envlist = py3
 [testenv:py3]
 allowlist_externals = docker
 deps = -rrequirements.txt
-commands = docker build -f _debian_11.Dockerfile -t pytest_pihole:test_container ../
+commands = docker buildx build --load --progress plain -f _debian_11.Dockerfile -t pytest_pihole:test_container ../
            pytest {posargs:-vv -n auto} ./test_any_automated_install.py ./test_any_utils.py

--- a/test/tox.fedora_36.ini
+++ b/test/tox.fedora_36.ini
@@ -4,5 +4,5 @@ envlist = py3
 [testenv:py3]
 allowlist_externals = docker
 deps = -rrequirements.txt
-commands = docker build -f _fedora_36.Dockerfile -t pytest_pihole:test_container ../
+commands = docker buildx build --load --progress plain -f _fedora_36.Dockerfile -t pytest_pihole:test_container ../
            pytest {posargs:-vv -n auto} ./test_any_automated_install.py ./test_any_utils.py ./test_centos_fedora_common_support.py ./test_fedora_support.py

--- a/test/tox.fedora_37.ini
+++ b/test/tox.fedora_37.ini
@@ -4,5 +4,5 @@ envlist = py3
 [testenv]
 allowlist_externals = docker
 deps = -rrequirements.txt
-commands = docker build -f _fedora_37.Dockerfile -t pytest_pihole:test_container ../
+commands = docker buildx build --load --progress plain -f _fedora_37.Dockerfile -t pytest_pihole:test_container ../
            pytest {posargs:-vv -n auto} ./test_any_automated_install.py ./test_any_utils.py ./test_centos_fedora_common_support.py ./test_fedora_support.py

--- a/test/tox.ubuntu_20.ini
+++ b/test/tox.ubuntu_20.ini
@@ -4,5 +4,5 @@ envlist = py3
 [testenv:py3]
 allowlist_externals = docker
 deps = -rrequirements.txt
-commands = docker build -f _ubuntu_20.Dockerfile -t pytest_pihole:test_container ../
+commands = docker buildx build --load --progress plain -f _ubuntu_20.Dockerfile -t pytest_pihole:test_container ../
            pytest {posargs:-vv -n auto} ./test_any_automated_install.py ./test_any_utils.py

--- a/test/tox.ubuntu_22.ini
+++ b/test/tox.ubuntu_22.ini
@@ -4,5 +4,5 @@ envlist = py3
 [testenv:py3]
 allowlist_externals = docker
 deps = -rrequirements.txt
-commands = docker build -f _ubuntu_22.Dockerfile -t pytest_pihole:test_container ../
+commands = docker buildx build --load --progress plain -f _ubuntu_22.Dockerfile -t pytest_pihole:test_container ../
            pytest {posargs:-vv -n auto} ./test_any_automated_install.py ./test_any_utils.py


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We use `docker` to build different images to run our tests on. So far, we use `docker build` to create the images. However, this command is considered deprecated and newer docker instances will warn

```
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/
```

This PR will use the recommended `docker buildx build` command.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
