### PR TITLE
Change reference of web `devel` branch to `development` in pihole Checkout command

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -77,13 +77,13 @@ checkout() {
 
     if [[ "${1}" == "dev" ]] ; then
         # Shortcut to check out development branches
-        echo -e "  ${INFO} Shortcut \"${COL_YELLOW}dev${COL_NC}\" detected - checking out development / devel branches..."
+        echo -e "  ${INFO} Shortcut \"${COL_YELLOW}dev${COL_NC}\" detected - checking out development branches..."
         echo ""
         echo -e "  ${INFO} Pi-hole Core"
         fetch_checkout_pull_branch "${PI_HOLE_FILES_DIR}" "development" || { echo "  ${CROSS} Unable to pull Core development branch"; exit 1; }
         echo ""
         echo -e "  ${INFO} Web interface"
-        fetch_checkout_pull_branch "${webInterfaceDir}" "devel" || { echo "  ${CROSS} Unable to pull Web development branch"; exit 1; }
+        fetch_checkout_pull_branch "${webInterfaceDir}" "development" || { echo "  ${CROSS} Unable to pull Web development branch"; exit 1; }
         #echo -e "  ${TICK} Pi-hole Core"
 
         local path


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Title. We had discussed in the past renaming the `web` repo's `devel` branch to `development` to align with the other repos. This PR accounts for that change in the pihole checkout command (nowhere else needed in the core repo that I can see)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_