### PR TITLE
Tweak/gravity dns

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -308,18 +308,6 @@ gravity_CheckDNSResolutionAvailable() {
     exit 1
   fi
 
-  # If the /etc/resolv.conf contains resolvers other than 127.0.0.1 then the local dnsmasq will not be queried and pi.hole is NXDOMAIN.
-  # This means that even though name resolution is working, the getent hosts check fails and the holddown timer keeps ticking and eventually fails
-  # So we check the output of the last command and if it failed, attempt to use dig +short as a fallback
-  if timeout 4 dig +short "${lookupDomain}" &>/dev/null; then
-    if [[ -n "${secs:-}" ]]; then
-      echo -e "${OVER}  ${TICK} DNS resolution is now available\\n"
-    fi
-    return 0
-  elif [[ -n "${secs:-}" ]]; then
-    echo -e "${OVER}  ${CROSS} DNS resolution is not available"
-    exit 1
-  fi
 
   # Determine error output message
   if pgrep pihole-FTL &>/dev/null; then

--- a/gravity.sh
+++ b/gravity.sh
@@ -298,29 +298,22 @@ gravity_CheckDNSResolutionAvailable() {
 
   # Determine if $lookupDomain is resolvable
   if timeout 4 getent hosts "${lookupDomain}" &>/dev/null; then
-    # Print confirmation of resolvability if it had previously failed
-    if [[ -n "${secs:-}" ]]; then
-      echo -e "${OVER}  ${TICK} DNS resolution is now available\\n"
-    fi
+    echo -e "${OVER}  ${TICK} DNS resolution is available\\n"
     return 0
-  elif [[ -n "${secs:-}" ]]; then
-    echo -e "${OVER}  ${CROSS} DNS resolution is not available"
-    exit 1
+  else
+    echo -e "  ${CROSS} DNS resolution is currently unavailable"
   fi
 
-
-  # Ensure DNS server is given time to be resolvable
-  secs="120"
-  echo -ne "  ${INFO} Time until retry: ${secs}"
-  until timeout 1 getent hosts "${lookupDomain}" &>/dev/null; do
-    [[ "${secs:-}" -eq 0 ]] && break
-    echo -ne "${OVER}  ${INFO} Time until retry: ${secs}"
-    : $((secs--))
+  echo -e "  ${INFO} Waiting until DNS resolution is available..."
+  until getent hosts github.com &> /dev/null; do
+  # Append one dot for each second waiting
+    str="${str}."
+    echo -ne "  ${OVER}  ${INFO} ${str}"
     sleep 1
   done
 
-  # Try again
-  gravity_CheckDNSResolutionAvailable
+  # If we reach this point, DNS resolution is available
+  echo -e "${OVER}  ${TICK} DNS resolution is available"
 }
 
 # Retrieve blocklist URLs and parse domains from adlist.list

--- a/gravity.sh
+++ b/gravity.sh
@@ -309,14 +309,6 @@ gravity_CheckDNSResolutionAvailable() {
   fi
 
 
-  # Determine error output message
-  if pgrep pihole-FTL &>/dev/null; then
-    echo -e "  ${CROSS} DNS resolution is currently unavailable"
-  else
-    echo -e "  ${CROSS} DNS service is not running"
-    "${PIHOLE_COMMAND}" restartdns
-  fi
-
   # Ensure DNS server is given time to be resolvable
   secs="120"
   echo -ne "  ${INFO} Time until retry: ${secs}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Tweaks the DNS resolution check within `gravity`. Historically, we used to set `FTL` as the systems DNS resolver. To check if it is up and running, we tried to resolve `pi.hole`. [Later we added a check using `dig` ](https://github.com/pi-hole/pi-hole/pull/1812)which should work on systems that did not use FTL as nameserver for the host. 
Since a while we do not set FTL as the hosts nameserver, and use `raw.githubusercontent.com` as the domain to check for. 

This PR cleans up the DNS resolution check.

**How does this PR accomplish the above?:**

Check if `raw.githubusercontent.com` is available right away. If so, return. If not, try to resolve it until it works.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
