### PR TITLE
Fix failing tests in development-v6 branch

### DIFF
--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -239,6 +239,7 @@ def test_FTL_detect_aarch64_no_errors(host):
     mock_command("uname", {"-m": ("aarch64", "0")}, host)
     detectPlatform = host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
@@ -272,6 +273,7 @@ def test_FTL_detect_armv6_no_errors(host):
     )
     detectPlatform = host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
@@ -305,6 +307,7 @@ def test_FTL_detect_armv7l_no_errors(host):
     )
     detectPlatform = host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
@@ -338,6 +341,7 @@ def test_FTL_detect_armv7_no_errors(host):
     )
     detectPlatform = host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
@@ -371,6 +375,7 @@ def test_FTL_detect_armv8a_no_errors(host):
     )
     detectPlatform = host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
@@ -393,6 +398,7 @@ def test_FTL_detect_x86_64_no_errors(host):
     """
     detectPlatform = host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
@@ -415,6 +421,7 @@ def test_FTL_detect_unknown_no_errors(host):
     mock_command("uname", {"-m": ("mips", "0")}, host)
     detectPlatform = host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)
@@ -442,6 +449,7 @@ def test_FTL_download_aarch64_no_errors(host):
     )
     download_binary = host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     FTLinstall "pihole-FTL-aarch64-linux-gnu"
@@ -458,6 +466,7 @@ def test_FTL_development_binary_installed_and_responsive_no_errors(host):
     """
     host.run(
         """
+    echo "development-v6" > /etc/pihole/ftlbranch
     source /opt/pihole/basic-install.sh
     create_pihole_user
     funcOutput=$(get_binary_name)


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

A change was introduced way back in June that presumably broke the tests. This got worked around by uploading the v6 binaries to the latest v5 release. No bueno.

The correct fix should have been to ensure that the `devlopment-v6` branch of FTL is selected before trying to download it in tests (as we do with other tests).

We must ensure these tests get changed when `development-v6` becomes `development`

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_