### PR TITLE
pihole -d: Include pihole.toml only once

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -544,18 +544,6 @@ disk_usage() {
     done
 }
 
-parse_pihole_toml() {
-    echo_current_diagnostic "Pi-hole configuration"
-    # If the file exists,
-    if [[ -r "${PIHOLE_FTL_CONF_FILE}" ]]; then
-        # parse it
-        parse_file "${PIHOLE_FTL_CONF_FILE}"
-    else
-        # If not, show an error
-        log_write "${CROSS} ${COL_RED}Could not read ${PIHOLE_FTL_CONF_FILE}.${COL_NC}"
-    fi
-}
-
 parse_locale() {
     local pihole_locale
     echo_current_diagnostic "Locale"
@@ -1402,10 +1390,6 @@ upload_to_tricorder() {
 # Run through all the functions we made
 make_temporary_log
 initialize_debug
-# TODO: Address the reliance on setupVars.conf here. Should debug read pihole.toml directly, or rely on pihole-FTL --config?
-# setupVars.conf needs to be sourced before the networking so the values are
-# available to the other functions
-source_setup_variables
 check_component_versions
 # check_critical_program_versions
 diagnose_operating_system
@@ -1419,7 +1403,6 @@ check_name_resolution
 check_dhcp_servers
 process_status
 ftl_full_status
-parse_pihole_toml
 analyze_ftl_db
 analyze_gravity_list
 show_groups


### PR DESCRIPTION
# What does this implement/fix?

Remove left-over parts of `setupVars.conf` processing and only include `pihole.toml` once

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.