### PR TITLE
If ${USER} variable is blank, then populate it with whoami

### DIFF
--- a/pihole
+++ b/pihole
@@ -544,6 +544,13 @@ if [[ ! $EUID -eq 0 && need_root -eq 1 ]];then
     exit 1
   fi
 fi
+
+# In the case of alpine running in a container, the USER variable appears to be blank
+# which prevents the next trap from working correctly. Set it by running whoami
+if [[ -z ${USER} ]]; then
+  USER=$(whoami)
+fi
+
 # Can also be user pihole for other functions
 if [[ ${USER} != "pihole" && need_root -eq 0 ]];then
   if [[ -x "$(command -v sudo)" ]]; then


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Running `pihole -g` inside the container never appears to fall into the trap that runs `pihole -g` as user `pihole` because the `${USER}` variable is always blank. (Tested by adding echos into gravity)

This is fine when `root` runs `pihole -g` on the command line, but when `pihole-FTL` (which is running as `pihole`) attempts to run it like this, then we get an error because `pihole` cannot run `pihole` as `pihole`....

The other side to this fix is to add `pihole` into the `sudoers` file in the container so that it can run `/usr/local/bin/pihole` (PR to follow)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_