### PR TITLE
When setting a blank password, use `webserver.api.password` instead of `webserver.api.pwhash`

### DIFF
--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -145,4 +145,8 @@ getFTLConfigValue(){
 #######################
 setFTLConfigValue(){
   pihole-FTL --config "${1}" "${2}" >/dev/null
+  if [[ $? -eq 5 ]]; then
+    echo -e "  ${CROSS} ${1} set by environment variable. Please unset it to use this function"
+    exit 5
+  fi
 }

--- a/pihole
+++ b/pihole
@@ -43,7 +43,7 @@ SetWebPassword() {
         echo ""
 
         if [ "${PASSWORD}" == "" ]; then
-            setFTLConfigValue "webserver.api.password" "" >/dev/null
+            setFTLConfigValue "webserver.api.password" ""
             echo -e "  ${TICK} Password Removed"
             exit 0
         fi
@@ -54,7 +54,7 @@ SetWebPassword() {
 
     if [ "${PASSWORD}" == "${CONFIRM}" ] ; then
         # pihole-FTL will automatically hash the password
-        setFTLConfigValue "webserver.api.password" "${PASSWORD}" >/dev/null
+        setFTLConfigValue "webserver.api.password" "${PASSWORD}"
         echo -e "  ${TICK} New password set"
     else
         echo -e "  ${CROSS} Passwords don't match. Your password has not been changed"

--- a/pihole
+++ b/pihole
@@ -43,7 +43,7 @@ SetWebPassword() {
         echo ""
 
         if [ "${PASSWORD}" == "" ]; then
-            setFTLConfigValue "webserver.api.pwhash" "" >/dev/null
+            setFTLConfigValue "webserver.api.password" "" >/dev/null
             echo -e "  ${TICK} Password Removed"
             exit 0
         fi


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Per title, uses the correct config item to set an empty password (rather than forcible clearing out the hash)

This also prevents the password from being set to empty when someone has already set it to a value with `FTLCONF_webserver_api_password`

Without environment variable set:

![image](https://github.com/pi-hole/pi-hole/assets/1998970/c8c6e3d6-bb61-4eae-886f-f0fec5ecfaa4)


With environment variable set:
![image](https://github.com/pi-hole/pi-hole/assets/1998970/c01e1a15-b802-495a-87e1-768194d4d398)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_