### PR TITLE
Use a different method to identify if a gravity restore succeeded

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -413,7 +413,7 @@ gravity_DownloadBlocklists() {
     echo -e "  ${INFO} Storing gravity database in ${COL_BOLD}${gravityDBfile}${COL_NC}"
   fi
 
-  local url domain str target compression adlist_type directory
+  local url domain str target compression adlist_type directory success
   echo ""
 
   # Prepare new gravity database
@@ -447,16 +447,18 @@ gravity_DownloadBlocklists() {
     echo -e "\\n  ${CROSS} Unable to copy data from ${gravityDBfile} to ${gravityTEMPfile}\\n  ${output}"
 
     # Try to attempt a backup restore
+    success=false
     if [[ -d "${gravityBCKdir}" ]]; then
       for i in {1..10}; do
         if try_restore_backup "${i}"; then
+          success=true
           break
         fi
       done
     fi
 
     # If none of the attempts worked, return 1
-    if [[ "${i}" -eq 10 ]]; then
+    if [[ "${success}" == false ]]; then
       pihole-FTL sqlite3 "${gravityTEMPfile}" "INSERT OR REPLACE INTO info (property,value) values ('gravity_restored','failed');"
       return 1
     fi


### PR DESCRIPTION
# What does this implement/fix?

Fixes https://github.com/pi-hole/pi-hole/pull/5818#discussion_r1930400850

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.