### PR TITLE
Implement DHCP Subnet Mask Configuration

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -448,7 +448,7 @@ ProcessDHCPSettings() {
 #            ANY CHANGES MADE TO THIS FILE WILL BE LOST ON CHANGE             #
 ###############################################################################
 dhcp-authoritative
-dhcp-range=${DHCP_START},${DHCP_END},${leasetime}
+dhcp-range=${DHCP_START},${DHCP_END},${DHCP_SUBNET_MASK},${leasetime}
 dhcp-option=option:router,${DHCP_ROUTER}
 dhcp-leasefile=/etc/pihole/dhcp.leases
 #quiet-dhcp
@@ -493,11 +493,12 @@ EnableDHCP() {
     addOrEditKeyValPair "${setupVars}" "DHCP_ACTIVE" "true"
     addOrEditKeyValPair "${setupVars}" "DHCP_START" "${args[2]}"
     addOrEditKeyValPair "${setupVars}" "DHCP_END" "${args[3]}"
-    addOrEditKeyValPair "${setupVars}" "DHCP_ROUTER" "${args[4]}"
-    addOrEditKeyValPair "${setupVars}" "DHCP_LEASETIME" "${args[5]}"
-    addOrEditKeyValPair "${setupVars}" "PIHOLE_DOMAIN" "${args[6]}"
-    addOrEditKeyValPair "${setupVars}" "DHCP_IPv6" "${args[7]}"
-    addOrEditKeyValPair "${setupVars}" "DHCP_rapid_commit" "${args[8]}"
+    addOrEditKeyValPair "${setupVars}" "DHCP_SUBNET_MASK" "${args[4]}"
+    addOrEditKeyValPair "${setupVars}" "DHCP_ROUTER" "${args[5]}"
+    addOrEditKeyValPair "${setupVars}" "DHCP_LEASETIME" "${args[6]}"
+    addOrEditKeyValPair "${setupVars}" "PIHOLE_DOMAIN" "${args[7]}"
+    addOrEditKeyValPair "${setupVars}" "DHCP_IPv6" "${args[8]}"
+    addOrEditKeyValPair "${setupVars}" "DHCP_rapid_commit" "${args[9]}"
 
     # Remove possible old setting from file
     removeKey "${dnsmasqconfig}" "dhcp-"


### PR DESCRIPTION
This PR introduces the capability to configure the DHCP subnet mask directly from the Pi-hole admin settings. The changes include the addition of a new positional parameter in the `EnableDHCP()` function and an update to the `ProcessDHCPSettings()` function to handle the DHCP subnet mask.

I have also updated the parameter positions following the new addition. The subnet mask is now taken into account when generating the `dhcp-range` setting in the Pi-hole DHCP configuration.

The motivation behind this change is to provide users with the flexibility to define their subnet masks as per their network requirements, enhancing the DHCP functionality of Pi-hole. 

Example: pihole on 192.168.1.10 but having a dhcp range in 192.168.4.100 -> .200. Currently the default config applies a /24 scope, which breaks client connectivity as they receive an incorrect subnet. There is no error or message to describe the intended behaviour in the webUI. This means having to go through and edit dhcp config file directly. However this gets reset each time you make a change to DHCP scope settings. So it would make the experience of managing DHCP a lot easier in these types of setups.

**Corresponding Changes**:
This PR is part of a set of changes, and there is a corresponding update in the `pi-hole/web` repository. The changes in the web repository handle the UI elements for this new configuration option. PR [[#2800](https://github.com/pi-hole/web/pull/2800)]

---

By submitting this pull request, I confirm the following:

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([git rebase](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

 

- [x]    I have read the above and my PR is ready for review. Check this box to confirm
