### PR TITLE
Don't use '--suffix' in mktemp

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -165,7 +165,10 @@ database_table_from_file() {
   src="${2}"
   backup_path="${piholeDir}/migration_backup"
   backup_file="${backup_path}/$(basename "${2}")"
-  tmpFile="$(mktemp -p "${GRAVITY_TMPDIR}" --suffix=".gravity")"
+  # Create a temporary file. We don't use '--suffix' here because not all
+  # implementations of mktemp support it, e.g. on Alpine
+  tmpFile="$(mktemp -p "${GRAVITY_TMPDIR}")"
+  mv "${tmpFile}" "${tmpFile%.*}.gravity"
 
   local timestamp
   timestamp="$(date --utc +'%s')"
@@ -438,7 +441,10 @@ gravity_DownloadBlocklists() {
     echo -e "${OVER}  ${TICK} ${str}"
   fi
 
-  target="$(mktemp -p "${GRAVITY_TMPDIR}" --suffix=".gravity")"
+  # Create a temporary file. We don't use '--suffix' here because not all
+  # implementations of mktemp support it, e.g. on Alpine
+  target="$(mktemp -p "${GRAVITY_TMPDIR}")"
+  mv "${target}" "${target%.*}.gravity"
 
   # Use compression to reduce the amount of data that is transferred
   # between the Pi-hole and the ad list provider. Use this feature
@@ -568,7 +574,9 @@ parseList() {
   fi
 
   # For completeness, we will get a count of non_domains (this is the number of entries left after stripping the source of comments/duplicates/false positives/domains)
-  invalid_domains="$(mktemp -p "${GRAVITY_TMPDIR}" --suffix=".ph-non-domains")"
+  # We don't use '--suffix' here because not all implementations of mktemp support it, e.g. on Alpine
+  invalid_domains=$(mktemp -p "${GRAVITY_TMPDIR}")
+  mv "${invalid_domains}" "${invalid_domains%.*}.ph-non-domains"
 
   num_non_domains=$(grep -Ev "^(${valid_domain_pattern}|${abp_domain_pattern}|${false_positives})$" "${src}" | tee "${invalid_domains}" | wc -l)
 
@@ -618,7 +626,9 @@ gravity_DownloadBlocklistFromUrl() {
   local heisenbergCompensator="" listCurlBuffer str httpCode success="" ip cmd_ext
 
   # Create temp file to store content on disk instead of RAM
-  listCurlBuffer=$(mktemp -p "${GRAVITY_TMPDIR}" --suffix=".phgpb")
+  # We don't use '--suffix' here because not all implementations of mktemp support it, e.g. on Alpine
+  listCurlBuffer="$(mktemp -p "${GRAVITY_TMPDIR}")"
+  mv "${listCurlBuffer}" "${listCurlBuffer%.*}.phgpb"
 
   # Determine if $saveLocation has read permission
   if [[ -r "${saveLocation}" && $url != "file"* ]]; then


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

I'm going to make `pihole` running on Alpine (and Alpine based docker) which requires a few changes to our scripts.
`busybox's` `mktemp` does not support the `--suffix` option, therefore we need a two-step approach to create temporary files with a set suffix.

We only used the `--suffix` option in `gravity.sh`

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
