### PR TITLE
Improve lighttpd disabling

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2301,6 +2301,11 @@ copy_to_install_log() {
 }
 
 disableLighttpd() {
+    # Return early when lighttpd is not installed
+    if [[ ! -f /etc/lighttpd/lighttpd.conf ]]; then
+        return
+    fi
+
     local response
     # Detect if the terminal is interactive
     if [[ -t 0 ]]; then
@@ -2344,6 +2349,9 @@ migrate_dnsmasq_configs() {
     if [[ -f "${PI_HOLE_V6_CONFIG}" ]]; then
         return 0
     fi
+
+    # Disable lighttpd server during v6 migration
+    disableLighttpd
 
     # Create target directory /etc/pihole/migration_backup_v6
     # and make it owned by pihole:pihole
@@ -2535,9 +2543,6 @@ main() {
     # so this change needs to be made after installation is complete,
     # but before starting or resttarting the ftl service
     disable_resolved_stublistener
-
-    # Disable lighttpd server
-    disableLighttpd
 
     # Check if gravity database needs to be upgraded. If so, do it without rebuilding
     # gravity altogether. This may be a very long running task needlessly blocking

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2301,8 +2301,8 @@ copy_to_install_log() {
 }
 
 disableLighttpd() {
-    # Return early when lighttpd is not installed
-    if [[ ! -f /etc/lighttpd/lighttpd.conf ]]; then
+    # Return early when lighttpd is not active
+    if ! check_service_active lighttpd; then
         return
     fi
 


### PR DESCRIPTION
# What does this implement/fix?

Show `lighttpd` disabling dialog only once during v6 migration and when `lighttpd` is actually installed

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.