### PR TITLE
Use pihole.toml to decide if installer runs on an update

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -77,6 +77,7 @@ PI_HOLE_FILES=(list piholeDebug piholeLogFlush setupLCD update version gravity u
 PI_HOLE_INSTALL_DIR="/opt/pihole"
 PI_HOLE_CONFIG_DIR="/etc/pihole"
 PI_HOLE_BIN_DIR="/usr/local/bin"
+PI_HOLE_V6_CONFIG="${PI_HOLE_CONFIG_DIR}/pihole.toml"
 if [ -z "$useUpdateVars" ]; then
     useUpdateVars=false
 fi
@@ -2194,7 +2195,7 @@ migrate_dnsmasq_configs() {
 
     # Exit early if this is already Pi-hole v6.0
     # We decide this on the presence of the file /etc/pihole/pihole.toml
-    if [[ -f /etc/pihole/pihole.toml ]]; then
+    if [[ -f "${PI_HOLE_V6_CONFIG}" ]]; then
         return 0
     fi
 
@@ -2289,16 +2290,19 @@ main() {
     printf "  %b Checking for / installing Required dependencies for this install script...\\n" "${INFO}"
     install_dependent_packages "${INSTALLER_COMMON_DEPS[@]}" "${INSTALLER_DEPS[@]}"
 
-    # if it's running unattended,
-    if [[ "${runUnattended}" == true ]]; then
-        printf "  %b Performing unattended setup, no dialogs will be displayed\\n" "${INFO}"
-        # Use the setup variables
-        useUpdateVars=true
-        # also disable debconf-apt-progress dialogs
-        export DEBIAN_FRONTEND="noninteractive"
-    else
-        # If running attended, show the available options (repair/reconfigure)
-        update_dialogs
+    # in case of an update
+    if [[ -f "${PI_HOLE_V6_CONFIG}" ]]; then
+        # if it's running unattended,
+        if [[ "${runUnattended}" == true ]]; then
+            printf "  %b Performing unattended setup, no dialogs will be displayed\\n" "${INFO}"
+            # Use the setup variables
+            useUpdateVars=true
+            # also disable debconf-apt-progress dialogs
+            export DEBIAN_FRONTEND="noninteractive"
+        else
+            # If running attended, show the available options (repair/reconfigure)
+            update_dialogs
+        fi
     fi
 
     if [[ "${useUpdateVars}" == false ]]; then


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Currently, a fresh v6 installation is not possible. The installer always assumes  it is an update. Reason is the removal of `setupVars.conf` by https://github.com/pi-hole/pi-hole/commit/7cbe713873d38eb4b4952ea7e24a59f4c0084ed7

This PR adds a check for an existing installation by checking the existence of `pihole.toml`

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
