### PR TITLE
Remove the restartdns functionality and promote the reloaddns functions

### DIFF
--- a/advanced/bash-completion/pihole
+++ b/advanced/bash-completion/pihole
@@ -7,7 +7,7 @@ _pihole() {
 
     case "${prev}" in
         "pihole")
-            opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex restartdns status tail uninstall updateGravity updatePihole version wildcard arpflush api"
+            opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex reloaddns reloaddns-lists status tail uninstall updateGravity updatePihole version wildcard arpflush api"
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         ;;
         "allow"|"deny"|"wildcard"|"regex"|"allow-regex"|"allow-wild")

--- a/advanced/bash-completion/pihole
+++ b/advanced/bash-completion/pihole
@@ -7,7 +7,7 @@ _pihole() {
 
     case "${prev}" in
         "pihole")
-            opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex reloaddns reloaddns-lists status tail uninstall updateGravity updatePihole version wildcard arpflush api"
+            opts="allow allow-regex allow-wild deny checkout debug disable enable flush help logging query reconfigure regex reloaddns reloadlists status tail uninstall updateGravity updatePihole version wildcard arpflush api"
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
         ;;
         "allow"|"deny"|"wildcard"|"regex"|"allow-regex"|"allow-wild")

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -241,7 +241,7 @@ Available commands and options:
     Update the lists and flush the cache without restarting the DNS server
 .br
 
-\fBreloaddns-lists\fR
+\fBreloadlists\fR
 .br
     Update the lists WITHOUT flushing the cache or restarting the DNS server
 .br

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -236,16 +236,14 @@ Available commands and options:
       #m                Disable Pi-hole functionality for # minute(s)
 .br
 
-\fBrestartdns\fR [options]
+\fBreloaddns\fR
 .br
-    Full restart Pi-hole subsystems. Without any options (see below) a full restart causes config file parsing and history re-reading
+    Update the lists and flush the cache without restarting the DNS server
 .br
 
-    (restart options):
+\fBreloaddns-lists\fR
 .br
-      reload            Updates the lists (incl. HOSTS files) and flushes DNS cache. Does not reparse config files
-.br
-      reload-lists      Updates the lists (excl. HOSTS files) WITHOUT flushing the DNS cache. Does not reparse config files
+    Update the lists WITHOUT flushing the cache or restarting the DNS server
 .br
 
 \fBcheckout\fR [repo] [branch]

--- a/pihole
+++ b/pihole
@@ -505,7 +505,7 @@ Options:
   disable             Disable Pi-hole subsystems
                         Add '-h' for more info on disable usage
   reloaddns           Update the lists and flush the cache without restarting the DNS server
-  reloadlists     Update the lists WITHOUT flushing the cache or restarting the DNS server
+  reloadlists         Update the lists WITHOUT flushing the cache or restarting the DNS server
   checkout            Switch Pi-hole subsystems to a different GitHub branch
                         Add '-h' for more info on checkout usage
   arpflush            Flush information stored in Pi-hole's network tables";
@@ -519,38 +519,38 @@ fi
 # functions that do not require sudo power
 need_root=1
 case "${1}" in
-  "-h" | "help" | "--help"      ) helpFunc;;
-  "-v" | "version"              ) versionFunc;;
-  "-c" | "chronometer"          ) chronometerFunc "$@";;
-  "-q" | "query"                ) queryFunc "$@";;
-  "status"                      ) statusFunc "$2";;
-  "tricorder"                   ) tricorderFunc;;
+  "-h" | "help" | "--help"        ) helpFunc;;
+  "-v" | "version"                ) versionFunc;;
+  "-c" | "chronometer"            ) chronometerFunc "$@";;
+  "-q" | "query"                  ) queryFunc "$@";;
+  "status"                        ) statusFunc "$2";;
+  "tricorder"                     ) tricorderFunc;;
 
   # we need to add all arguments that require sudo power to not trigger the * argument
-  "allow" | "allowlist"         ) need_root=0;;
-  "deny" | "denylist"           ) need_root=0;;
-  "--wild" | "wildcard"         ) need_root=0;;
-  "--regex" | "regex"           ) need_root=0;;
+  "allow" | "allowlist"           ) need_root=0;;
+  "deny" | "denylist"             ) need_root=0;;
+  "--wild" | "wildcard"           ) need_root=0;;
+  "--regex" | "regex"             ) need_root=0;;
   "--allow-regex" | "allow-regex" ) need_root=0;;
   "--allow-wild" | "allow-wild"   ) need_root=0;;
