### PR TITLE
Revert "Return early during v6 migration if migration dir exists"

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2146,8 +2146,8 @@ migrate_dnsmasq_configs() {
     # avoid conflicts with other services on this system
 
     # Exit early if this is already Pi-hole v6.0
-    # We decide this on the presence of the migration dir
-    if [[ -d "${V6_CONF_MIGRATION_DIR}" ]]; then
+    # We decide this on the presence of the file /etc/pihole/pihole.toml
+    if [[ -f /etc/pihole/pihole.toml ]]; then
         return 0
     fi
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This reverts commit 251f3295f3b64a81c86ef1e18ce92f91f8658f5e.
Reverts https://github.com/pi-hole/pi-hole/pull/5766 after comment https://github.com/pi-hole/pi-hole/pull/5766#issuecomment-2347228146

Creation of the migration dir is now handled by FTL https://github.com/pi-hole/FTL/pull/2061

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*
