### PR TITLE
Set owner of gravity output files to pihole

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1085,12 +1085,15 @@ installScripts() {
 installConfigs() {
     printf "\\n  %b Installing configs from %s...\\n" "${INFO}" "${PI_HOLE_LOCAL_REPO}"
 
+    # Ensure that permissions are correctly set
+    chown -R pihole:pihole /etc/pihole
 
     # Install list of DNS servers
     # Format: Name;Primary IPv4;Secondary IPv4;Primary IPv6;Secondary IPv6
     # Some values may be empty (for example: DNS servers without IPv6 support)
     echo "${DNS_SERVERS}" > "${PI_HOLE_CONFIG_DIR}/dns-servers.conf"
     chmod 644 "${PI_HOLE_CONFIG_DIR}/dns-servers.conf"
+    chown pihole:pihole "${PI_HOLE_CONFIG_DIR}/dns-servers.conf"
 
     # Install empty custom.list file if it does not exist
     if [[ ! -r "${PI_HOLE_CONFIG_DIR}/custom.list" ]]; then
@@ -1386,7 +1389,7 @@ installCron() {
 # which is what Pi-hole needs to begin blocking ads
 runGravity() {
     # Run gravity in the current shell as user pihole
-    { exec sudo -u pihole bash /opt/pihole/gravity.sh --force; }
+    { sudo -u pihole bash /opt/pihole/gravity.sh --force; }
 }
 
 # Check if the pihole user exists and create if it does not
@@ -1480,7 +1483,7 @@ installLogrotate() {
         return 2
     fi
     # Copy the file over from the local repo
-    install -D -m 644 -T "${PI_HOLE_LOCAL_REPO}"/advanced/Templates/logrotate ${target}
+    install -o pihole -g pihole -D -m 644 -T "${PI_HOLE_LOCAL_REPO}"/advanced/Templates/logrotate ${target}
     # Different operating systems have different user / group
     # settings for logrotate that makes it impossible to create
     # a static logrotate file that will work with e.g.
@@ -2049,6 +2052,7 @@ copy_to_install_log() {
     # Since we use color codes such as '\e[1;33m', they should be removed
     sed 's/\[[0-9;]\{1,5\}m//g' < /proc/$$/fd/3 > "${installLogLoc}"
     chmod 644 "${installLogLoc}"
+    chown pihole:pihole "${installLogLoc}"
 }
 
 main() {
@@ -2142,7 +2146,7 @@ main() {
         # Display welcome dialogs
         welcomeDialogs
         # Create directory for Pi-hole storage (/etc/pihole/)
-        install -o pihole -g pihole -d -m 660 "${PI_HOLE_CONFIG_DIR}"
+        install -d -m 755 "${PI_HOLE_CONFIG_DIR}"
         # Determine available interfaces
         get_available_interfaces
         # Find interfaces and let the user choose one

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1385,8 +1385,8 @@ installCron() {
 # Gravity is a very important script as it aggregates all of the domains into a single HOSTS formatted list,
 # which is what Pi-hole needs to begin blocking ads
 runGravity() {
-    # Run gravity in the current shell
-    { /opt/pihole/gravity.sh --force; }
+    # Run gravity in the current shell as user pihole
+    { exec sudo -u pihole bash /opt/pihole/gravity.sh --force; }
 }
 
 # Check if the pihole user exists and create if it does not

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2141,8 +2141,8 @@ main() {
     if [[ "${useUpdateVars}" == false ]]; then
         # Display welcome dialogs
         welcomeDialogs
-        # Create directory for Pi-hole storage
-        install -d -m 755 /etc/pihole/
+        # Create directory for Pi-hole storage (/etc/pihole/)
+        install -o pihole -g pihole -d -m 660 "${PI_HOLE_CONFIG_DIR}"
         # Determine available interfaces
         get_available_interfaces
         # Find interfaces and let the user choose one

--- a/gravity.sh
+++ b/gravity.sh
@@ -488,6 +488,10 @@ compareLists() {
     # We assume here it was changed upstream
     database_adlist_status "${adlistID}" "1"
   fi
+
+  # set owner of the file to pihole
+  chown pihole:pihole "${target}.sha1"
+
 }
 
 # Download specified URL and perform checks on HTTP status and file content
@@ -621,6 +625,9 @@ gravity_DownloadBlocklistFromUrl() {
       database_adlist_status "${adlistID}" "4"
     fi
   fi
+
+  # set owner of the file to pihole
+  chown pihole:pihole "${saveLocation}"
 }
 
 # Parse source files into domains format

--- a/gravity.sh
+++ b/gravity.sh
@@ -488,10 +488,6 @@ compareLists() {
     # We assume here it was changed upstream
     database_adlist_status "${adlistID}" "1"
   fi
-
-  # set owner of the file to pihole
-  chown pihole:pihole "${target}.sha1"
-
 }
 
 # Download specified URL and perform checks on HTTP status and file content
@@ -625,9 +621,6 @@ gravity_DownloadBlocklistFromUrl() {
       database_adlist_status "${adlistID}" "4"
     fi
   fi
-
-  # set owner of the file to pihole
-  chown pihole:pihole "${saveLocation}"
 }
 
 # Parse source files into domains format


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes permission issues with downloaded list and `*.sha` files that occurs on v6. All files in `/etc/pihole` should belong to `pihole` (See https://github.com/pi-hole/pi-hole/pull/5356). However, during `pihole -up` (which runs as root), the install script is called, which in turn runs `gravity` from `/opt/pihole`. All touched files will be owned by `root` afterwards. 

In contrast, `pihole -g` runs gravity as `pihole` which causes issues at https://github.com/pi-hole/pi-hole/blob/96640ea2c8272c22e244893b204b8da77a82298a/gravity.sh#L635

```
rw-rw----  1 pihole pihole  408  8. Okt 22:20 install.log
-rw-r--r--  1 root   root   2,9M  8. Okt 22:20 list.1.raw.githubusercontent.com.domains
-rw-r--r--  1 root   root     95  8. Okt 22:20 list.1.raw.githubusercontent.com.domains.sha1
-rw-r--r--  1 root   root   403K  8. Okt 22:20 list.2.sysctl.org.domains
-rw-r--r--  1 root   root     80  8. Okt 22:20 list.2.sysctl.org.domains.sha1
-rw-r--r--  1 root   root   913K  8. Okt 22:20 list.3.raw.githubusercontent.com.domains
-rw-r--r--  1 root   root     95  8. Okt 22:20 list.3.raw.githubusercontent.com.domains.sha1
-rw-r--r--  1 root   root   842K  8. Okt 22:20 list.4.small.oisd.nl.domains
-rw-r--r--  1 root   root     83  8. Okt 22:20 list.4.small.oisd.nl.domains.sha1
-rw-r--r--  1 pihole pihole   65  8. Okt 22:20 local.list
-rw-rw----  1 pihole pihole  241  1. Aug 23:15 logrotate
-rw-rw----  1 pihole pihole 3,0M  8. Okt 21:41 macvendor.db
drw-rw----  2 pihole pihole 4,0K  1. Aug 23:16 migration_backup
-rw-rw----  1 pihole pihole  127  1. Aug 23:15 pihole-FTL.conf.bck
-rw-rw-r--  1 pihole pihole  18M  8. Okt 22:22 pihole-FTL.db
-rw-rw----  1 pihole pihole  39K  8. Okt 22:20 pihole.toml
-rw-rw----  1 pihole pihole  347  1. Aug 23:16 setupVars.conf
-rw-rw----  1 pihole pihole  648  1. Aug 23:18 tls.crt
-rw-rw----  1 pihole pihole  936  1. Aug 23:18 tls.pem
-rw-r--r--  1 pihole pihole  385  8. Okt 22:20 versions
nanopi@nanopi:~$ pihole -g
[sudo] Passwort für nanopi: 
  [i] Neutrino emissions detected...
  [i] Storing gravity database in /etc/pihole/gravity.db
  [✓] Pulling blocklist source list into range

  [✓] Preparing new gravity database
  [✓] Creating new gravity databases
  [i] Using libz compression

  [i] Target: https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
  [✓] Status: Retrieval successful
/opt/pihole/gravity.sh: line 635: /etc/pihole/list.1.raw.githubusercontent.com.domains: Permission denied


```


**How does this PR accomplish the above?:**

Explicitly set the invoking user to `pihole` in `basic-install.sh` when running gravity. As the gravity run is one of the last things we do, `pihole` should already be available.
Additionally, this requires that that `/etc/pihole` is writable by `pihole` already at that stage.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