-  "-f" | "flush"                ) ;;
-  "-up" | "updatePihole"        ) ;;
-  "-r"  | "reconfigure"         ) ;;
-  "-l" | "logging"              ) ;;
-  "uninstall"                   ) ;;
-  "enable"                      ) need_root=0;;
-  "disable"                     ) need_root=0;;
-  "-d" | "debug"                ) ;;
-  "-g" | "updateGravity"        ) ;;
-  "reloaddns"                   ) ;;
-  "reloadlists"             ) ;;
-  "setpassword"                 ) ;;
-  "checkout"                    ) ;;
-  "updatechecker"               ) ;;
-  "arpflush"                    ) ;;
-  "-t" | "tail"                 ) ;;
-  "api"                         ) need_root=0;;
-  *                             ) helpFunc;;
+  "-f" | "flush"                  ) ;;
+  "-up" | "updatePihole"          ) ;;
+  "-r"  | "reconfigure"           ) ;;
+  "-l" | "logging"                ) ;;
+  "uninstall"                     ) ;;
+  "enable"                        ) need_root=0;;
+  "disable"                       ) need_root=0;;
+  "-d" | "debug"                  ) ;;
+  "-g" | "updateGravity"          ) ;;
+  "reloaddns"                     ) ;;
+  "reloadlists"                   ) ;;
+  "setpassword"                   ) ;;
+  "checkout"                      ) ;;
+  "updatechecker"                 ) ;;
+  "arpflush"                      ) ;;
+  "-t" | "tail"                   ) ;;
+  "api"                           ) need_root=0;;
+  *                               ) helpFunc;;
 esac
 
 # In the case of alpine running in a container, the USER variable appears to be blank
@@ -569,28 +569,28 @@ fi
 
 # Handle redirecting to specific functions based on arguments
 case "${1}" in
-  "allow" | "allowlist"         ) listFunc "$@";;
-  "deny" | "denylist"           ) listFunc "$@";;
-  "--wild" | "wildcard"         ) listFunc "$@";;
-  "--regex" | "regex"           ) listFunc "$@";;
+  "allow" | "allowlist"           ) listFunc "$@";;
+  "deny" | "denylist"             ) listFunc "$@";;
+  "--wild" | "wildcard"           ) listFunc "$@";;
+  "--regex" | "regex"             ) listFunc "$@";;
   "--allow-regex" | "allow-regex" ) listFunc "$@";;
   "--allow-wild" | "allow-wild"   ) listFunc "$@";;
-  "-d" | "debug"                ) debugFunc "$@";;
-  "-f" | "flush"                ) flushFunc "$@";;
-  "-up" | "updatePihole"        ) updatePiholeFunc "$@";;
-  "-r"  | "reconfigure"         ) reconfigurePiholeFunc;;
-  "-g" | "updateGravity"        ) updateGravityFunc "$@";;
-  "-l" | "logging"              ) piholeLogging "$@";;
-  "uninstall"                   ) uninstallFunc;;
-  "enable"                      ) piholeEnable true "$2";;
-  "disable"                     ) piholeEnable false "$2";;
-  "reloaddns"                   ) reloadDNS "reload";;
-  "reloadlists"             ) reloadDNS "reload-lists";;
-  "setpassword"                 ) SetWebPassword "$@";;
-  "checkout"                    ) piholeCheckoutFunc "$@";;
-  "updatechecker"               ) shift; updateCheckFunc "$@";;
-  "arpflush"                    ) arpFunc "$@";;
-  "-t" | "tail"                 ) tailFunc "$2";;
-  "api"                         ) apiFunc "$2";;
-  *                             ) helpFunc;;
+  "-d" | "debug"                  ) debugFunc "$@";;
+  "-f" | "flush"                  ) flushFunc "$@";;
+  "-up" | "updatePihole"          ) updatePiholeFunc "$@";;
+  "-r"  | "reconfigure"           ) reconfigurePiholeFunc;;
+  "-g" | "updateGravity"          ) updateGravityFunc "$@";;
+  "-l" | "logging"                ) piholeLogging "$@";;
+  "uninstall"                     ) uninstallFunc;;
+  "enable"                        ) piholeEnable true "$2";;
+  "disable"                       ) piholeEnable false "$2";;
+  "reloaddns"                     ) reloadDNS "reload";;
+  "reloadlists"                   ) reloadDNS "reload-lists";;
+  "setpassword"                   ) SetWebPassword "$@";;
+  "checkout"                      ) piholeCheckoutFunc "$@";;
+  "updatechecker"                 ) shift; updateCheckFunc "$@";;
+  "arpflush"                      ) arpFunc "$@";;
+  "-t" | "tail"                   ) tailFunc "$2";;
+  "api"                           ) apiFunc "$2";;
+  *                               ) helpFunc;;
 esac

