### PR TITLE
Fix empty adlists

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -441,11 +441,6 @@ gravity_DownloadBlocklists() {
       continue
     fi
 
-    # Chown the file to the pihole user
-    # This is necessary for the FTL to be able to update the file
-    # when gravity is run from the web interface
-    fix_owner_permissions "${saveLocation}"
-
     echo -e "  ${INFO} Target: ${url}"
     local regex check_url
     # Check for characters NOT allowed in URLs
@@ -746,7 +741,7 @@ gravity_ParseFileIntoDomains() {
     -e 's/^.*\s+//g' \
     -e '/^$/d' "${destination}"
 
-  chmod 644 "${destination}"
+  fix_owner_permissions "${destination}"
 }
 
 # Report number of entries in a table


### PR DESCRIPTION
# What does this implement/fix?

Do not `touch` list files as this creates them. This causes issues down the line in the Heisenberg compensator. This fixes an unintended side-effect of #5819 

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/ad-lists-are-empty/74207

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.