### PR TITLE
Do not update package cache on install/upgrade

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -77,6 +77,7 @@ PI_HOLE_FILES=(list piholeDebug piholeLogFlush setupLCD update version gravity u
 PI_HOLE_INSTALL_DIR="/opt/pihole"
 PI_HOLE_CONFIG_DIR="/etc/pihole"
 PI_HOLE_BIN_DIR="/usr/local/bin"
+PKG_MANAGER_UPDATE=false
 if [ -z "$useUpdateVars" ]; then
     useUpdateVars=false
 fi
@@ -1296,6 +1297,12 @@ disable_resolved_stublistener() {
 update_package_cache() {
     # Update package cache on apt based OSes. Do this every time since
     # it's quick and packages can be updated at any time.
+
+    # Update package cache only once
+    if [[ "${PKG_MANAGER_UPDATE}" == "true" ]]; then
+        return
+    fi
+    PKG_MANAGER_UPDATE=true
 
     # Local, named variables
     local str="Update local cache of available packages"


### PR DESCRIPTION
# What does this implement/fix?

Do not update package cache on install/upgrade. It takes quite a long time and we don't do this for `dnf`/`yum` either.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.