### PR TITLE
Filter ABP CSS selectors

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -770,7 +770,7 @@ gravity_ParseFileIntoDomains() {
   # 2) Remove carriage returns
   # 3) Remove lines starting with ! (ABP Comments)
   # 4) Remove lines starting with [ (ABP Header)
-  # 5) Remove lines containing ABP extended CSS selectors ("##", "#!#", "#@#", "#?#")
+  # 5) Remove lines containing ABP extended CSS selectors ("##", "#!#", "#@#", "#?#") preceded by a letter
   # 6) Remove comments (text starting with "#", include possible spaces before the hash sign)
   # 7) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
   # 8) Remove empty lines
@@ -779,7 +779,7 @@ gravity_ParseFileIntoDomains() {
     -e 's/\r$//' \
     -e 's/\s*!.*//g' \
     -e 's/\s*\[.*//g' \
-    -e '/\#[$?@]{0,1}\#/d' \
+    -e '/[a-z]\#[$?@]{0,1}\#/d' \
     -e 's/\s*#.*//g' \
     -e 's/^.*\s+//g' \
     -e '/^$/d' "${destination}"

--- a/gravity.sh
+++ b/gravity.sh
@@ -772,9 +772,8 @@ gravity_ParseFileIntoDomains() {
   # 4) Remove lines starting with [ (ABP Header)
   # 5) Remove lines containing ABP extended CSS selectors ("##", "#!#", "#@#", "#?#")
   # 6) Remove comments (text starting with "#", include possible spaces before the hash sign)
-  # 7) Remove lines containing "/"
-  # 8) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
-  # 9) Remove empty lines
+  # 7) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
+  # 8) Remove empty lines
 
     sed -i -r \
     -e 's/\r$//' \
@@ -782,7 +781,6 @@ gravity_ParseFileIntoDomains() {
     -e 's/\s*\[.*//g' \
     -e '/\#[!|?|@]{0,1}\#/d' \
     -e 's/\s*#.*//g' \
-    -e '/(\/).*$/d' \
     -e 's/^.*\s+//g' \
     -e '/^$/d' "${destination}"
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -768,18 +768,20 @@ gravity_ParseFileIntoDomains() {
   tr '[:upper:]' '[:lower:]' < "${src}" > "${destination}"
 
   # 2) Remove carriage returns
-  # 3) Remove comments (text starting with "#", include possible spaces before the hash sign)
-  # 4) Remove lines starting with ! (ABP Comments)
-  # 5) Remove lines starting with [ (ABP Header)
-  # 6) Remove lines containing "/"
-  # 7) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
-  # 8) Remove empty lines
+  # 3) Remove lines starting with ! (ABP Comments)
+  # 4) Remove lines starting with [ (ABP Header)
+  # 5) Remove lines containing ABP extended CSS selectors ("##", "#!#", "#@#", "#?#")
+  # 6) Remove comments (text starting with "#", include possible spaces before the hash sign)
+  # 7) Remove lines containing "/"
+  # 8) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
+  # 9) Remove empty lines
 
     sed -i -r \
     -e 's/\r$//' \
-    -e 's/\s*#.*//g' \
     -e 's/\s*!.*//g' \
     -e 's/\s*\[.*//g' \
+    -e '/\#[!|?|@]{0,1}\#/d' \
+    -e 's/\s*#.*//g' \
     -e '/(\/).*$/d' \
     -e 's/^.*\s+//g' \
     -e '/^$/d' "${destination}"

--- a/gravity.sh
+++ b/gravity.sh
@@ -779,7 +779,7 @@ gravity_ParseFileIntoDomains() {
     -e 's/\r$//' \
     -e 's/\s*!.*//g' \
     -e 's/\s*\[.*//g' \
-    -e '/\#[!|?|@]{0,1}\#/d' \
+    -e '/\#[$?@]{0,1}\#/d' \
     -e 's/\s*#.*//g' \
     -e 's/^.*\s+//g' \
     -e '/^$/d' "${destination}"

--- a/gravity.sh
+++ b/gravity.sh
@@ -768,25 +768,21 @@ gravity_ParseFileIntoDomains() {
   tr '[:upper:]' '[:lower:]' < "${src}" > "${destination}"
 
   # 2) Remove carriage returns
-  sed -i 's/\r$//' "${destination}"
+  # 3) Remove comments (text starting with "#", include possible spaces before the hash sign)
+  # 4) Remove lines starting with ! (ABP Comments)
+  # 5) Remove lines starting with [ (ABP Header)
+  # 6) Remove lines containing "/"
+  # 7) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
+  # 8) Remove empty lines
 
-  # 3a) Remove comments (text starting with "#", include possible spaces before the hash sign)
-  sed -i 's/\s*#.*//g' "${destination}"
-
-  # 3b) Remove lines starting with ! (ABP Comments)
-  sed -i 's/\s*!.*//g' "${destination}"
-
-  # 3c) Remove lines starting with [ (ABP Header)
-  sed -i 's/\s*\[.*//g' "${destination}"
-
-  # 4) Remove lines containing "/"
-  sed -i -r '/(\/).*$/d' "${destination}"
-
-  # 5) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
-  sed -i -r 's/^.*\s+//g' "${destination}"
-
-  # 6) Remove empty lines
-  sed -i '/^$/d' "${destination}"
+    sed -i -r \
+    -e 's/\r$//' \
+    -e 's/\s*#.*//g' \
+    -e 's/\s*!.*//g' \
+    -e 's/\s*\[.*//g' \
+    -e '/(\/).*$/d' \
+    -e 's/^.*\s+//g' \
+    -e '/^$/d' "${destination}"
 
   chmod 644 "${destination}"
 }


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Some ABP style lists contain lines with [(extended) CSS selectors](https://adblockplus.org/filter-cheatsheet#elementhideemulation): `##`, `#$#`, `#?#` and `#@#`

Currently our code strips all comments from the input file, converting e.g. `good.com##bad-element` to `good.com` leading to overblocking.
This PR deletes lines with CSS selectors **before** stripping comments.

Fixes https://github.com/pi-hole/pi-hole/issues/5246

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
