### PR TITLE
Improve changed binary message during update process

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2030,7 +2030,7 @@ FTLcheckUpdate() {
             # Alt branches don't have a tagged version against them, so just
             # confirm the checksum of the local vs remote to decide whether we
             # download or not
-            printf "  %b FTL binary already installed. Confirming Checksum...\\n" "${INFO}"
+            printf "  %b FTL binary already installed, verifying integrity...\\n" "${INFO}"
             checkSumFile="https://ftl.pi-hole.net/${ftlBranch}/${binary}.sha1"
             # Continue further down...
         else
@@ -2061,7 +2061,7 @@ FTLcheckUpdate() {
                 # If the installed version matches the latest version, then
                 # check the installed sha1sum of the binary vs the remote
                 # sha1sum. If they do not match, then download
-                printf "  %b Latest FTL binary already installed (%s). Confirming Checksum...\\n" "${INFO}" "${FTLlatesttag}"
+                printf "  %b Latest FTL binary already installed (%s), verifying integrity...\\n" "${INFO}" "${FTLlatesttag}"
                 checkSumFile="https://github.com/pi-hole/FTL/releases/download/${FTLversion%$'\r'}/${binary}.sha1"
                 # Continue further down...
             fi
@@ -2078,14 +2078,14 @@ FTLcheckUpdate() {
     # Check we downloaded a valid checksum (no 404 or other error like
     # no DNS resolution)
     if [[ ! "${remoteSha1}" =~ ^[a-f0-9]{40}$ ]]; then
-        printf "  %b Remote checksum not available, trying to redownload binary...\\n" "${CROSS}"
+        printf "  %b Remote checksum not available, trying to redownload...\\n" "${CROSS}"
         return 0
     elif [[ "${remoteSha1}" != "${localSha1}" ]]; then
-        printf "  %b Corruption detected, redownloading binary...\\n" "${CROSS}"
+        printf "  %b Remote binary is different, downloading...\\n" "${CROSS}"
         return 0
     fi
 
-    printf "  %b Checksum correct. No need to download!\\n" "${INFO}"
+    printf "  %b Local binary up-to-date. No need to download!\\n" "${INFO}"
     return 1
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Non-matching checksums are not always corruption. Actually, they will instead be caused by binaries updated on the remote branch. This is most seen with frequently changing branches such as development-v6 at this time.

This was recently been made worse in [PR #5603](https://github.com/pi-hole/pi-hole/pull/5603/files#diff-595630a29a855f6d667a84ca0662042e826bf3ec56322ef61d4a6ef149147d23L2032) where code duplication has been reduced: before we had different messages for `master` and custom branches - now there is only one.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.