### PR TITLE
*BREAKING* Drop support for ancient ARMv4 and ARMv5

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1870,9 +1870,9 @@ get_binary_name() {
             printf "%b  %b Detected AArch64 (64 Bit ARM) architecture\\n" "${OVER}" "${TICK}"
             # set the binary to be used
             l_binary="pihole-FTL-arm64"
-        elif [[ "${cpu_arch}" == "armv6KZ" ]]; then
-            printf "%b  %b Detected ARMv6KZ architecture\\n" "${OVER}" "${TICK}"
-            # set the binary to be used
+        elif [[ "${cpu_arch}" == "armv6"* ]]; then
+            printf "%b  %b Detected ARMv6 architecture\\n" "${OVER}" "${TICK}"
+            # set the binary to be used (e.g., BCM2835 as found in Raspberry Pi Zero and Model 1)
             l_binary="pihole-FTL-armv6"
         else
             # If ARMv8 or higher is found (e.g., BCM2837 as found in Raspberry Pi Model 3B)
@@ -1885,24 +1885,10 @@ get_binary_name() {
                 printf "%b  %b Detected ARMv7 architecture (%s)\\n" "${OVER}" "${TICK}" "${cpu_arch}"
                 # set the binary to be used
                 l_binary="pihole-FTL-armv6"
-            elif [[ "${cpu_arch}" == "v5TE" || "${rev}" -gt 5 ]]; then
-                # Check if the system is using GLIBC 2.29 or higher
-                if [[ -n "${l_glibc_version}" && "$(printf '%s\n' "2.29" "${l_glibc_version}" | sort -V | head -n1)" == "2.29" ]]; then
-                    # If so, use the ARMv6 binary (e.g., BCM2835 as found in Raspberry Pi Zero and Model 1)
-                    printf "%b  %b Detected ARMv6 architecture (running GLIBC 2.29 or higher, %s)\\n" "${OVER}" "${TICK}" "${cpu_arch}"
-                    # set the binary to be used
-                    l_binary="pihole-FTL-armv5"
-                else
-                    # Otherwise, use the ARMv5 binary (e.g., BCM2835 as found in Raspberry Pi Zero and Model 1)
-                    printf "%b  %b Detected ARMv6 architecture (running GLIBC older than 2.29, %s)\\n" "${OVER}" "${TICK}" "${cpu_arch}"
-                    # set the binary to be used
-                    l_binary="pihole-FTL-armv4"
-                fi
             else
-                # Otherwise, use the ARMv4 binary (e.g., BCM2835 as found in Raspberry Pi Zero and Model 1)
-                printf "%b  %b Detected ARMv4 or ARMv5 architecture (%s)\\n" "${OVER}" "${TICK}" "${cpu_arch}"
-                # set the binary to be used
-                l_binary="pihole-FTL-armv4"
+                # Otherwise, Pi-hole does not support this architecture
+                printf "%b  %b This processor architecture is not supported by Pi-hole (%s)\\n" "${OVER}" "${CROSS}" "${cpu_arch}"
+                l_binary=""
             fi
         fi
     elif [[ "${machine}" == "x86_64" ]]; then

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -259,158 +259,12 @@ def test_FTL_detect_aarch64_no_errors(host):
     assert expected_stdout in detectPlatform.stdout
 
 
-def test_FTL_detect_armv4_no_errors(host):
-    """
-    confirms only armv4 package is downloaded for FTL engine
-    """
-    # mock uname to return armv4 platform
-    mock_command("uname", {"-m": ("armv4t", "0")}, host)
-    # mock readelf to respond with armv4 CPU architecture
-    mock_command_2(
-        "readelf",
-        {
-            "-A /bin/sh": ("Tag_CPU_arch: armv4t", "0"),
-            "-A /usr/bin/sh": ("Tag_CPU_arch: armv4t", "0"),
-        },
-        host,
-    )
-    detectPlatform = host.run(
-        """
-    source /opt/pihole/basic-install.sh
-    create_pihole_user
-    funcOutput=$(get_binary_name)
-    binary="pihole-FTL${funcOutput##*pihole-FTL}"
-    theRest="${funcOutput%pihole-FTL*}"
-    FTLdetect "${binary}" "${theRest}"
-    """
-    )
-    expected_stdout = info_box + " FTL Checks..."
-    assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + " Detected ARMv4 or ARMv5 architecture (armv4t)"
-    assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + " Downloading and Installing FTL"
-    assert expected_stdout in detectPlatform.stdout
-
-
-def test_FTL_detect_armv5_no_errors(host):
-    """
-    confirms only armv5 package is downloaded for FTL engine
-    """
-    # mock uname to return armv5te platform
-    mock_command("uname", {"-m": ("armv5te", "0")}, host)
-    # mock readelf to respond with armv5 CPU architecture
-    mock_command_2(
-        "readelf",
-        {
-            "-A /bin/sh": ("Tag_CPU_arch: armv5te", "0"),
-            "-A /usr/bin/sh": ("Tag_CPU_arch: armv5te", "0"),
-        },
-        host,
-    )
-    detectPlatform = host.run(
-        """
-    source /opt/pihole/basic-install.sh
-    create_pihole_user
-    funcOutput=$(get_binary_name)
-    binary="pihole-FTL${funcOutput##*pihole-FTL}"
-    theRest="${funcOutput%pihole-FTL*}"
-    FTLdetect "${binary}" "${theRest}"
-    """
-    )
-    expected_stdout = info_box + " FTL Checks..."
-    assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + " Detected ARMv4 or ARMv5 architecture (armv5te)"
-    assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + " Downloading and Installing FTL"
-    assert expected_stdout in detectPlatform.stdout
-
-
-def test_FTL_detect_armv6_old_no_errors(host):
+def test_FTL_detect_armv6_no_errors(host):
     """
     confirms only armv6 package is downloaded for FTL engine
     """
-    # mock uname to return armv6l platform
-    mock_command("uname", {"-m": ("armv6l", "0")}, host)
-    # mock readelf to respond with armv6l CPU architecture
-    mock_command_2(
-        "readelf",
-        {
-            "-A /bin/sh": ("Tag_CPU_arch: armv6l", "0"),
-            "-A /usr/bin/sh": ("Tag_CPU_arch: armv6l", "0"),
-        },
-        host,
-    )
-    # Mock old ldd GLIBC version
-    mock_command(
-        "ldd", {"--version": ("ldd (Debian GLIBC 2.13-38+deb7u8) 2.13", "0")}, host
-    )
-
-    detectPlatform = host.run(
-        """
-    source /opt/pihole/basic-install.sh
-    create_pihole_user
-    funcOutput=$(get_binary_name)
-    binary="pihole-FTL${funcOutput##*pihole-FTL}"
-    theRest="${funcOutput%pihole-FTL*}"
-    FTLdetect "${binary}" "${theRest}"
-    """
-    )
-    expected_stdout = info_box + " FTL Checks..."
-    assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + (
-        " Detected ARMv6 architecture (running GLIBC older than 2.29, armv6l)"
-    )
-    assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + " Downloading and Installing FTL"
-    assert expected_stdout in detectPlatform.stdout
-
-
-def test_FTL_detect_armv6_recent_no_errors(host):
-    """
-    confirms only armv6 package is downloaded for FTL engine
-    """
-    # mock uname to return armv6l platform
-    mock_command("uname", {"-m": ("armv6l", "0")}, host)
-    # mock readelf to respond with armv6l CPU architecture
-    mock_command_2(
-        "readelf",
-        {
-            "-A /bin/sh": ("Tag_CPU_arch: armv6l", "0"),
-            "-A /usr/bin/sh": ("Tag_CPU_arch: armv6l", "0"),
-        },
-        host,
-    )
-    # Mock old ldd GLIBC version
-    mock_command(
-        "ldd", {"--version": ("'ldd (Debian GLIBC 2.35-38+deb7u8) 2.35'", "0")}, host
-    )
-
-    detectPlatform = host.run(
-        """
-    source /opt/pihole/basic-install.sh
-    create_pihole_user
-    funcOutput=$(get_binary_name)
-    binary="pihole-FTL${funcOutput##*pihole-FTL}"
-    theRest="${funcOutput%pihole-FTL*}"
-    FTLdetect "${binary}" "${theRest}"
-    """
-    )
-    expected_stdout = info_box + " FTL Checks..."
-    assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + (
-        " Detected ARMv6 architecture (running GLIBC 2.29 or higher, armv6l)"
-    )
-    assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + " Downloading and Installing FTL"
-    assert expected_stdout in detectPlatform.stdout
-
-
-def test_FTL_detect_armv6KZ_no_errors(host):
-    """
-    confirms only armv6KZ package is downloaded for FTL engine
-    """
-    # mock uname to return armv6KZ platform
-    mock_command("uname", {"-m": ("armv6KZ", "0")}, host)
+    # mock uname to return armv6 platform
+    mock_command("uname", {"-m": ("armv6", "0")}, host)
     # mock readelf to respond with armv6l CPU architecture
     mock_command_2(
         "readelf",
@@ -432,7 +286,7 @@ def test_FTL_detect_armv6KZ_no_errors(host):
     )
     expected_stdout = info_box + " FTL Checks..."
     assert expected_stdout in detectPlatform.stdout
-    expected_stdout = tick_box + " Detected ARMv6KZ architecture"
+    expected_stdout = tick_box + " Detected ARMv6 architecture"
     assert expected_stdout in detectPlatform.stdout
     expected_stdout = tick_box + " Downloading and Installing FTL"
     assert expected_stdout in detectPlatform.stdout


### PR DESCRIPTION
# What does this implement/fix?

Drop support for ancient ARMv4 and ARMv5, the Debian binaries turn out to cause unsolvable SIGFPE on ARMv6 and lower. Fortunately, we can still use the Alpine binaries on all Raspberry Pi models (even the oldest ones). Use them on ARMv6 devices to restore compatibility of Pi-hole with the very early boards like Raspberry Pi 1B and Zero (W).

Both feature a `BCM2835` chip which is a member of the ARM11 family (type `ARM1176JZF-S `) which turns out to be the `armv6KZ` architecture so exactly what `alpine/arm/v6` is designed for.

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/failure-to-create-gravity-floating-point-error/65705

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** *to be checked*

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.