### PR TITLE
Remove idn2 as punycode conversion is handled by FTL

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -108,13 +108,11 @@ Main(){
 
     if [ -z "${domain}" ]; then
         echo "No domain specified"; exit 1
-    else
-        # convert domain to punycode
-        domain=$(idn2 "${domain}")
-
-        # convert the domain to lowercase
-        domain=$(echo "${domain}" | tr '[:upper:]' '[:lower:]')
     fi
+    # domains are lowercased and converted to punycode by FTL since
+    # https://github.com/pi-hole/FTL/pull/1715
+    # no need to do it here
+
 
     # Test if the authentication endpoint is available
     TestAPIAvailability

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -305,7 +305,7 @@ package_manager_detect() {
         # Packages required to run this install script
         INSTALLER_DEPS=(git iproute2 dialog ca-certificates)
         # Packages required to run Pi-hole
-        PIHOLE_DEPS=(cron curl iputils-ping psmisc sudo unzip idn2 libcap2-bin dns-root-data libcap2 netcat-openbsd procps jq)
+        PIHOLE_DEPS=(cron curl iputils-ping psmisc sudo unzip libcap2-bin dns-root-data libcap2 netcat-openbsd procps jq)
 
     # If apt-get is not found, check for rpm.
     elif is_command rpm ; then
@@ -322,7 +322,7 @@ package_manager_detect() {
         PKG_COUNT="${PKG_MANAGER} check-update | grep -E '(.i686|.x86|.noarch|.arm|.src|.riscv64)' | wc -l || true"
         OS_CHECK_DEPS=(grep bind-utils)
         INSTALLER_DEPS=(git dialog iproute newt procps-ng chkconfig ca-certificates binutils)
-        PIHOLE_DEPS=(cronie curl findutils sudo unzip libidn2 psmisc libcap nmap-ncat jq)
+        PIHOLE_DEPS=(cronie curl findutils sudo unzip psmisc libcap nmap-ncat jq)
 
     # If neither apt-get or yum/dnf package managers were found
     else


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Remove `idn2` as punycode conversion is handled by FTL (https://github.com/pi-hole/FTL/pull/1715)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
