### PR TITLE
Avoid printing getFTLConfigValue return in statusFunc()

### DIFF
--- a/pihole
+++ b/pihole
@@ -345,7 +345,7 @@ analyze_ports() {
 
 statusFunc() {
     # Determine if there is pihole-FTL service is listening
-    local pid port ftl_pid_file
+    local pid port ftl_pid_file block_status
 
     ftl_pid_file="$(getFTLPIDFile)"
 
@@ -375,7 +375,8 @@ statusFunc() {
     fi
 
   # Determine if Pi-hole's blocking is enabled
-  if getFTLConfigValue dns.blocking.active; then
+  block_status=$(getFTLConfigValue dns.blocking.active)
+  if [ ${block_status} == "true" ]; then
     case "${1}" in
       "web") echo "$port";;
       *) echo -e "  ${TICK} Pi-hole blocking is enabled";;


### PR DESCRIPTION
### What does this PR aim to accomplish?

`pihole status` is printing the string `true`, but it shouldn't.

```console
pidev:/# pihole status
  [✓] FTL is listening on port 53
     [✓] UDP (IPv4)
     [✓] TCP (IPv4)
     [✓] UDP (IPv6)
     [✓] TCP (IPv6)

true
  [✓] Pi-hole blocking is enabled
```

This value is generated when function `getFTLConfigValue dns.blocking.active` executes `pihole-FTL --config -q dns.blocking.active`.

The `pihole-FTL` return is `true` and the value is printed.

**Note:**
it happens at least inside Alpine container. Not sure about bare metal install.

### How does this PR accomplish the above?

Storing the return in a variable avoids the printing.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
