### PR TITLE
Update test dependencies (v5)

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,4 @@
-docker-compose == 1.29.2
+pyyaml == 6.0.1
 pytest == 7.4.0
 pytest-xdist == 3.3.1
 pytest-testinfra == 8.1.0


### PR DESCRIPTION
See https://github.com/yaml/pyyaml/issues/601, specifically https://github.com/yaml/pyyaml/issues/601#issuecomment-1638528905

Edit: pyyaml 6.0.1 released: https://github.com/yaml/pyyaml/pull/702, so we can use that.

We also drop docker-compose here, as we're not using it (and it relies on pyyaml <6)