### PR TITLE
Disable SELINUX on CentOS 9 test dockerfile v5

### DIFF
--- a/test/_centos_9.Dockerfile
+++ b/test/_centos_9.Dockerfile
@@ -1,4 +1,6 @@
 FROM quay.io/centos/centos:stream9
+# Disable SELinux
+RUN echo "SELINUX=disabled" > /etc/selinux/config
 RUN yum install -y --allowerasing curl git initscripts
 
 ENV GITDIR /etc/.pihole


### PR DESCRIPTION
Same as https://github.com/pi-hole/pi-hole/pull/5743 but for v5