### PR TITLE
Delete the cli password file if it exists on FTL stop

### DIFF
--- a/advanced/Templates/pihole-FTL-poststop.sh
+++ b/advanced/Templates/pihole-FTL-poststop.sh
@@ -11,3 +11,8 @@ FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 
 # Cleanup
 rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}"
+
+# Delete the cli password file if it exists on FTL stop
+if [ -f /etc/pihole/cli_pw ]; then
+    rm /etc/pihole/cli_pw
+fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Delete the cli password file if it exists on FTL stop.
See https://github.com/pi-hole/FTL/pull/2041#issuecomment-2314440386

**How does this PR accomplish the above?:**

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
