### PR TITLE
Remove obsolet getFTLPIDFile()

### DIFF
--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -82,25 +82,6 @@ removeKey() {
 }
 
 #######################
-# returns path of FTL's PID  file
-#######################
-getFTLPIDFile() {
-  local FTLCONFFILE="/etc/pihole/pihole-FTL.conf"
-  local DEFAULT_PID_FILE="/run/pihole-FTL.pid"
-  local FTL_PID_FILE
-
-  if [ -s "${FTLCONFFILE}" ]; then
-    # if PIDFILE is not set in pihole-FTL.conf, use the default path
-    FTL_PID_FILE="$({ grep '^PIDFILE=' "${FTLCONFFILE}" || echo "${DEFAULT_PID_FILE}"; } | cut -d'=' -f2-)"
-  else
-    # if there is no pihole-FTL.conf, use the default path
-    FTL_PID_FILE="${DEFAULT_PID_FILE}"
-  fi
-
-  echo "${FTL_PID_FILE}"
-}
-
-#######################
 # returns FTL's PID based on the content of the pihole-FTL.pid file
 #
 # Takes one argument: path to pihole-FTL.pid

--- a/advanced/Templates/pihole-FTL-poststop.sh
+++ b/advanced/Templates/pihole-FTL-poststop.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
-# Source utils.sh for getFTLPIDFile()
+# Source utils.sh for getFTLConfigValue()
 PI_HOLE_SCRIPT_DIR='/opt/pihole'
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck disable=SC1090
 . "${utilsfile}"
 
 # Get file paths
-FTL_PID_FILE="$(getFTLPIDFile)"
+FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 
 # Cleanup
 rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}"

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
-# Source utils.sh for getFTLPIDFile()
+# Source utils.sh for getFTLConfigValue()
 PI_HOLE_SCRIPT_DIR='/opt/pihole'
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck disable=SC1090
 . "${utilsfile}"
 
 # Get file paths
-FTL_PID_FILE="$(getFTLPIDFile)"
+FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
 # shellcheck disable=SC2174

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -9,7 +9,7 @@
 # Description:       Enable service provided by pihole-FTL daemon
 ### END INIT INFO
 
-# Source utils.sh for getFTLPIDFile(), getFTLPID()
+# Source utils.sh for getFTLConfigValue(), getFTLPID()
 PI_HOLE_SCRIPT_DIR="/opt/pihole"
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck disable=SC1090
@@ -98,7 +98,7 @@ status() {
 trap 'cleanup; exit 1' INT HUP TERM ABRT
 
 # Get FTL's PID file path
-FTL_PID_FILE="$(getFTLPIDFile)"
+FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 
 # Get FTL's current PID
 FTL_PID="$(getFTLPID "${FTL_PID_FILE}")"

--- a/pihole
+++ b/pihole
@@ -152,7 +152,7 @@ restartDNS() {
   svcOption="${1:-restart}"
 
   # get the current path to the pihole-FTL.pid
-  FTL_PID_FILE="$(getFTLPIDFile)"
+  FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 
   # Determine if we should reload or restart
   if [[ "${svcOption}" =~ "reload-lists" ]]; then
@@ -337,7 +337,7 @@ statusFunc() {
     # Determine if there is pihole-FTL service is listening
     local pid port ftl_pid_file block_status
 
-    ftl_pid_file="$(getFTLPIDFile)"
+    ftl_pid_file="$(getFTLConfigValue files.pid)"
 
     pid="$(getFTLPID ${ftl_pid_file})"
 

--- a/test/test_any_utils.py
+++ b/test/test_any_utils.py
@@ -82,18 +82,6 @@ def test_key_removal_works(host):
     assert expected_stdout == output.stdout
 
 
-def test_getFTLPIDFile_default(host):
-    """Confirms getFTLPIDFile returns the default PID file path"""
-    output = host.run(
-        """
-    source /opt/pihole/utils.sh
-    getFTLPIDFile
-    """
-    )
-    expected_stdout = "/run/pihole-FTL.pid\n"
-    assert expected_stdout == output.stdout
-
-
 def test_getFTLPID_default(host):
     """Confirms getFTLPID returns the default value if FTL is not running"""
     output = host.run(
@@ -106,27 +94,7 @@ def test_getFTLPID_default(host):
     assert expected_stdout == output.stdout
 
 
-def test_getFTLPIDFile_and_getFTLPID_custom(host):
-    """Confirms getFTLPIDFile returns a custom PID file path"""
-    host.run(
-        """
-    tmpfile=$(mktemp)
-    echo "PIDFILE=${tmpfile}" > /etc/pihole/pihole-FTL.conf
-    echo "1234" > ${tmpfile}
-    """
-    )
-    output = host.run(
-        """
-    source /opt/pihole/utils.sh
-    FTL_PID_FILE=$(getFTLPIDFile)
-    getFTLPID "${FTL_PID_FILE}"
-    """
-    )
-    expected_stdout = "1234\n"
-    assert expected_stdout == output.stdout
-
-
-def test_getFTLConfigValue_getFTLConfigValue(host):
+def test_setFTLConfigValue_getFTLConfigValue(host):
     """
     Confirms getFTLConfigValue works (also assumes setFTLConfigValue works)
     Requires FTL to be installed, so we do that first


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Removes the `getFTLPIDFile()` function as it was used to parse the removed `pihole-FTL.conf` file. Instead we can ask `pihole-FTL` via `getFTLConfigValues` where the PID file is.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
