### PR TITLE
Use versionConverter instead of two grep calls

### DIFF
--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -93,3 +93,15 @@ setFTLConfigValue(){
     exit 5
   fi
 }
+
+#######################
+# converts a given version string e.g. v3.7.1 to 3007001000 to allow for easier
+# comparison of multi digit version numbers
+#
+# Credits https://apple.stackexchange.com/a/123408
+#
+# Example usage: versionConverter "v3.7.1"
+#######################
+versionConverter() {
+  echo "$@" | tr -d '[:alpha:]' | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
+}

--- a/gravity.sh
+++ b/gravity.sh
@@ -414,7 +414,7 @@ gravity_DownloadBlocklists() {
     echo -e "  ${INFO} Storing gravity database in ${COL_BOLD}${gravityDBfile}${COL_NC}"
   fi
 
-  local url domain str target compression adlist_type directory curlVersion success
+  local url domain str target compression adlist_type directory curlVersion curlVersionConv success
   echo ""
 
   # Prepare new gravity database
@@ -511,13 +511,9 @@ gravity_DownloadBlocklists() {
   # comparing the version string being >= 7.68.0 (released Jan 2020)
   # https://github.com/curl/curl/pull/4543 followed by
   # https://github.com/curl/curl/pull/4678
-  if echo "${curlVersion}" | grep -q "curl 7\.[6-9][8-9]"; then
+  curlVersionConv=$(versionConverter "$(echo "${curlVersion}" | sed -nE 's/curl ([0-9.]+).*/\1/p')")
+  if [[ "${curlVersionConv}" -ge 7068000000 ]]; then
     etag_support=true
-  else
-    # Check if the version is >= 8
-    if echo "${curlVersion}" | grep -q "curl 8"; then
-      etag_support=true
-    fi
   fi
 
   # Loop through $sources and download each one


### PR DESCRIPTION
# What does this implement/fix?

See https://github.com/pi-hole/pi-hole/pull/5867

This PR is an amendment to PR implementing the alternative version comparison scheme borrowed from PADD. IMO it is making things a lot more complicated but I still propose it as alternative for discussion.

However, since I am not convinced this is the better method, I open this change as another PR into the former one instead of simply adding this commit into it.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.