### PR TITLE
Add protocol validation when downloading blocklist from URL

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -622,6 +622,12 @@ gravity_DownloadBlocklistFromUrl() {
     fi
   fi
 
+  # Check for allowed protocols
+  if [[ $url != "http"* && $url != "https"* && $url != "file"* && $url != "ftp"* && $url != "ftps"* && $url != "sftp"* ]]; then
+    echo -e "${OVER}  ${CROSS} ${str} Invalid protocol specified, ignoring list"
+    download=false
+  fi
+
   if [[ "${download}" == true ]]; then
     # shellcheck disable=SC2086
     httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} ${heisenbergCompensator} -w "%{http_code}" "${url}" -o "${listCurlBuffer}" 2>/dev/null)


### PR DESCRIPTION
# What does this implement/fix?

Cherry-picking https://github.com/pi-hole/pi-hole/security/advisories/GHSA-jg6g-rrj6-xfg6 for `development-v6`. No modifications made to the commit.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.