### PR TITLE
Add fallback option for OS check without hard-coded nameserver

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -173,7 +173,7 @@ os_check_dig(){
     local nameserver="$3"
     local response
 
-    response="$(dig "${protocol}" +short -t txt "${domain}" "${nameserver}" 2>&1
+    response="$(dig -"${protocol}" +short -t txt "${domain}" "${nameserver}" 2>&1
     echo $?
     )"
     echo "${response}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -167,88 +167,108 @@ is_command() {
     command -v "${check_command}" >/dev/null 2>&1
 }
 
+os_check_dig(){
+    local protocol="$1"
+    local domain="$2"
+    local nameserver="$3"
+    local response
+
+    response="$(dig "${protocol}" +short -t txt "${domain}" "${nameserver}" 2>&1
+    echo $?
+    )"
+    echo "${response}"
+}
+
+os_check_dig_response(){
+    # Checks the reply from the dig command to determine if it's a valid response
+    local digReply="$1"
+    local response
+
+    # Dig returned 0 (success), so get the actual response, and loop through it to determine if the detected variables above are valid
+    response="${digReply%%$'\n'*}"
+    # If the value of ${response} is a single 0, then this is the return code, not an actual response.
+    if [ "${response}" == 0 ]; then
+        echo false
+    else
+        echo true
+    fi
+}
+
 os_check() {
     if [ "$PIHOLE_SKIP_OS_CHECK" != true ]; then
         # This function gets a list of supported OS versions from a TXT record at versions.pi-hole.net
         # and determines whether or not the script is running on one of those systems
         local remote_os_domain valid_os valid_version valid_response detected_os detected_version display_warning cmdResult digReturnCode response
+        local piholeNameserver="@ns1.pi-hole.net"
         remote_os_domain=${OS_CHECK_DOMAIN_NAME:-"versions.pi-hole.net"}
 
         detected_os=$(grep '^ID=' /etc/os-release | cut -d '=' -f2 | tr -d '"')
         detected_version=$(grep VERSION_ID /etc/os-release | cut -d '=' -f2 | tr -d '"')
 
         # Test via IPv4 and hardcoded nameserver ns1.pi-hole.net
-        cmdResult="$(
-            dig -4 +short -t txt "${remote_os_domain}" @ns1.pi-hole.net 2>&1
-            echo $?
-        )"
+        cmdResult=$(os_check_dig 4 "${remote_os_domain}" "${piholeNameserver}")
+
         # Gets the return code of the previous command (last line)
         digReturnCode="${cmdResult##*$'\n'}"
 
         if [ ! "${digReturnCode}" == "0" ]; then
             valid_response=false
         else
-            # Dig returned 0 (success), so get the actual response, and loop through it to determine if the detected variables above are valid
-            response="${cmdResult%%$'\n'*}"
-            # If the value of ${response} is a single 0, then this is the return code, not an actual response.
-            if [ "${response}" == 0 ]; then
-                valid_response=false
-            else
-                valid_response=true
-            fi
+            valid_response=$(os_check_dig_response cmdResult)
         fi
 
         # Try again via IPv6 and hardcoded nameserver ns1.pi-hole.net
         if [ "$valid_response" = false ]; then
             unset valid_response
+            unset cmdResult
+            unset digReturnCode
 
-            cmdResult="$(
-                dig -6 +short -t txt "${remote_os_domain}" @ns1.pi-hole.net 2>&1
-                echo $?
-            )"
+            cmdResult=$(os_check_dig 6 "${remote_os_domain}" "${piholeNameserver}")
             # Gets the return code of the previous command (last line)
             digReturnCode="${cmdResult##*$'\n'}"
 
             if [ ! "${digReturnCode}" == "0" ]; then
                 valid_response=false
             else
-                # Dig returned 0 (success), so get the actual response, and loop through it to determine if the detected variables above are valid
-                response="${cmdResult%%$'\n'*}"
-                # If the value of ${response} is a single 0, then this is the return code, not an actual response.
-                if [ "${response}" == 0 ]; then
-                    valid_response=false
-                else
-                    valid_response=true
-                fi
+                valid_response=$(os_check_dig_response cmdResult)
             fi
         fi
 
         # Try again without hardcoded nameserver
         if [ "$valid_response" = false ]; then
             unset valid_response
+            unset cmdResult
+            unset digReturnCode
 
-            cmdResult="$(
-                dig +short -t txt "${remote_os_domain}" 2>&1
-                echo $?
-            )"
+            cmdResult=$(os_check_dig 4 "${remote_os_domain}")
             # Gets the return code of the previous command (last line)
             digReturnCode="${cmdResult##*$'\n'}"
 
             if [ ! "${digReturnCode}" == "0" ]; then
                 valid_response=false
             else
-                # Dig returned 0 (success), so get the actual response, and loop through it to determine if the detected variables above are valid
-                response="${cmdResult%%$'\n'*}"
-                # If the value of ${response} is a single 0, then this is the return code, not an actual response.
-                if [ "${response}" == 0 ]; then
-                    valid_response=false
-                else
-                    valid_response=true
-                fi
+                valid_response=$(os_check_dig_response cmdResult)
+            fi
+        fi
+
+        if [ "$valid_response" = false ]; then
+            unset valid_response
+            unset cmdResult
+            unset digReturnCode
+
+            cmdResult=$(os_check_dig 6 "${remote_os_domain}")
+            # Gets the return code of the previous command (last line)
+            digReturnCode="${cmdResult##*$'\n'}"
+
+            if [ ! "${digReturnCode}" == "0" ]; then
+                valid_response=false
+            else
+                valid_response=$(os_check_dig_response cmdResult)
             fi
         fi
 
         if [ "$valid_response" = true ]; then
+            response="${cmdResult%%$'\n'*}"
             IFS=" " read -r -a supportedOS < <(echo "${response}" | tr -d '"')
             for distro_and_versions in "${supportedOS[@]}"; do
                 distro_part="${distro_and_versions%%=*}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Inspired by https://github.com/pi-hole/pi-hole/pull/5683 this PR adds a fallback to the OS check. Currently we check for supported OS via IPv4 and IPv6 via hard-coded name server (ns1.pi-hole.net). If, for any reason (DNS server down, firewall blocking certain nam servers), this fails the installer will exit despite the host might have a working DNS resolution. So I added a check to `versions.pi-hole.net` without any hard-coded nameserver.

**How does this PR accomplish the above?:**

Re-use the code from the IPv6 test but remove the hard-coded nameserver

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
