### PR TITLE
Allow pihole to access subdirs in /etc/pihole

### DIFF
--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -9,19 +9,26 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # Get file paths
 FTL_PID_FILE="$(getFTLPIDFile)"
 
-# Touch files to ensure they exist (create if non-existing, preserve if existing)
-# shellcheck disable=SC2174
-mkdir -pm 0755 /var/log/pihole
-[ -f "${FTL_PID_FILE}" ] || install -D -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"
-[ -f /var/log/pihole/FTL.log ] || install -m 644 -o pihole -g pihole /dev/null /var/log/pihole/FTL.log
-[ -f /var/log/pihole/pihole.log ] || install -m 640 -o pihole -g pihole /dev/null /var/log/pihole/pihole.log
-[ -f /etc/pihole/dhcp.leases ] || install -m 644 -o pihole -g pihole /dev/null /etc/pihole/dhcp.leases
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
+# shellcheck disable=SC2174
+mkdir -pm 0640 /var/log/pihole
 chown -R pihole:pihole /etc/pihole /var/log/pihole
 chmod -R 0640 /var/log/pihole
 chmod -R 0660 /etc/pihole
+
 # allow all users to enter the directories
 chmod 0755 /etc/pihole /var/log/pihole
+
+# allow pihole to access subdirs in /etc/pihole (sets execution bit on dirs)
+# credits https://stackoverflow.com/a/11512211
+find /etc/pihole -type d -exec chmod 0755 {} \;
+
+# Touch files to ensure they exist (create if non-existing, preserve if existing)
+[ -f "${FTL_PID_FILE}" ] || install -D -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"
+[ -f /var/log/pihole/FTL.log ] || install -m 640 -o pihole -g pihole /dev/null /var/log/pihole/FTL.log
+[ -f /var/log/pihole/pihole.log ] || install -m 640 -o pihole -g pihole /dev/null /var/log/pihole/pihole.log
+[ -f /etc/pihole/dhcp.leases ] || install -m 644 -o pihole -g pihole /dev/null /etc/pihole/dhcp.leases
+
 
 # Backward compatibility for user-scripts that still expect log files in /var/log instead of /var/log/pihole
 # Should be removed with Pi-hole v6.0


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Before `FTL` starts we execute the pre-start script, which ensures that permissions are set correctly to various files and dirs. 

https://github.com/pi-hole/pi-hole/blob/96640ea2c8272c22e244893b204b8da77a82298a/advanced/Templates/pihole-FTL-prestart.sh#L19-L24

However, we forgot to set the execution bit on the subdirs in `/etc/pihole` so `FTL` (running as `pihole` user) was not able to access the dirs , despite being the owner of the dirs. This resulted in errors on each `FTL` restart like

```
2023-10-13 08:58:14.547 [180M] WARNING: copy_file(): Failed to open "/etc/pihole/config_backups/pihole.toml.1" for writing: Permission denied
2023-10-13 08:58:14.547 [180M] WARNING: Rotation /etc/pihole/pihole.toml -(COPY)> /etc/pihole/config_backups/pihole.toml.1 failed
2023-10-13 08:58:14.547 [180M] INFO: Writing config file
2023-10-13 08:58:14.548 [180M] WARNING: copy_file(): Failed to open "/etc/pihole/config_backups/dnsmasq.conf.1" for writing: Permission denied
2023-10-13 08:58:14.548 [180M] WARNING: Rotation /etc/pihole/dnsmasq.conf -(COPY)> /etc/pihole/config_backups/dnsmasq.conf.1 failed
2023-10-13 08:58:14.548 [180M] WARNING: copy_file(): Failed to open "/etc/pihole/config_backups/custom.list.1" for writing: Permission denied
2023-10-13 08:58:14.548 [180M] WARNING: Rotation /etc/pihole/custom.list -(COPY)> /etc/pihole/config_backups/custom.list.1 failed
```

**How does this PR accomplish the above?:**

Set the execution bit on subdirs in `/etc/pihole`.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
