### PR TITLE
Verify remote FTL checksum

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2002,9 +2002,11 @@ FTLcheckUpdate() {
     local localSha1
 
     if [[ ! "${ftlBranch}" == "master" ]]; then
-        # Check whether or not the binary for this FTL branch actually exists. If not, then there is no update!
+        # This is not the master branch
         local path
         path="${ftlBranch}/${binary}"
+
+        # Check whether or not the binary for this FTL branch actually exists. If not, then there is no update!
         # shellcheck disable=SC1090
         check_download_exists "$path"
         local ret=$?
@@ -2023,12 +2025,20 @@ FTLcheckUpdate() {
         fi
 
         if [[ ${ftlLoc} ]]; then
-            # We already have a pihole-FTL binary downloaded.
-            # Alt branches don't have a tagged version against them, so just confirm the checksum of the local vs remote to decide whether we download or not
+            # We already have a pihole-FTL binary installed, check if it's the
+            # same as the remote one
+            # Alt branches don't have a tagged version against them, so just
+            # confirm the checksum of the local vs remote to decide whether we
+            # download or not
             remoteSha1=$(curl -sSL --fail "https://ftl.pi-hole.net/${ftlBranch}/${binary}.sha1" | cut -d ' ' -f 1)
-            localSha1=$(sha1sum "$(command -v pihole-FTL)" | cut -d ' ' -f 1)
+            localSha1=$(sha1sum "${ftlLoc}" | cut -d ' ' -f 1)
 
-            if [[ "${remoteSha1}" != "${localSha1}" ]]; then
+            # Check we downloaded a valid checksum (no 404 or other error like
+            # no DNS resolution)
+            if [[ ! "${remoteSha1}" =~ ^[a-f0-9]{40}$ ]]; then
+                printf "  %b Remote checksum not available, trying to download binary from ftl.pi-hole.net.\\n" "${CROSS}"
+                return 0
+            elif [[ "${remoteSha1}" != "${localSha1}" ]]; then
                 printf "  %b Checksums do not match, downloading from ftl.pi-hole.net.\\n" "${INFO}"
                 return 0
             else
@@ -2039,7 +2049,10 @@ FTLcheckUpdate() {
             return 0
         fi
     else
+        # This is the master branch
         if [[ ${ftlLoc} ]]; then
+            # We already have a pihole-FTL binary installed, check if it's the
+            # same as the remote one
             local FTLversion
             FTLversion=$(/usr/bin/pihole-FTL tag)
             local FTLlatesttag
@@ -2053,15 +2066,24 @@ FTLcheckUpdate() {
 
             # Check if the installed version matches the latest version
             if [[ "${FTLversion}" != "${FTLlatesttag}" ]]; then
+                # If the installed version does not match the latest version, then download
                 return 0
             else
+                # If the installed version matches the latest version, then
+                # check the installed sha1sum of the binary vs the remote
+                # sha1sum. If they do not match, then download
                 printf "  %b Latest FTL Binary already installed (%s). Confirming Checksum...\\n" "${INFO}" "${FTLlatesttag}"
 
                 remoteSha1=$(curl -sSL --fail "https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1" | cut -d ' ' -f 1)
-                localSha1=$(sha1sum "$(command -v pihole-FTL)" | cut -d ' ' -f 1)
+                localSha1=$(sha1sum "${ftlLoc}" | cut -d ' ' -f 1)
 
-                if [[ "${remoteSha1}" != "${localSha1}" ]]; then
-                    printf "  %b Corruption detected...\\n" "${INFO}"
+                # Check we downloaded a valid checksum (no 404 or other error like
+                # no DNS resolution)
+                if [[ ! "${remoteSha1}" =~ ^[a-f0-9]{40}$ ]]; then
+                    printf "  %b Remote checksum not available, trying to redownload binary...\\n" "${CROSS}"
+                    return 0
+                elif [[ "${remoteSha1}" != "${localSha1}" ]]; then
+                    printf "  %b Corruption detected, redownloading binary...\\n" "${CROSS}"
                     return 0
                 else
                     printf "  %b Checksum correct. No need to download!\\n" "${INFO}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2030,21 +2030,9 @@ FTLcheckUpdate() {
             # Alt branches don't have a tagged version against them, so just
             # confirm the checksum of the local vs remote to decide whether we
             # download or not
-            remoteSha1=$(curl -sSL --fail "https://ftl.pi-hole.net/${ftlBranch}/${binary}.sha1" | cut -d ' ' -f 1)
-            localSha1=$(sha1sum "${ftlLoc}" | cut -d ' ' -f 1)
-
-            # Check we downloaded a valid checksum (no 404 or other error like
-            # no DNS resolution)
-            if [[ ! "${remoteSha1}" =~ ^[a-f0-9]{40}$ ]]; then
-                printf "  %b Remote checksum not available, trying to download binary from ftl.pi-hole.net.\\n" "${CROSS}"
-                return 0
-            elif [[ "${remoteSha1}" != "${localSha1}" ]]; then
-                printf "  %b Checksums do not match, downloading from ftl.pi-hole.net.\\n" "${INFO}"
-                return 0
-            else
-                printf "  %b Checksum of installed binary matches remote. No need to download!\\n" "${INFO}"
-                return 1
-            fi
+            printf "  %b FTL binary already installed. Confirming Checksum...\\n" "${INFO}"
+            checkSumFile="https://ftl.pi-hole.net/${ftlBranch}/${binary}.sha1"
+            # Continue further down...
         else
             return 0
         fi
@@ -2066,34 +2054,39 @@ FTLcheckUpdate() {
 
             # Check if the installed version matches the latest version
             if [[ "${FTLversion}" != "${FTLlatesttag}" ]]; then
-                # If the installed version does not match the latest version, then download
+                # If the installed version does not match the latest version,
+                # then download
                 return 0
             else
                 # If the installed version matches the latest version, then
                 # check the installed sha1sum of the binary vs the remote
                 # sha1sum. If they do not match, then download
-                printf "  %b Latest FTL Binary already installed (%s). Confirming Checksum...\\n" "${INFO}" "${FTLlatesttag}"
-
-                remoteSha1=$(curl -sSL --fail "https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1" | cut -d ' ' -f 1)
-                localSha1=$(sha1sum "${ftlLoc}" | cut -d ' ' -f 1)
-
-                # Check we downloaded a valid checksum (no 404 or other error like
-                # no DNS resolution)
-                if [[ ! "${remoteSha1}" =~ ^[a-f0-9]{40}$ ]]; then
-                    printf "  %b Remote checksum not available, trying to redownload binary...\\n" "${CROSS}"
-                    return 0
-                elif [[ "${remoteSha1}" != "${localSha1}" ]]; then
-                    printf "  %b Corruption detected, redownloading binary...\\n" "${CROSS}"
-                    return 0
-                else
-                    printf "  %b Checksum correct. No need to download!\\n" "${INFO}"
-                    return 1
-                fi
+                printf "  %b Latest FTL binary already installed (%s). Confirming Checksum...\\n" "${INFO}" "${FTLlatesttag}"
+                checkSumFile="https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1"
+                # Continue further down...
             fi
         else
             return 0
         fi
     fi
+
+    # If we reach this point, we need to check the checksum of the local vs
+    # remote to decide whether we download or not
+    remoteSha1=$(curl -sSL --fail "${checkSumFile}" | cut -d ' ' -f 1)
+    localSha1=$(sha1sum "${ftlLoc}" | cut -d ' ' -f 1)
+
+    # Check we downloaded a valid checksum (no 404 or other error like
+    # no DNS resolution)
+    if [[ ! "${remoteSha1}" =~ ^[a-f0-9]{40}$ ]]; then
+        printf "  %b Remote checksum not available, trying to redownload binary...\\n" "${CROSS}"
+        return 0
+    elif [[ "${remoteSha1}" != "${localSha1}" ]]; then
+        printf "  %b Corruption detected, redownloading binary...\\n" "${CROSS}"
+        return 0
+    fi
+
+    printf "  %b Checksum correct. No need to download!\\n" "${INFO}"
+    return 1
 }
 
 # Detect suitable FTL binary platform


### PR DESCRIPTION
# What does this implement/fix?

Verify that we actually downloaded a valid checksum before comparing it to the local one. This covers situations where downloading the checksum from remote might have failed.

Before, we simply always believed that `curl` "will surely have worked" and might falsely compare an empty remote checksum to the local one always resulting in a checksum mismatch + FTL re-downloading. In case of an unreadable upstream checksum, we still re-download (seems the best compromise) but print a clear message telling the user what is going on.

This PR does not introduce any functional changes.

---

**Related issue or feature (if applicable):** See Discourse thread linked below

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.