### PR TITLE
Treat FTL return data as strings

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -93,7 +93,7 @@ GetFTLData() {
 
   if [ "${status}" = 200 ]; then
     # response OK
-    echo "${data}"
+    printf %s "${data}"
   elif [ "${status}" = 000 ]; then
     # connection lost
     echo "000"

--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -46,14 +46,14 @@ GenerateOutput(){
     data="${1}"
 
     # construct a new json for the list results where each object contains the domain and the related type
-    lists_data=$(echo "${data}" | jq '.search.domains | [.[] | {domain: .domain, type: .type}]')
+    lists_data=$(printf %s "${data}" | jq '.search.domains | [.[] | {domain: .domain, type: .type}]')
 
     # construct a new json for the gravity results where each object contains the adlist URL and the related domains
-    gravity_data=$(echo "${data}" | jq '.search.gravity  | group_by(.address) | map({ address: (.[0].address), domains: [.[] | .domain] })')
+    gravity_data=$(printf %s "${data}" | jq '.search.gravity  | group_by(.address) | map({ address: (.[0].address), domains: [.[] | .domain] })')
 
     # number of objects in each json
-    num_gravity=$(echo "${gravity_data}" | jq length )
-    num_lists=$(echo "${lists_data}" | jq length )
+    num_gravity=$(printf %s "${gravity_data}" | jq length )
+    num_lists=$(printf %s "${lists_data}" | jq length )
 
     if [ "${partial}" = true ]; then
       search_type_str="partially"
@@ -66,7 +66,7 @@ GenerateOutput(){
     if [ "${num_lists}" -gt 0 ]; then
         # Convert the data to a csv, each line is a "domain,type" string
         # not using jq's @csv here as it quotes each value individually
-        lists_data_csv=$(echo "${lists_data}" | jq --raw-output '.[] | [.domain, .type] | join(",")' )
+        lists_data_csv=$(printf %s "${lists_data}" | jq --raw-output '.[] | [.domain, .type] | join(",")' )
 
         # Generate output for each csv line, separating line in a domain and type substring at the ','
         echo "${lists_data_csv}" | while read -r line; do
@@ -79,7 +79,7 @@ GenerateOutput(){
     if [ "${num_gravity}" -gt 0 ]; then
         # Convert the data to a csv, each line is a "URL,domain,domain,...." string
         # not using jq's @csv here as it quotes each value individually
-        gravity_data_csv=$(echo "${gravity_data}" | jq --raw-output '.[] | [.address, .domains[]] | join(",")' )
+        gravity_data_csv=$(printf %s "${gravity_data}" | jq --raw-output '.[] | [.address, .domains[]] | join(",")' )
 
         # Generate line-by-line output for each csv line
         echo "${gravity_data_csv}" | while read -r line; do

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -465,7 +465,7 @@ def test_FTL_development_binary_installed_and_responsive_no_errors(host):
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
-    echo "development" > /etc/pihole/ftlbranch
+    echo "development-v6" > /etc/pihole/ftlbranch
     binary="pihole-FTL${funcOutput##*pihole-FTL}"
     theRest="${funcOutput%pihole-FTL*}"
     FTLdetect "${binary}" "${theRest}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes a bug reported on [Discourse](https://discourse.pi-hole.net/t/pihole-q-error/66754): when FTL return a RegEx which fits a domain searched by with `pihole -q` it can error due to `invalid escape`. This only occurs because we use `sh` as shebang for the query script.

**How does this PR accomplish the above?:**

Replace `echo` calls with `printf %s`.

Fix confirmed working by OP on discourse.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
