### PR TITLE
Fix wrong message being displayed while waiting for the DNS

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -304,7 +304,8 @@ gravity_CheckDNSResolutionAvailable() {
     echo -e "  ${CROSS} DNS resolution is currently unavailable"
   fi
 
-  echo -e "  ${INFO} Waiting until DNS resolution is available..."
+  str="Waiting until DNS resolution is available..."
+  echo -ne "  ${INFO} ${str}"
   until getent hosts github.com &> /dev/null; do
   # Append one dot for each second waiting
     str="${str}."


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Right now while waiting for the DNS the following can be observed:

```
  [✓] Deleting existing list cache
  [✗] DNS resolution is currently unavailable
  [i] Waiting until DNS resolution is available...
  [i] Deleting existing list cache....................^C

  [i] User-abort detected
  [✓] Cleaning up stray matter
  [✗] DNS service is NOT running
```

This is caused by f80efa51aac22611ff5d0fa031c80cd7b1287e39 using `${str}` but not defining it in the `gravity_CheckDNSResolutionAvailable` function making it use existing value from earlier: https://github.com/pi-hole/pi-hole/blob/1789b1ce99f909fe68eeb115847847d21da90f3e/gravity.sh#L919

This PR fixes this minor thing.

---

**How does this PR accomplish the above?:**

By defining mentioned variable inside `gravity_CheckDNSResolutionAvailable` function and adding `-n` `echo` parameter to not create additional line.

This is how it looks now:

```
  [✓] Deleting existing list cache
  [✗] DNS resolution is currently unavailable
  [i] Waiting until DNS resolution is available......^C

  [i] User-abort detected
  [✓] Cleaning up stray matter
  [✗] DNS service is NOT running
```

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
