### PR TITLE
Fix setting query logging and privacy level

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -86,9 +86,9 @@ adlistFile="/etc/pihole/adlists.list"
 IPV4_ADDRESS=${IPV4_ADDRESS}
 IPV6_ADDRESS=${IPV6_ADDRESS}
 # Give settings their default values. These may be changed by prompts later in the script.
-QUERY_LOGGING=true
+QUERY_LOGGING=
 WEBPORT=8080
-PRIVACY_LEVEL=0
+PRIVACY_LEVEL=
 
 # Where old configs go to if a v6 migration is performed
 V6_CONF_MIGRATION_DIR="/etc/pihole/migration_backup_v6"
@@ -2298,6 +2298,15 @@ main() {
         # generate a random password
         pw=$(tr -dc _A-Z-a-z-0-9 </dev/urandom | head -c 8)
         pihole -a -p "${pw}"
+    fi
+
+    # write privacy level and logging to pihole.toml
+    # set on fresh installations by setPrivacyLevel() and setLogging(
+    if [ -n "${QUERY_LOGGING}" ]; then
+        pihole-FTL --config dns.queryLogging "${QUERY_LOGGING}"
+    fi
+    if [ -n "${PRIVACY_LEVEL}" ]; then
+        pihole-FTL --config misc.privacylevel "${PRIVACY_LEVEL}"
     fi
 
     # Migrate existing install to v6.0


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

In v5 we offer on fresh installations to set the privacy level and enable/disable the query logging. In the v6 transition this code was partly removed. This PR adds the ability to set them back.

(This needs to be done after  FTL has been installed successfully)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
