### PR TITLE
Switch to new branch name for FTL v6 development

### DIFF
--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -82,7 +82,7 @@ def test_installPihole_fresh_install_readableFiles(host):
     # Workaround to get FTLv6 installed until it reaches master branch
     host.run(
         """
-    echo "new/http" > /etc/pihole/ftlbranch
+    echo "development-v6" > /etc/pihole/ftlbranch
     """
     )
     install = host.run(

--- a/test/test_any_utils.py
+++ b/test/test_any_utils.py
@@ -137,7 +137,7 @@ def test_getFTLConfigValue_getFTLConfigValue(host):
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
-    echo "new/http" > /etc/pihole/ftlbranch
+    echo "development-v6" > /etc/pihole/ftlbranch
     binary="pihole-FTL${funcOutput##*pihole-FTL}"
     theRest="${funcOutput%pihole-FTL*}"
     FTLdetect "${binary}" "${theRest}"


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Currently tests have the `new/http` branch of ftl hardcoded into them. This is/has change[d] to `development-v6` to add some consistency between the repos

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_