### PR TITLE
Remove lines containing Adguard JavaScript rules from adlists

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -698,10 +698,10 @@ gravity_ParseFileIntoDomains() {
   # 2) Remove carriage returns
   # 3) Remove lines starting with ! (ABP Comments)
   # 4) Remove lines starting with [ (ABP Header)
-  # 5) Remove lines containing ABP extended CSS selectors ("##", "#!#", "#@#", "#?#") preceded by a letter
-  # 7) Remove comments (text starting with "#", include possible spaces before the hash sign)
-  # 8) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
-  # 9) Remove empty lines
+  # 5) Remove lines containing ABP extended CSS selectors ("##", "#$#", "#@#", "#?#") and Adguard JavaScript (#%#) preceded by a letter
+  # 6) Remove comments (text starting with "#", include possible spaces before the hash sign)
+  # 7) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
+  # 8) Remove empty lines
 
   sed -i -r \
     -e 's/\r$//' \

--- a/gravity.sh
+++ b/gravity.sh
@@ -699,7 +699,7 @@ gravity_ParseFileIntoDomains() {
   # 3) Remove lines starting with ! (ABP Comments)
   # 4) Remove lines starting with [ (ABP Header)
   # 5) Remove lines containing ABP extended CSS selectors ("##", "#!#", "#@#", "#?#") preceded by a letter
-  # 6) Remove lines containing ABP JavaScript rules ("#%#") preceded by a letter
+  # 6) Remove lines containing Adguard JavaScript rules ("#%#") preceded by a letter
   # 7) Remove comments (text starting with "#", include possible spaces before the hash sign)
   # 8) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
   # 9) Remove empty lines

--- a/gravity.sh
+++ b/gravity.sh
@@ -699,7 +699,6 @@ gravity_ParseFileIntoDomains() {
   # 3) Remove lines starting with ! (ABP Comments)
   # 4) Remove lines starting with [ (ABP Header)
   # 5) Remove lines containing ABP extended CSS selectors ("##", "#!#", "#@#", "#?#") preceded by a letter
-  # 6) Remove lines containing Adguard JavaScript rules ("#%#") preceded by a letter
   # 7) Remove comments (text starting with "#", include possible spaces before the hash sign)
   # 8) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
   # 9) Remove empty lines
@@ -708,8 +707,7 @@ gravity_ParseFileIntoDomains() {
     -e 's/\r$//' \
     -e 's/\s*!.*//g' \
     -e 's/\s*\[.*//g' \
-    -e '/[a-z]\#[$?@]{0,1}\#/d' \
-    -e '/[a-z]\#%\#/d' \
+    -e '/[a-z]\#[$?@%]{0,3}\#/d' \
     -e 's/\s*#.*//g' \
     -e 's/^.*\s+//g' \
     -e '/^$/d' "${destination}"

--- a/gravity.sh
+++ b/gravity.sh
@@ -699,15 +699,17 @@ gravity_ParseFileIntoDomains() {
   # 3) Remove lines starting with ! (ABP Comments)
   # 4) Remove lines starting with [ (ABP Header)
   # 5) Remove lines containing ABP extended CSS selectors ("##", "#!#", "#@#", "#?#") preceded by a letter
-  # 6) Remove comments (text starting with "#", include possible spaces before the hash sign)
-  # 7) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
-  # 8) Remove empty lines
+  # 6) Remove lines containing ABP JavaScript rules ("#%#") preceded by a letter
+  # 7) Remove comments (text starting with "#", include possible spaces before the hash sign)
+  # 8) Remove leading tabs, spaces, etc. (Also removes leading IP addresses)
+  # 9) Remove empty lines
 
   sed -i -r \
     -e 's/\r$//' \
     -e 's/\s*!.*//g' \
     -e 's/\s*\[.*//g' \
     -e '/[a-z]\#[$?@]{0,1}\#/d' \
+    -e '/[a-z]\#%\#/d' \
     -e 's/\s*#.*//g' \
     -e 's/^.*\s+//g' \
     -e '/^$/d' "${destination}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Addresses a [discourse feature request ](https://discourse.pi-hole.net/t/filtering-extended-abp-syntax-e-g-adguard/72004)regarding the removallines containing [ABP JavaScript rules](https://adguard.com/kb/de/general/ad-filtering/create-own-filters/#javascript-rules) before continue processing the list.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
