### PR TITLE
Fix version check for release Docker images

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -54,7 +54,8 @@ chmod 644 "${VERSION_FILE}"
 
 # if /pihole.docker.tag file exists, we will use it's value later in this script
 DOCKER_TAG=$(cat /pihole.docker.tag 2>/dev/null)
-regex='^([0-9]+\.){1,2}(\*|[0-9]+)(-.*)?$|(^nightly$)|(^dev.*$)'
+release_regex='^([0-9]+\.){1,2}(\*|[0-9]+)(-.*)?$'
+regex=$release_regex'|(^nightly$)|(^dev.*$)'
 if [[ ! "${DOCKER_TAG}" =~ $regex ]]; then
     # DOCKER_TAG does not match the pattern (see https://regex101.com/r/RsENuz/1), so unset it.
     unset DOCKER_TAG
@@ -121,6 +122,12 @@ addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_FTL_HASH" "${GITHUB_FTL_HASH}"
 if [[ "${DOCKER_TAG}" ]]; then
     addOrEditKeyValPair "${VERSION_FILE}" "DOCKER_VERSION" "${DOCKER_TAG}"
 
-    GITHUB_DOCKER_VERSION="$(get_remote_version docker-pi-hole)"
+    # Remote version check only if the tag is a valid release version
+    docker_branch=""
+    if [[ "${DOCKER_TAG}" =~ $release_regex ]]; then
+        docker_branch="master"
+    fi
+
+    GITHUB_DOCKER_VERSION="$(get_remote_version docker-pi-hole "${docker_branch}")"
     addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_DOCKER_VERSION" "${GITHUB_DOCKER_VERSION}"
 fi


### PR DESCRIPTION
At the current state `GITHUB_DOCKER_VERSION` will always be null because `get_remote_version docker-pi-hole` call lacks the second parameter.

**What does this PR aim to accomplish?:**

Fix `get_remote_version docker-pi-hole` call to also set second parameter to `master` when inside release Docker image.

**How does this PR accomplish the above?:**

This PR adds a code that checks `DOCKER_TAG` for valid release tag (per first alternative in https://regex101.com/r/RsENuz/1) and if the match is found then it sets the second parameter.
I moved release match regex to `release_regex` variable, this is to keep both regexes in the same place in case of change in the future.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
