### PR TITLE
Allow "pihole checkout ftl [branch]" in docker

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -16,10 +16,16 @@
 #
 # curl -sSL https://install.pi-hole.net | bash
 
-# -e option instructs bash to immediately exit if any command [1] has a non-zero exit status
-# We do not want users to end up with a partially working install, so we exit the script
-# instead of continuing the installation with something broken
-set -e
+# -e option instructs bash to immediately exit if any command [1] has a non-zero
+# exit status We do not want users to end up with a partially working install,
+# so we exit the script instead of continuing the installation with something
+# broken
+# We do not want this when merely sourcing functions from this function as it
+# would exit the parent script e.g. when check_download_exists() determines that
+# a given branch does not exist returning 1 (= error)
+if [ -z $SOURCING ]; then
+  set -e
+fi
 
 # Append common folders to the PATH to ensure that all basic commands are available.
 # When using "su" an incomplete PATH could be passed: https://github.com/pi-hole/pi-hole/issues/3209

--- a/pihole
+++ b/pihole
@@ -404,23 +404,29 @@ tailFunc() {
 }
 
 piholeCheckoutFunc() {
-  if [ -n "${DOCKER_VERSION}" ]; then
+  if [ -n "${DOCKER_VERSION}" ] && [[ "$2" != "ftl" ]]; then
     unsupportedFunc
   else
     if [[ "$2" == "-h" ]] || [[ "$2" == "--help" ]]; then
-      echo "Usage: pihole checkout [repo] [branch]
-  Example: 'pihole checkout master' or 'pihole checkout core dev'
-  Switch Pi-hole subsystems to a different GitHub branch
+      echo -e "Switch Pi-hole subsystems to a different GitHub branch
+    Usage: ${COL_GREEN}pihole checkout${COL_NC} ${COL_YELLOW}shortcut${COL_NC}
+        or ${COL_GREEN}pihole checkout${COL_NC} ${COL_PURPLE}repo${COL_NC} ${COL_CYAN}branch${COL_NC}\n
+  Example: ${COL_GREEN}pihole checkout${COL_NC} ${COL_YELLOW}master${COL_NC}
+       or  ${COL_GREEN}pihole checkout${COL_NC} ${COL_PURPLE}ftl ${COL_CYAN}development${COL_NC}\n\n"
 
-  Repositories:
-    core [branch]       Change the branch of Pi-hole's core subsystem
-    web [branch]        Change the branch of Web Interface subsystem
-    ftl [branch]        Change the branch of Pi-hole's FTL subsystem
+    if [ -z "${DOCKER_VERSION}" ]; then
+      echo -e "  Shortcuts:
+    ${COL_YELLOW}master${COL_NC}              Update all subsystems to the latest stable release
+    ${COL_YELLOW}dev${COL_NC}                 Update all subsystems to the latest development release\n"
+    fi
 
-  Branches:
-    master              Update subsystems to the latest stable release
-    dev                 Update subsystems to the latest development release
-    branchname          Update subsystems to the specified branchname"
+    echo "  Individual components:"
+    if [ -z "${DOCKER_VERSION}" ]; then
+      echo "    ${COL_PURPLE}core${COL_NC} ${COL_CYAN}branch${COL_NC}       Change the branch of Pi-hole's core subsystem
+    ${COL_PURPLE}web${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of Web Interface subsystem"
+    fi
+    echo "    ${COL_PURPLE}ftl${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of Pi-hole's FTL subsystem"
+
       exit 0
     fi
 


### PR DESCRIPTION
# What does this implement/fix?

Currently, the entire `pihole checkout <whatever>` family of functions is disabled in dockerized Pi-holes. Even when Pi-hole offers a convenience script to build custom images locally, this is still a lot more work (as in: steps to explain/perform) than simply running something like `pihole checkout ftl what/the_heck` inside the container. As downloading FTL is merely replacing (and restarting) the binary, this PR *selectively* allows  the `ftl <branch>` subcommand of `pihole checkout ...`.
It also makes the output more colorful.

![image](https://github.com/user-attachments/assets/91953477-24dd-4e19-ad6d-507f6adff848)



---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.