### PR TITLE
Add the new sensors listing feature from pihole-FTL

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -496,6 +496,19 @@ hardware_check() {
     run_and_print_command "lscpu"
 }
 
+list_sensors(){
+    echo_current_diagnostic "Listing system sensors"
+
+    local errmsg="${CROSS} ${COL_RED}Command failed${COL_NC}"
+
+    # Raw input (-R) and slurp (-s) options combined treat a valid JSON or an error message in the same way.
+    # Then the command `fromjson?` tries to convert the raw input into JSON:
+    # - In case of failure (error message), the `// $err` command will output the formatted error message.
+    # - In case of success (valid JSON), it outputs the formatted JSON using indentation and colors (-C).
+    log_write "$(pihole-FTL --sensors 2>&1 | jq -RsrC --indent 4 --arg err "${errmsg}" 'fromjson? // $err')"
+}
+
+
 disk_usage() {
     local file_system
     local hide
@@ -1368,6 +1381,7 @@ diagnose_operating_system
 check_selinux
 check_firewalld
 hardware_check
+list_sensors
 disk_usage
 check_ip_command
 check_networking


### PR DESCRIPTION
### What does this PR aim to accomplish?

https://github.com/pi-hole/FTL/pull/2038 follow-up PR.

Add the new sensors listing feature from pihole-FTL to the Debug Log.

This new function will print:
- formatted output (with indentation and colors) in case of a successful json; or
- an error message in case of `pihole-FTL --sensors` failure.

### How does this PR accomplish the above?

Calling the new `pihole-FTL --sensors` command and formatting the returned value using `jq` with the following options:

`-R` (raw input) and `-s` (slurp) options combined treat a valid JSON or an error message in the same way.
Then the command `fromjson?` tries to convert the raw input into JSON. 
In case of failure (error message), the Alternative operator (`// $err`) will output the formatted error message.
In case of success (valid JSON), it outputs the formatted JSON using indentation and colors (`-C`: colorful output).


### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
