### PR TITLE
Remove no longer needed `restartDNS` function from the `pihole` script

### DIFF
--- a/advanced/bash-completion/pihole
+++ b/advanced/bash-completion/pihole
@@ -7,7 +7,7 @@ _pihole() {
 
     case "${prev}" in
         "pihole")
-            opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex restartdns status tail uninstall updateGravity updatePihole version wildcard arpflush api"
+            opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex status tail uninstall updateGravity updatePihole version wildcard arpflush api"
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         ;;
         "allow"|"deny"|"wildcard"|"regex"|"allow-regex"|"allow-wild")

--- a/gravity.sh
+++ b/gravity.sh
@@ -777,12 +777,6 @@ gravity_Cleanup() {
 
   echo -e "${OVER}  ${TICK} ${str}"
 
-  # # Only restart DNS service if offline
-  # if ! pgrep pihole-FTL &> /dev/null; then
-  #   "${PIHOLE_COMMAND}" restartdns
-  #   dnsWasOffline=true
-  # fi
-
   # Print Pi-hole status if an error occurred
   if [[ -n "${error}" ]]; then
     "${PIHOLE_COMMAND}" status

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -39,8 +39,6 @@ pihole -g\fR
 .br
 pihole status
 .br
-pihole restartdns\fR [options]
-.br
 \fBpihole\fR (\fBenable\fR|\fBdisable\fR [time])
 .br
 \fBpihole\fR \fBcheckout\fR repo [branch]
@@ -234,18 +232,6 @@ Available commands and options:
       #s                Disable Pi-hole functionality for # second(s)
 .br
       #m                Disable Pi-hole functionality for # minute(s)
-.br
-
-\fBrestartdns\fR [options]
-.br
-    Full restart Pi-hole subsystems. Without any options (see below) a full restart causes config file parsing and history re-reading
-.br
-
-    (restart options):
-.br
-      reload            Updates the lists (incl. HOSTS files) and flushes DNS cache. Does not reparse config files
-.br
-      reload-lists      Updates the lists (excl. HOSTS files) WITHOUT flushing the DNS cache. Does not reparse config files
 .br
 
 \fBcheckout\fR [repo] [branch]

--- a/pihole
+++ b/pihole
@@ -147,66 +147,6 @@ versionFunc() {
   exec "${PI_HOLE_SCRIPT_DIR}"/version.sh
 }
 
-restartDNS() {
-  local svcOption svc str output status pid icon FTL_PID_FILE
-  svcOption="${1:-restart}"
-
-  # get the current path to the pihole-FTL.pid
-  FTL_PID_FILE="$(getFTLConfigValue files.pid)"
-
-  # Determine if we should reload or restart
-  if [[ "${svcOption}" =~ "reload-lists" ]]; then
-    # Reloading of the lists has been requested
-    # Note 1: This will NOT re-read any *.conf files
-    # Note 2: We cannot use killall here as it does
-    #         not know about real-time signals
-
-    pid="$(getFTLPID ${FTL_PID_FILE})"
-    if [[ "$pid" -eq "-1" ]]; then
-      svc="true"
-      str="FTL is not running"
-      icon="${INFO}"
-    else
-      svc="kill -RTMIN ${pid}"
-      str="Reloading DNS lists"
-      icon="${TICK}"
-    fi
-  elif [[ "${svcOption}" =~ "reload" ]]; then
-    # Reloading of the DNS cache has been requested
-    # Note: This will NOT re-read any *.conf files
-    pid="$(getFTLPID ${FTL_PID_FILE})"
-    if [[ "$pid" -eq "-1" ]]; then
-      svc="true"
-      str="FTL is not running"
-      icon="${INFO}"
-    else
-      svc="kill -HUP ${pid}"
-      str="Flushing DNS cache"
-      icon="${TICK}"
-    fi
-  else
-    # A full restart has been requested
-    svc="service pihole-FTL restart"
-    str="Restarting DNS server"
-    icon="${TICK}"
-  fi
-
-  # Print output to Terminal, but not to Web Admin
-  [[ -t 1 ]] && echo -ne "  ${INFO} ${str}..."
-
-  output=$( { ${svc}; } 2>&1 )
-  status="$?"
-
-  if [[ "${status}" -eq 0 ]]; then
-    [[ -t 1 ]] && echo -e "${OVER}  ${icon} ${str}"
-    return 0
-  else
-    [[ ! -t 1 ]] && local OVER=""
-    echo -e "${OVER}  ${CROSS} ${output}"
-    return 1
-  fi
-}
-
 piholeEnable() {
   if [[ "${2}" == "-h" ]] || [[ "${2}" == "--help" ]]; then
     echo "Usage: pihole enable/disable [time]
@@ -298,7 +238,6 @@ Options:
   Try 'pihole logging --help' for more information."
     exit 1
   fi
-  restartDNS
   echo -e "${OVER}  ${TICK} ${str}"
 }
 
@@ -509,9 +448,6 @@ Options:
   enable              Enable Pi-hole subsystems
   disable             Disable Pi-hole subsystems
                         Add '-h' for more info on disable usage
-  restartdns          Full restart Pi-hole subsystems
-                        Add 'reload' to update the lists and flush the cache without restarting the DNS server
-                        Add 'reload-lists' to only update the lists WITHOUT flushing the cache or restarting the DNS server
   checkout            Switch Pi-hole subsystems to a different GitHub branch
                         Add '-h' for more info on checkout usage
   arpflush            Flush information stored in Pi-hole's network tables";
@@ -547,7 +483,6 @@ case "${1}" in
   "enable"                      ) need_root=0;;
   "disable"                     ) need_root=0;;
   "-d" | "debug"                ) ;;
-  "restartdns"                  ) ;;
   "-g" | "updateGravity"        ) ;;
   "reloaddns"                   ) ;;
   "setpassword"                 ) ;;
@@ -590,8 +525,6 @@ case "${1}" in
   "uninstall"                   ) uninstallFunc;;
   "enable"                      ) piholeEnable true "$2";;
   "disable"                     ) piholeEnable false "$2";;
-  "restartdns"                  ) restartDNS "$2";;
-  "reloaddns"                   ) restartDNS "reload";;
   "setpassword"                 ) SetWebPassword "$@";;
   "checkout"                    ) piholeCheckoutFunc "$@";;
   "updatechecker"               ) shift; updateCheckFunc "$@";;


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Something we discussed doing a while back when we first started exploring the changes necessary for v6, but we ultimately did not get around to doing.

All settings changed in the `pihole.toml` file, or via the API or CLI which require a restart of FTL will trigger this automagically, so this function is no longer needed

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_