### PR TITLE
[fix] [v6] typo in bash-completion allow-regex option

### DIFF
--- a/advanced/bash-completion/pihole
+++ b/advanced/bash-completion/pihole
@@ -1,5 +1,5 @@
 _pihole() {
-    local cur prev opts opts_checkout opts_debug  opts_logging opts_query opts_update opts_version
+    local cur prev opts opts_checkout opts_debug opts_logging opts_query opts_update opts_version
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -10,7 +10,7 @@ _pihole() {
             opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex restartdns status tail uninstall updateGravity updatePihole version wildcard arpflush"
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         ;;
-        "allow"|"deny"|"wildcard"|"regex"|"allow-regx"|"allow-wild")
+        "allow"|"deny"|"wildcard"|"regex"|"allow-regex"|"allow-wild")
             opts_lists="\not \--delmode \--quiet \--list \--help"
             COMPREPLY=( $(compgen -W "${opts_lists}" -- ${cur}) )
         ;;


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**
prevent bad autocomplete option
removes a space in a double whitespace

<!--- Replace this with detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues -->

**How does this PR accomplish the above?:**
fix typo from allow-regx to allow-regex

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
