### PR TITLE
Fix rare case when apt and rpm package managers are found

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -484,9 +484,8 @@ build_dependency_package(){
 
         # Move back into the directory the user started in
         popd &> /dev/null || return 1
-    fi
 
-    if is_command rpm; then
+    elif is_command rpm; then
         # move into the tmp directory
         pushd /tmp &>/dev/null || return 1
 
@@ -517,6 +516,13 @@ build_dependency_package(){
 
         # Move back into the directory the user started in
         popd &> /dev/null || return 1
+
+    # If neither apt-get or yum/dnf package managers were found
+    else
+        # we cannot build required packages
+        printf "  %b No supported package manager found\\n" "${CROSS}"
+        # so exit the installer
+        exit 1
     fi
 
     # Remove the build directory

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1517,11 +1517,9 @@ install_dependent_packages() {
             printf "  %b Error: Unable to find Pi-hole dependency meta package.\\n" "${COL_LIGHT_RED}"
             return 1
         fi
-    fi
-
     # Install Fedora/CentOS packages
-    if is_command rpm; then
-            if [ -f /tmp/pihole-meta.rpm ]; then
+    elif is_command rpm; then
+        if [ -f /tmp/pihole-meta.rpm ]; then
             eval "${PKG_INSTALL}" "/tmp/pihole-meta.rpm"
             rm /tmp/pihole-meta.rpm
         else
@@ -1529,7 +1527,14 @@ install_dependent_packages() {
             return 1
         fi
 
+    # If neither apt-get or yum/dnf package managers were found
+    else
+        # we cannot install the dependency package
+        printf "  %b No supported package manager found\\n" "${CROSS}"
+        # so exit the installer
+        exit 1
     fi
+
     printf "\\n"
     return 0
 }


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes an edge case when `apt` and `rpm` both are present and the meta package is build/installed

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