--- a/pihole
+++ b/pihole
@@ -149,7 +149,7 @@ versionFunc() {
 
 reloadDNS() {
   local svcOption svc str output status pid icon FTL_PID_FILE
-  svcOption="${1:-restart}"
+  svcOption="${1:-reload}"
 
   # get the current path to the pihole-FTL.pid
   FTL_PID_FILE="$(getFTLConfigValue files.pid)"

--- a/pihole
+++ b/pihole
@@ -505,7 +505,7 @@ Options:
   disable             Disable Pi-hole subsystems
                         Add '-h' for more info on disable usage
   reloaddns           Update the lists and flush the cache without restarting the DNS server
-  reloaddns-lists     Update the lists WITHOUT flushing the cache or restarting the DNS server
+  reloadlists     Update the lists WITHOUT flushing the cache or restarting the DNS server
   checkout            Switch Pi-hole subsystems to a different GitHub branch
                         Add '-h' for more info on checkout usage
   arpflush            Flush information stored in Pi-hole's network tables";
@@ -543,7 +543,7 @@ case "${1}" in
   "-d" | "debug"                ) ;;
   "-g" | "updateGravity"        ) ;;
   "reloaddns"                   ) ;;
-  "reloaddns-lists"             ) ;;
+  "reloadlists"             ) ;;
   "setpassword"                 ) ;;
   "checkout"                    ) ;;
   "updatechecker"               ) ;;
@@ -585,7 +585,7 @@ case "${1}" in
   "enable"                      ) piholeEnable true "$2";;
   "disable"                     ) piholeEnable false "$2";;
   "reloaddns"                   ) reloadDNS "reload";;
-  "reloaddns-lists"             ) reloadDNS "reload-lists";;
+  "reloadlists"             ) reloadDNS "reload-lists";;
   "setpassword"                 ) SetWebPassword "$@";;
   "checkout"                    ) piholeCheckoutFunc "$@";;
   "updatechecker"               ) shift; updateCheckFunc "$@";;

--- a/pihole
+++ b/pihole
@@ -147,7 +147,7 @@ versionFunc() {
   exec "${PI_HOLE_SCRIPT_DIR}"/version.sh
 }
 
-restartDNS() {
+reloadDNS() {
   local svcOption svc str output status pid icon FTL_PID_FILE
   svcOption="${1:-restart}"
 
@@ -184,11 +184,6 @@ restartDNS() {
       str="Flushing DNS cache"
       icon="${TICK}"
     fi
-  else
-    # A full restart has been requested
-    svc="service pihole-FTL restart"
-    str="Restarting DNS server"
-    icon="${TICK}"
   fi
 
   # Print output to Terminal, but not to Web Admin
@@ -509,9 +504,8 @@ Options:
   enable              Enable Pi-hole subsystems
   disable             Disable Pi-hole subsystems
                         Add '-h' for more info on disable usage
-  restartdns          Full restart Pi-hole subsystems
-                        Add 'reload' to update the lists and flush the cache without restarting the DNS server
-                        Add 'reload-lists' to only update the lists WITHOUT flushing the cache or restarting the DNS server
+  reloaddns           Update the lists and flush the cache without restarting the DNS server
+  reloaddns-lists     Update the lists WITHOUT flushing the cache or restarting the DNS server
   checkout            Switch Pi-hole subsystems to a different GitHub branch
                         Add '-h' for more info on checkout usage
   arpflush            Flush information stored in Pi-hole's network tables";
@@ -547,9 +541,9 @@ case "${1}" in
   "enable"                      ) need_root=0;;
   "disable"                     ) need_root=0;;
   "-d" | "debug"                ) ;;
-  "restartdns"                  ) ;;
   "-g" | "updateGravity"        ) ;;
   "reloaddns"                   ) ;;
+  "reloaddns-lists"             ) ;;
   "setpassword"                 ) ;;
   "checkout"                    ) ;;
   "updatechecker"               ) ;;
@@ -590,8 +584,8 @@ case "${1}" in
   "uninstall"                   ) uninstallFunc;;
   "enable"                      ) piholeEnable true "$2";;
   "disable"                     ) piholeEnable false "$2";;
-  "restartdns"                  ) restartDNS "$2";;
-  "reloaddns"                   ) restartDNS "reload";;
+  "reloaddns"                   ) reloadDNS "reload";;
+  "reloaddns-lists"             ) reloadDNS "reload-lists";;
   "setpassword"                 ) SetWebPassword "$@";;
   "checkout"                    ) piholeCheckoutFunc "$@";;
   "updatechecker"               ) shift; updateCheckFunc "$@";;


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Offered as an alternative to https://github.com/pi-hole/pi-hole/pull/5779

This PR adds an additional `reloaddns-lists` to mirror the existing shortcut for `reloaddns` -> `restartDNS reload`,renames the `restartDNS` function to `reloadDNS` and removes it's ability to restart the resolver

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_