### PR TITLE
Do not remove -all|exact when not surrounded by space in query.sh

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -50,7 +50,7 @@ fi
 
 # Strip valid options, leaving only the domain and invalid options
 # This allows users to place the options before or after the domain
-options=$(sed -E 's/ ?-(all|exact) ?//g' <<< "${options}")
+options=$(sed -E 's/ +-(all|exact) ?//g' <<< "${options}")
 
 # Handle remaining options
 # If $options contain non ASCII characters, convert to punycode


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix issue https://github.com/pi-hole/pi-hole/issues/5299.

Within `query.sh` we remove the arguments `-all` and `-exact` from the string to query the adlists. However, we used `?` as a multiplier after a space seperator which translates to 'zero or more'. But we want to have **one or more** (spaces) which is a `+` multiplier.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
