### PR TITLE
Add code to remove old lighttpd config files left over from v5. 

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1001,6 +1001,38 @@ remove_old_dnsmasq_ftl_configs() {
     fi
 }
 
+remove_old_pihole_lighttpd_configs() {
+    local lighttpdConfig="/etc/lighttpd/lighttpd.conf"
+    local condfd="/etc/lighttpd/conf.d/pihole-admin.conf"
+    local confavailable="/etc/lighttpd/conf-available/15-pihole-admin.conf"
+    local confenabled="/etc/lighttpd/conf-enabled/15-pihole-admin.conf"
+
+
+    if [[ -d "/etc/lighttpd/conf.d" ]]; then
+        if grep -q -F 'include "/etc/lighttpd/conf.d/pihole-admin.conf"' "${lighttpdConfig}"; then
+           sed -i '/include "/etc/lighttpd/conf.d/pihole-admin.conf"/d' "${lighttpdConfig}"
+        fi
+
+        if [[ -f "${condfd}" ]]; then
+            rm "${condfd}"
+        fi
+
+
+    elif [[ -d "/etc/lighttpd/conf-available" ]]; then
+        if is_command lighty-disable-mod ; then
+            lighty-disable-mod pihole-admin > /dev/null || true
+        fi
+
+        if [[ -f "${confavailable}" ]]; then
+            rm "${confavailable}"
+        fi
+
+        if [[ -f "${confenabled}" ]]; then
+            rm "${confenabled}"
+        fi
+     fi
+}
+
 # Clean an existing installation to prepare for upgrade/reinstall
 clean_existing() {
     # Local, named variables
@@ -1486,6 +1518,7 @@ installPihole() {
     fi
 
     remove_old_dnsmasq_ftl_configs
+    remove_old_pihole_lighttpd_configs
 
     # Install config files
     if ! installConfigs; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1010,7 +1010,7 @@ remove_old_pihole_lighttpd_configs() {
 
     if [[ -d "/etc/lighttpd/conf.d" ]]; then
         if grep -q -F 'include "/etc/lighttpd/conf.d/pihole-admin.conf"' "${lighttpdConfig}"; then
-           sed -i '/include "/etc/lighttpd/conf.d/pihole-admin.conf"/d' "${lighttpdConfig}"
+           sed -i '/include "\/etc\/lighttpd\/conf.d\/pihole-admin.conf"/d' "${lighttpdConfig}"
         fi
 
         if [[ -f "${condfd}" ]]; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1009,9 +1009,7 @@ remove_old_pihole_lighttpd_configs() {
 
 
     if [[ -d "/etc/lighttpd/conf.d" ]]; then
-        if grep -q -F 'include "/etc/lighttpd/conf.d/pihole-admin.conf"' "${lighttpdConfig}"; then
-           sed -i '/include "\/etc\/lighttpd\/conf.d\/pihole-admin.conf"/d' "${lighttpdConfig}"
-        fi
+        sed -i '/include "\/etc\/lighttpd\/conf.d\/pihole-admin.conf"/d' "${lighttpdConfig}"
 
         if [[ -f "${condfd}" ]]; then
             rm "${condfd}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1008,27 +1008,25 @@ remove_old_pihole_lighttpd_configs() {
     local confenabled="/etc/lighttpd/conf-enabled/15-pihole-admin.conf"
 
 
-    if [[ -d "/etc/lighttpd/conf.d" ]]; then
+    if [[ -f "${lighttpdConfig}" ]]; then
         sed -i '/include "\/etc\/lighttpd\/conf.d\/pihole-admin.conf"/d' "${lighttpdConfig}"
+    fi
 
-        if [[ -f "${condfd}" ]]; then
-            rm "${condfd}"
-        fi
+    if [[ -f "${condfd}" ]]; then
+        rm "${condfd}"
+    fi
 
+    if is_command lighty-disable-mod ; then
+        lighty-disable-mod pihole-admin > /dev/null || true
+    fi
 
-    elif [[ -d "/etc/lighttpd/conf-available" ]]; then
-        if is_command lighty-disable-mod ; then
-            lighty-disable-mod pihole-admin > /dev/null || true
-        fi
+    if [[ -f "${confavailable}" ]]; then
+        rm "${confavailable}"
+    fi
 
-        if [[ -f "${confavailable}" ]]; then
-            rm "${confavailable}"
-        fi
-
-        if [[ -f "${confenabled}" ]]; then
-            rm "${confenabled}"
-        fi
-     fi
+    if [[ -f "${confenabled}" ]]; then
+        rm "${confenabled}"
+    fi
 }
 
 # Clean an existing installation to prepare for upgrade/reinstall

--- a/gravity.sh
+++ b/gravity.sh
@@ -178,7 +178,7 @@ database_table_from_file() {
         echo "${rowid},\"${domain}\",${timestamp}" >> "${tmpFile}"
       elif [[ "${table}" == "adlist" ]]; then
         # Adlist table format
-        echo "${rowid},\"${domain}\",1,${timestamp},${timestamp},\"Migrated from ${src}\",,0,0,0" >> "${tmpFile}"
+        echo "${rowid},\"${domain}\",1,${timestamp},${timestamp},\"Migrated from ${src}\",,0,0,0,0" >> "${tmpFile}"
       else
         # White-, black-, and regexlist table format
         echo "${rowid},${list_type},\"${domain}\",1,${timestamp},${timestamp},\"Migrated from ${src}\"" >> "${tmpFile}"


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

in V6 we will no longer have lighttpd - therefore if we are coming from a v5.x version, we should remove any of lighttpd config we have added to avoid confusion.

Basically reverses what we do here:

https://github.com/pi-hole/pi-hole/blob/6a45c6a8e027e1ac30d4556a88f31684bc80ccf1/automated%20install/basic-install.sh#L1402-L1472

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_