### PR TITLE
 Test ftl.pi-hole.net availability

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -144,7 +144,7 @@ main() {
     local binary
     binary="pihole-FTL${funcOutput##*pihole-FTL}" #binary name will be the last line of the output of get_binary_name (it always begins with pihole-FTL)
 
-    if FTLcheckUpdate "${binary}" > /dev/null; then
+    if FTLcheckUpdate "${binary}"; then
         FTL_update=true
         echo -e "  ${INFO} FTL:\\t\\t${COL_YELLOW}update available${COL_NC}"
     else
@@ -155,8 +155,13 @@ main() {
             2)
                 echo -e "  ${INFO} FTL:\\t\\t${COL_LIGHT_RED}Branch is not available.${COL_NC}\\n\\t\\t\\tUse ${COL_LIGHT_GREEN}pihole checkout ftl [branchname]${COL_NC} to switch to a valid branch."
                 ;;
+            3)
+                echo -e "  ${INFO} FTL:\\t\\t${COL_LIGHT_RED}Something has gone wrong, cannot reach download server${COL_NC}"
+                exit 1
+                ;;
             *)
                 echo -e "  ${INFO} FTL:\\t\\t${COL_LIGHT_RED}Something has gone wrong, contact support${COL_NC}"
+                exit 1
         esac
         FTL_update=false
     fi


### PR DESCRIPTION
# What does this implement/fix?

Add checking for availability of https://ftl.pi-hole.net when using FTL from a custom branch. If the server is down (or the user is offline, cannot resolve the domain, etc.), we fail early and hard instead of possibly corrupting the installation.

> [!NOTE]
> This can easily be tested by checking out this branch and - **thereafter** - defining a local DNS record like
> ```
> 0.0.0.0 ftl.pi-hole.net
> ```
>
> Then, `pihole -up` sees a situation where we have simulated a non-reachable FTL binary server:
>
> ![Screenshot from 2024-01-30 19-21-59](https://github.com/pi-hole/pi-hole/assets/16748619/3659d0d6-fa52-4570-9f14-50ec4a132726)



---

**Related issue or feature (if applicable):** #5561  #5562 

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.