### PR TITLE
Fix Faulty Regex pattern in custom DNS domain validation

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -664,7 +664,7 @@ checkDomain()
     local domain validDomain
     # Convert to lowercase
     domain="${1,,}"
-    validDomain=$(grep -P "^((-|_)*[a-z0-9]((-|_)*[a-z0-9)*(-|_)*)(\\.(-|_)*([a-z0-9]((-|_)*[a-z0-9])*))*$" <<< "${domain}") # Valid chars check
+    validDomain=$(grep -P "^((-|_)*[a-z0-9]((-|_)*[a-z0-9])*(-|_)*)(\\.(-|_)*([a-z0-9]((-|_)*[a-z0-9])*))*$" <<< "${domain}") # Valid chars check
     validDomain=$(grep -P "^[^\\.]{1,63}(\\.[^\\.]{1,63})*$" <<< "${validDomain}") # Length of each label
     echo "${validDomain}"
 }

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -1151,3 +1151,30 @@ def test_package_manager_has_web_deps(host):
 
     assert "No package" not in output.stdout
     assert output.rc == 0
+
+
+def test_webpage_sh_valid_domain(host):
+    """Confirms checkDomain function in webpage.sh works as expected"""
+    check1 = host.run(
+        """
+    source /opt/pihole/webpage.sh
+    checkDomain "pi-hole.net"
+    """
+    )
+    check2 = host.run(
+        """
+    source /opt/pihole/webpage.sh
+    checkDomain "ab.pi-hole.net"
+    """
+    )
+
+    check3 = host.run(
+        """
+    source /opt/pihole/webpage.sh
+    checkDomain "abc.pi-hole.net"
+    """
+    )
+
+    assert "pi-hole.net" in check1.stdout
+    assert "ab.pi-hole.net" in check2.stdout
+    assert "abc.pi-hole.net" in check3.stdout


### PR DESCRIPTION

### **What does this PR aim to accomplish?:**

Fixes #5290  by adding the `]` back in where it was accidentally removed

```
root@docker-pihole-pi4:/# grep -P "^((-|_)*[a-z0-9]((-|_)*[a-z0-9])*(-|_)*)(\\.(-|_)*([a-z0-9]((-|_)*[a-z0-9])*))*$" <<< "db.rg-10.hm"
db.rg-10.hm
root@docker-pihole-pi4:/# grep -P "^((-|_)*[a-z0-9]((-|_)*[a-z0-9])*(-|_)*)(\\.(-|_)*([a-z0-9]((-|_)*[a-z0-9])*))*$" <<< "my.rg-10.hm"
my.rg-10.hm
root@docker-pihole-pi4:/# grep -P "^((-|_)*[a-z0-9]((-|_)*[a-z0-9])*(-|_)*)(\\.(-|_)*([a-z0-9]((-|_)*[a-z0-9])*))*$" <<< "mydb.rg-10.hm"
mydb.rg-10.hm
```

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_