### PR TITLE
Add pihole api [endpoint] callback suitable for local API requests

### DIFF
--- a/advanced/bash-completion/pihole
+++ b/advanced/bash-completion/pihole
@@ -7,7 +7,7 @@ _pihole() {
 
     case "${prev}" in
         "pihole")
-            opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex restartdns status tail uninstall updateGravity updatePihole version wildcard arpflush"
+            opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex restartdns status tail uninstall updateGravity updatePihole version wildcard arpflush api"
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         ;;
         "allow"|"deny"|"wildcard"|"regex"|"allow-regex"|"allow-wild")

--- a/pihole
+++ b/pihole
@@ -484,6 +484,7 @@ Debugging Options:
   -t, tail [arg]      View the live output of the Pi-hole log.
                       Add an optional argument to filter the log
                       (regular expressions are supported)
+  api <endpoint>      Query the Pi-hole API at <endpoint>
 
 
 Options:

--- a/pihole
+++ b/pihole
@@ -550,6 +550,7 @@ case "${1}" in
   "updatechecker"               ) ;;
   "arpflush"                    ) ;;
   "-t" | "tail"                 ) ;;
+  "api"                         ) need_root=0;;
   *                             ) helpFunc;;
 esac
 
@@ -591,5 +592,6 @@ case "${1}" in
   "updatechecker"               ) shift; updateCheckFunc "$@";;
   "arpflush"                    ) arpFunc "$@";;
   "-t" | "tail"                 ) tailFunc "$2";;
+  "api"                         ) apiFunc "$2";;
   *                             ) helpFunc;;
 esac


### PR DESCRIPTION
# What does this implement/fix?

Useful for debugging purposes, especially if we ask users to show us some API responses. Note that this endpoint may require the user to login if authentication is enabled and CLI password not being available.

Example:

![image](https://github.com/user-attachments/assets/73fa06b4-7961-46b2-a514-ebea143cd6c0)

----

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.