### PR TITLE
Fix v5 -> v6 update

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2401,8 +2401,8 @@ main() {
         exit 1
     fi
 
-    # in case of an update
-    if [[ -f "${PI_HOLE_V6_CONFIG}" ]]; then
+    # in case of an update (can be a v5 -> v6 or v6 -> v6 update)
+    if [[ -f "${PI_HOLE_V6_CONFIG}" ]] || [[ -f "/etc/pihole/setupVars.conf" ]]; then
         # if it's running unattended,
         if [[ "${runUnattended}" == true ]]; then
             printf "  %b Performing unattended setup, no dialogs will be displayed\\n" "${INFO}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Should fix v5 -> v6 updated where `pihole.toml` is not present yet.
Background: https://github.com/pi-hole/pi-hole/pull/5790 fixed fresh v6 installations, but forgot about v5->v6 updates.

**How does this PR accomplish the above?:**

Re-add `setupVars.conf` at the right place. If present, this is an update.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
