### PR TITLE
Etag

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -563,9 +563,9 @@ gravity_DownloadBlocklistFromUrl() {
     cmd_ext="--resolve $domain:$port:$ip"
   fi
 
-  if [ -f "${piholeDir}/list.${id}.${domain}.etag" ]
+  if [ -f "${piholeDir}/list.${id}.${domain}.header" ]
 	then
-	  currentetag=$(<"${piholeDir}/list.${id}.${domain}.etag")
+	  currentetag=$(sed -n 's/^etag: //Ip' < "${piholeDir}/list.${id}.${domain}.header")
 	else
 	  currentetag=$""
   fi
@@ -575,20 +575,20 @@ gravity_DownloadBlocklistFromUrl() {
    # shellcheck disable=SC2086
   ####httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" 2> /dev/null)
 
-if [ -z "$currentetag" ]
+  if [ -z "$currentetag" ]
 	then
-		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" 2> /dev/null)
+		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" -D "${piholeDir}/list.${id}.${domain}.header" 2> /dev/null)
 	else
-		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} --header "If-None-Match: ${currentetag}" -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" 2> /dev/null)
+		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} --header "If-None-Match: ${currentetag}" -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" -D "${piholeDir}/list.${id}.${domain}.header" 2>> /dev/null)
  fi
 
 # shellcheck disable=SC2086
   curl -sI "${url}" -L ${compression} ${cmd_ext} ${heisenbergCompensator} -A "${agent}" | sed -n 's/^etag: //Ip' > "${piholeDir}/list.${id}.${domain}.etag"
 
-# if [ "${httpCode}" != 304 ]
-# then
+#  if [ "${httpCode}" != 304 ]
+#	then
 #	echo -e "\n statuscode: " "$httpCode"
-#	newetag=$(<"${piholeDir}/list.${id}.${domain}.etag")
+#	newetag=$(cat "${piholeDir}/list.${id}.${domain}.header"|sed -n 's/^etag: //Ip')
 #	echo -e "\n new Etag:     " "$newetag"
 #  fi
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -563,8 +563,34 @@ gravity_DownloadBlocklistFromUrl() {
     cmd_ext="--resolve $domain:$port:$ip"
   fi
 
-  # shellcheck disable=SC2086
-  httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" 2> /dev/null)
+  if [ -f "${piholeDir}/list.${id}.${domain}.etag" ]
+	then
+	  currentetag=$(<"${piholeDir}/list.${id}.${domain}.etag")
+	else
+	  currentetag=$""
+  fi
+
+  #echo -e "\n current Etag: " "$currentetag"
+
+   # shellcheck disable=SC2086
+  ####httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" 2> /dev/null)
+
+if [ -z "$currentetag" ]
+	then
+		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" 2> /dev/null)
+	else
+		httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} --header "If-None-Match: ${currentetag}" -w "%{http_code}" -A "${agent}" "${url}" -o "${listCurlBuffer}" 2> /dev/null)
+ fi
+
+# shellcheck disable=SC2086
+  curl -sI "${url}" -L ${compression} ${cmd_ext} ${heisenbergCompensator} -A "${agent}" | sed -n 's/^etag: //Ip' > "${piholeDir}/list.${id}.${domain}.etag"
+
+# if [ "${httpCode}" != 304 ]
+# then
+#	echo -e "\n statuscode: " "$httpCode"
+#	newetag=$(<"${piholeDir}/list.${id}.${domain}.etag")
+#	echo -e "\n new Etag:     " "$newetag"
+#  fi
 
   case $url in
     # Did we "download" a local file?


### PR DESCRIPTION
Signed-off-by: Yoshimo [yoshimo@users.noreply.github.com](mailto:yoshimo@users.noreply.github.com)

What does this PR aim to accomplish?:
  
  It tries to save bandwith by avoiding unneccessary downloads of files that haven't changed on the remote location since we last downloaded them.

How does this PR accomplish the above?:

  If the remote server supplies an etag header we store it for every list locally.
      When we refresh a list we check if there is an etag stored for this entry and if we have an etag we add a "if-none-match: " header to the request.
      The remote server compares our etag with its local database and if the conclusion is, that there hasn't been any change on the file, it will send us back a 304 not-modified status code.
      We then use our local copy, avoid an unneccessary re-download and move on to the next entry on our list.