### PR TITLE
Remove double quotes that prevented _any_ local files from being read by gravity

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -575,7 +575,7 @@ gravity_DownloadBlocklistFromUrl() {
     else
       # Check if the file has a+r permissions
       permissions=$(stat -c "%a" "$file_path")
-      if [[ $permissions == "??4" || $permissions == "??5" || $permissions == "??6" || $permissions == "??7" ]]; then
+      if [[ $permissions == *4 || $permissions == *5 || $permissions == *6 || $permissions == *7 ]]; then
         # Output that we are using the local file
         echo -e "${OVER}  ${INFO} Using local file ${file_path}"
       else


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

At least the vulnerability was technically fixed in the previous release...

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_