### PR TITLE
Disable lighttpd if found

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2305,8 +2305,8 @@ disableLighttpd() {
     if [[ -t 0 ]]; then
         # The terminal is interactive
         dialog --no-shadow --keep-tite \
-            --title "Pi-hole v6.0 does no longer need lighttpd" \
-            --yesno "Pi-hole v6.0 has its own embedded web server so lighttpd is no longer needed *unless* you have custom configurations. In this case, you can opt-out of disabling lighttpd and pihole-FTL will try to bind to an alternative port such as 8080.\\n\\nDo you want to disable lighttpd (recommended)?" "${r}" "${c}"
+            --title "Pi-hole v6.0 no longer uses lighttpd" \
+           --yesno "\\n\\nPi-hole v6.0 has its own embedded web server so lighttpd is no longer needed *unless* you have custom configurations.\\n\\nIn this case, you can opt-out of disabling lighttpd and pihole-FTL will try to bind to an alternative port such as 8080.\\n\\nDo you want to disable lighttpd (recommended)?" "${r}" "${c}"
         response=$?
     else
         # The terminal is non-interactive, assume yes. Lighttpd will be stopped

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2301,13 +2301,13 @@ copy_to_install_log() {
 }
 
 disableLighttpd() {
+    local response
     # Detect if the terminal is interactive
     if [[ -t 0 ]]; then
         # The terminal is interactive
         dialog --no-shadow --keep-tite \
             --title "Pi-hole v6.0 no longer uses lighttpd" \
-           --yesno "\\n\\nPi-hole v6.0 has its own embedded web server so lighttpd is no longer needed *unless* you have custom configurations.\\n\\nIn this case, you can opt-out of disabling lighttpd and pihole-FTL will try to bind to an alternative port such as 8080.\\n\\nDo you want to disable lighttpd (recommended)?" "${r}" "${c}"
-        response=$?
+           --yesno "\\n\\nPi-hole v6.0 has its own embedded web server so lighttpd is no longer needed *unless* you have custom configurations.\\n\\nIn this case, you can opt-out of disabling lighttpd and pihole-FTL will try to bind to an alternative port such as 8080.\\n\\nDo you want to disable lighttpd (recommended)?" "${r}" "${c}" && response=0 || response="$?"
     else
         # The terminal is non-interactive, assume yes. Lighttpd will be stopped
         # but keeps being installed and can easily be re-enabled by the user

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2301,6 +2301,24 @@ copy_to_install_log() {
 }
 
 disableLighttpd() {
+    # Detect if the terminal is interactive
+    if [[ -t 0 ]]; then
+        # The terminal is interactive
+        dialog --no-shadow --keep-tite \
+            --title "Pi-hole v6.0 does no longer need lighttpd" \
+            --yesno "Pi-hole v6.0 has its own embedded web server so lighttpd is no longer needed *unless* you have custom configurations. In this case, you can opt-out of disabling lighttpd and pihole-FTL will try to bind to an alternative port such as 8080.\\n\\nDo you want to disable lighttpd (recommended)?" "${r}" "${c}"
+        response=$?
+    else
+        # The terminal is non-interactive, assume yes. Lighttpd will be stopped
+        # but keeps being installed and can easily be re-enabled by the user
+        response=0
+    fi
+
+    # If the user does not want to disable lighttpd, return early
+    if [[ "${response}" -ne 0 ]]; then
+        return
+    fi
+
     # Lighttpd is not needed anymore, so disable it
     # We keep all the configuration files in place, so the user can re-enable it
     # if needed

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2300,6 +2300,21 @@ copy_to_install_log() {
     chown pihole:pihole "${installLogLoc}"
 }
 
+disableLighttpd() {
+    # Lighttpd is not needed anymore, so disable it
+    # We keep all the configuration files in place, so the user can re-enable it
+    # if needed
+
+    # Check if lighttpd is installed
+    if is_command lighttpd; then
+        # Stop the lighttpd service
+        stop_service lighttpd
+
+        # Disable the lighttpd service
+        disable_service lighttpd
+    fi
+}
+
 migrate_dnsmasq_configs() {
     # Previously, Pi-hole created a number of files in /etc/dnsmasq.d
     # During migration, their content is copied into the new single source of
@@ -2488,6 +2503,9 @@ main() {
     # so this change needs to be made after installation is complete,
     # but before starting or resttarting the ftl service
     disable_resolved_stublistener
+
+    # Disable lighttpd server
+    disableLighttpd
 
     # Check if gravity database needs to be upgraded. If so, do it without rebuilding
     # gravity altogether. This may be a very long running task needlessly blocking


### PR DESCRIPTION
# What does this implement/fix?

Lighttpd is not needed anymore, so let's disable it to avoid conflicts concerning (at least) port 80. We keep all the configuration files in place, so the user can re-enable it if needed and can then also decide how they want to assign ports. Pi-hole v6.0 is a major release and such a "soft" breaking change is fine. In the end, the vast majority of Pi-hole users will only be using `lighttpd` for the Pi-hole web interface which makes it a useless service for them with v6.0+.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.