### PR TITLE
Set new gravity database version to 16

### DIFF
--- a/advanced/Templates/gravity.db.sql
+++ b/advanced/Templates/gravity.db.sql
@@ -58,7 +58,7 @@ CREATE TABLE info
 	value TEXT NOT NULL
 );
 
-INSERT INTO "info" VALUES('version','15');
+INSERT INTO "info" VALUES('version','16');
 
 CREATE TABLE domain_audit
 (


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Fixes the following error when running gravity:

```
[i] Upgrading gravity database from version 15 to 16
Parse error near line 7: duplicate column name: abp_entries
```

Gravity is still all kinds of broken, but lets take this in baby steps

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_