### PR TITLE
Use port 8080 only if 80 is already taken

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2243,6 +2243,14 @@ main() {
         mv /var/log/pihole*.* /var/log/pihole/ 2>/dev/null
     fi
 
+    # v5 -> v6 upgrade path
+    # if port 80 is already taken, e.g. on update where lighttpd is installed, change the default port to 8080
+    # this should be no issue on upgrades/repairs if FTL is the only webserver as we stop it right above and it should free port 80
+
+    if ss --listening --numeric --tcp --udp | grep -q ":80" ; then
+        setFTLConfigValue webserver.port 8080
+    fi
+
     restart_service pihole-FTL
 
     # Download and compile the aggregated block list


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

User expect to open the web interface via `pi.hole/admin/` and not `pi.hole:8080/admin/`. 

This PR changes the port of the web server only to 8080 if port 80 is already taken. This will be the case on updates, where `lighttpd` is still installed or anther webserver is running, but not on fresh installs.

**How does this PR accomplish the above?:**

Adds a check for used ports during install/updates after FTL has been stopped and before it's restarted.

In conjunction with: https://github.com/pi-hole/FTL/pull/1608

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
