### PR TITLE
Start counting at postion 1

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -31,7 +31,7 @@ function get_remote_version() {
 
 
 function get_remote_hash(){
-    git ls-remote "https://github.com/pi-hole/${1}" --tags "${2}" | awk '{print substr($0, 0,8);}' || return 1
+    git ls-remote "https://github.com/pi-hole/${1}" --tags "${2}" | awk '{print substr($0, 1,8);}' || return 1
 }
 
 # Source the utils file for addOrEditKeyValPair()


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

A long forgotten branch adapted to v6.
`awk`'s `substr` starts counting at position 1, not zero (see https://www.gnu.org/software/gawk/manual/html_node/String-Functions.html#index-substr_0028_0029-function). There is no change in output, but this is the correct way of doing things.

```
nanopi@nanopi:~$ git ls-remote "https://github.com/pi-hole/pi-hole" --tags development | awk '{print substr($0, 0,8);}'
300a4e22
nanopi@nanopi:~$ git ls-remote "https://github.com/pi-hole/pi-hole" --tags development | awk '{print substr($0, 1,8);}'
300a4e22
```

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
