### PR TITLE
Make the help text of "pihole checkout [what] [branch]" more colorful

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -161,34 +161,52 @@ checkout() {
     elif [[ "${1}" == "ftl" ]] ; then
         local path
         local oldbranch
+        local existing=false
         path="${2}/${binary}"
         oldbranch="$(pihole-FTL -b)"
 
-        echo -e "  ${INFO} Checking for branch ${COL_CYAN}${2}${COL_NC} on https://ftl.pi-hole.net"
-        check_download_exists "$path"
-        local ret=$?
-        if [ $ret -eq 0 ]; then
-            echo "  ${TICK} Branch ${2} exists"
+        # Check if requested branch is available
+        echo -e "  ${INFO} Checking for availability of branch ${COL_CYAN}${2}${COL_NC} on GitHub"
+        ftlbranches=( $(git ls-remote https://github.com/pi-hole/ftl | grep "refs/heads" | cut -d'/' -f3- -) )
+        # If returned array is empty -> connectivity issue
+        if [[ ${#ftlbranches[@]} -eq 0 ]]; then
+            echo -e "  ${CROSS} Unable to fetch branches from GitHub. Please check your Internet connection and try again later."
+            exit 1
+        fi
+
+        for e in "${ftlbranches[@]}"; do [[ "$e" == "${2}" ]] && existing=true; done
+        if [[ "${existing}" == false ]]; then
+            echo -e "  ${CROSS} Requested branch is not available\n"
+            echo -e "  ${INFO} Available branches are:"
+            for e in "${ftlbranches[@]}"; do echo "      - $e"; done
+            exit 1
+        fi
+        echo -e "  ${TICK} Branch ${2} exists on GitHub"
+
+        echo -e "  ${INFO} Checking for ${COL_YELLOW}${binary}${COL_NC} binary on https://ftl.pi-hole.net"
+
+        if check_download_exists "$path"; then
+            echo "  ${TICK} Binary exists"
             echo "${2}" > /etc/pihole/ftlbranch
             chmod 644 /etc/pihole/ftlbranch
-            echo -e "  ${INFO} Switching to branch: \"${2}\" from \"${oldbranch}\""
+            echo -e "  ${INFO} Switching to branch: ${COL_CYAN}${2}${COL_NC} from ${COL_CYAN}${oldbranch}${COL_NC}"
             FTLinstall "${binary}"
             restart_service pihole-FTL
             enable_service pihole-FTL
             # Update local and remote versions via updatechecker
             /opt/pihole/updatecheck.sh
         else
-            if [[ $ret -eq 1 ]]; then
-                echo "  ${CROSS} Requested branch \"${2}\" is not available"
-                ftlbranches=( $(git ls-remote https://github.com/pi-hole/ftl | grep 'heads' | sed 's/refs\/heads\///;s/ //g' | awk '{print $2}') )
-                echo -e "  ${INFO} Available branches for FTL are:"
-                for e in "${ftlbranches[@]}"; do echo "      - $e"; done
+            if [ $? -eq 1 ]; then
+                # Binary for requested branch is not available, may still be
+                # int he process of being built or CI build job failed
+                printf "  %b Binary for requested branch is not available, please try again later.\\n" ${CROSS}
+                printf "      If the issue persists, please contact Pi-hole Support and ask them to re-generate the binary.\\n"
                 exit 1
-            elif [[ $ret -eq 2 ]]; then
+            elif [ $? -eq 2 ]; then
                 printf "  %b Unable to download from ftl.pi-hole.net. Please check your Internet connection and try again later.\\n" "${CROSS}"
                 exit 1
             else
-                printf "  %b Unknown error. Please contact Pi-hole Support\\n" "${CROSS}"
+                printf "  %b Unknown checkout error. Please contact Pi-hole Support\\n" "${CROSS}"
                 exit 1
             fi
         fi

--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -77,7 +77,7 @@ checkout() {
 
     if [[ "${1}" == "dev" ]] ; then
         # Shortcut to check out development branches
-        echo -e "  ${INFO} Shortcut \"dev\" detected - checking out development / devel branches..."
+        echo -e "  ${INFO} Shortcut \"${COL_YELLOW}dev${COL_NC}\" detected - checking out development / devel branches..."
         echo ""
         echo -e "  ${INFO} Pi-hole Core"
         fetch_checkout_pull_branch "${PI_HOLE_FILES_DIR}" "development" || { echo "  ${CROSS} Unable to pull Core development branch"; exit 1; }
@@ -92,7 +92,7 @@ checkout() {
         chmod 644 /etc/pihole/ftlbranch
     elif [[ "${1}" == "master" ]] ; then
         # Shortcut to check out master branches
-        echo -e "  ${INFO} Shortcut \"master\" detected - checking out master branches..."
+        echo -e "  ${INFO} Shortcut \"${COL_YELLOW}master${COL_NC}\" detected - checking out master branches..."
         echo -e "  ${INFO} Pi-hole core"
         fetch_checkout_pull_branch "${PI_HOLE_FILES_DIR}" "master" || { echo "  ${CROSS} Unable to pull Core master branch"; exit 1; }
         echo -e "  ${INFO} Web interface"
@@ -123,7 +123,7 @@ checkout() {
         echo ""
         # Have the user choose the branch they want
         if ! (for e in "${corebranches[@]}"; do [[ "$e" == "${2}" ]] && exit 0; done); then
-            echo -e "  ${INFO} Requested branch \"${2}\" is not available"
+            echo -e "  ${INFO} Requested branch \"${COL_CYAN}${2}${COL_NC}\" is not available"
             echo -e "  ${INFO} Available branches for Core are:"
             for e in "${corebranches[@]}"; do echo "      - $e"; done
             exit 1
@@ -150,7 +150,7 @@ checkout() {
         echo ""
         # Have the user choose the branch they want
         if ! (for e in "${webbranches[@]}"; do [[ "$e" == "${2}" ]] && exit 0; done); then
-            echo -e "  ${INFO} Requested branch \"${2}\" is not available"
+            echo -e "  ${INFO} Requested branch \"${COL_CYAN}${2}${COL_NC}\" is not available"
             echo -e "  ${INFO} Available branches for Web Admin are:"
             for e in "${webbranches[@]}"; do echo "      - $e"; done
             exit 1
@@ -164,6 +164,7 @@ checkout() {
         path="${2}/${binary}"
         oldbranch="$(pihole-FTL -b)"
 
+        echo -e "  ${INFO} Checking for branch ${COL_CYAN}${2}${COL_NC} on https://ftl.pi-hole.net"
         check_download_exists "$path"
         local ret=$?
         if [ $ret -eq 0 ]; then
@@ -193,7 +194,7 @@ checkout() {
         fi
 
     else
-        echo -e "  ${INFO} Requested option \"${1}\" is not available"
+        echo -e "  ${CROSS} Requested option \"${1}\" is not available"
         exit 1
     fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -16,10 +16,9 @@
 #
 # curl -sSL https://install.pi-hole.net | bash
 
-# -e option instructs bash to immediately exit if any command [1] has a non-zero
-# exit status We do not want users to end up with a partially working install,
-# so we exit the script instead of continuing the installation with something
-# broken
+# -e option instructs bash to immediately exit if any command [1] has a non-zero exit status
+# We do not want users to end up with a partially working install, so we exit the script
+# instead of continuing the installation with something broken
 set -e
 
 # Append common folders to the PATH to ensure that all basic commands are available.
@@ -1694,7 +1693,7 @@ update_dialogs() {
 
 check_download_exists() {
     # Check if the download exists and we can reach the server
-    status=$(curl --head --silent "https://ftl.pi-hole.net/${1}" | head -n 1)
+    local status=$(curl --head --silent "https://ftl.pi-hole.net/${1}" | head -n 1)
 
     # Check the status code
     if grep -q "200" <<<"$status"; then
@@ -2012,14 +2011,12 @@ FTLcheckUpdate() {
 
         # Check whether or not the binary for this FTL branch actually exists. If not, then there is no update!
         # shellcheck disable=SC1090
-        check_download_exists "$path"
-        local ret=$?
-        if [ $ret -ne 0 ]; then
-            if [[ $ret -eq 1 ]]; then
+        if ! check_download_exists "$path"; then
+            if [ $? -eq 1 ]; then
                 printf "  %b Branch \"%s\" is not available.\\n" "${INFO}" "${ftlBranch}"
                 printf "  %b Use %bpihole checkout ftl [branchname]%b to switch to a valid branch.\\n" "${INFO}" "${COL_LIGHT_GREEN}" "${COL_NC}"
                 return 2
-            elif [[ $ret -eq 2 ]]; then
+            elif [ $? -eq 2 ]; then
                 printf "  %b Unable to download from ftl.pi-hole.net. Please check your Internet connection and try again later.\\n" "${CROSS}"
                 return 3
             else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -16,9 +16,10 @@
 #
 # curl -sSL https://install.pi-hole.net | bash
 
-# -e option instructs bash to immediately exit if any command [1] has a non-zero exit status
-# We do not want users to end up with a partially working install, so we exit the script
-# instead of continuing the installation with something broken
+# -e option instructs bash to immediately exit if any command [1] has a non-zero
+# exit status We do not want users to end up with a partially working install,
+# so we exit the script instead of continuing the installation with something
+# broken
 set -e
 
 # Append common folders to the PATH to ensure that all basic commands are available.

--- a/pihole
+++ b/pihole
@@ -411,6 +411,7 @@ piholeCheckoutFunc() {
       echo "Switch Pi-hole subsystems to a different GitHub branch
     Usage: ${COL_GREEN}pihole checkout${COL_NC} ${COL_YELLOW}shortcut${COL_NC}
         or ${COL_GREEN}pihole checkout${COL_NC} ${COL_PURPLE}repo${COL_NC} ${COL_CYAN}branch${COL_NC}
+
   Example: ${COL_GREEN}pihole checkout${COL_NC} ${COL_YELLOW}master${COL_NC}
        or  ${COL_GREEN}pihole checkout${COL_NC} ${COL_PURPLE}ftl ${COL_CYAN}development${COL_NC}
 

--- a/pihole
+++ b/pihole
@@ -408,19 +408,21 @@ piholeCheckoutFunc() {
     unsupportedFunc
   else
     if [[ "$2" == "-h" ]] || [[ "$2" == "--help" ]]; then
-      echo "Usage: pihole checkout [repo] [branch]
-  Example: 'pihole checkout master' or 'pihole checkout core dev'
-  Switch Pi-hole subsystems to a different GitHub branch
+      echo "Switch Pi-hole subsystems to a different GitHub branch
+    Usage: ${COL_GREEN}pihole checkout${COL_NC} ${COL_YELLOW}shortcut${COL_NC}
+        or ${COL_GREEN}pihole checkout${COL_NC} ${COL_PURPLE}repo${COL_NC} ${COL_CYAN}branch${COL_NC}
+  Example: ${COL_GREEN}pihole checkout${COL_NC} ${COL_YELLOW}master${COL_NC}
+       or  ${COL_GREEN}pihole checkout${COL_NC} ${COL_PURPLE}ftl ${COL_CYAN}development${COL_NC}
 
-  Repositories:
-    core [branch]       Change the branch of Pi-hole's core subsystem
-    web [branch]        Change the branch of Web Interface subsystem
-    ftl [branch]        Change the branch of Pi-hole's FTL subsystem
+  Shortcuts:
+    ${COL_YELLOW}master${COL_NC}            Update all subsystems to the latest stable release
+    ${COL_YELLOW}dev${COL_NC}               Update all subsystems to the latest development release
 
-  Branches:
-    master              Update subsystems to the latest stable release
-    dev                 Update subsystems to the latest development release
-    branchname          Update subsystems to the specified branchname"
+  Individual components:
+    ${COL_PURPLE}core${COL_NC} ${COL_CYAN}branch${COL_NC}       Change the branch of Pi-hole's core subsystem
+    ${COL_PURPLE}web${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of the web interface subsystem
+    ${COL_PURPLE}ftl${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of Pi-hole's FTL subsystem"
+
       exit 0
     fi
 


### PR DESCRIPTION
# What does this implement/fix?

See title.

![image](https://github.com/user-attachments/assets/9193a2f1-fc05-4a68-b341-fd60c1306b16)
---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.