### PR TITLE
Trigger stale workflow on issue comments to remove stale label immediately

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
+  issue_comment:
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   issue_comment:
 
+env:
+  stale_label: stale
+
 jobs:
   stale_action:
     if: github.event_name != 'issue_comment'
@@ -20,7 +23,7 @@ jobs:
           days-before-stale: 30
           days-before-close: 5
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please comment or update this issue or it will be closed in 5 days.'
-          stale-issue-label: 'stale'
+          stale-issue-label: $stale_label
           exempt-issue-labels: 'Internal, Fixed in next release, Bug: Confirmed, Documentation Needed'
           exempt-all-issue-assignees: true
           operations-per-run: 300
@@ -36,7 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.4.0
       - name: Remove 'stale' label
-        run: gh issue edit ${{ github.event.issue.number }} --remove-label 'stale'
+        run: gh issue edit ${{ github.event.issue.number }} --remove-label $stale_label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,8 +7,8 @@ on:
   issue_comment:
 
 jobs:
-  stale:
-
+  stale_action:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -25,3 +25,18 @@ jobs:
           exempt-all-issue-assignees: true
           operations-per-run: 300
           close-issue-reason: 'not_planned'
+
+  remove_stale: # trigger "stale" removal immediately when stale issues are commented on
+    if: github.event_name == 'issue_comment'
+    permissions:
+      contents: read #  for actions/checkout
+      issues: write #  to edit issues label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.4.0
+      - name: Remove 'stale' label
+        run: gh issue edit ${{ github.event.issue.number }} --remove-label 'stale'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We use the `stale` action to mark issues stale after 30 days of inactivity. The actions runs only once a day to mark stale issues. If updates to issues occur (e.g. comments) the action removes the stale label. However, this happens so far only once a day - in the worst case leaving a "gap" of 23:59 between comments and label removal.

This PR adds a trigger to the stale workflow to run on `issue_comment`so that new comments should remove the label immediately.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
