### PR TITLE
Do not print FTL update check details on pihole -up

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -144,7 +144,7 @@ main() {
     local binary
     binary="pihole-FTL${funcOutput##*pihole-FTL}" #binary name will be the last line of the output of get_binary_name (it always begins with pihole-FTL)
 
-    if FTLcheckUpdate "${binary}"; then
+    if FTLcheckUpdate "${binary}" &>/dev/null; then
         FTL_update=true
         echo -e "  ${INFO} FTL:\\t\\t${COL_YELLOW}update available${COL_NC}"
     else


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Should fix https://github.com/pi-hole/pi-hole/issues/5772.

Currently we source `FTLcheckUpdate()` from the install script to check for FTL updates. This prints a few lines during the update check. If a FTL update exists, the same function is executed again as part of the installer run later during the update. 

While only being cosmetic, I can understand that a duplicated output is not desired. . As we already have code in place to deal with a non-zero return code I think it is fine to suppress the detailed output during the check.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
