### PR TITLE
Fix counting of domains in the gravity summary

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -864,11 +864,11 @@ gravity_Table_Count() {
 gravity_ShowCount() {
   # Here we use the table "gravity" instead of the view "vw_gravity" for speed.
   # It's safe to replace it here, because right after a gravity run both will show the exactly same number of domains.
-  gravity_Table_Count "gravity" "gravity domains" ""
-  gravity_Table_Count "vw_blacklist" "exact denied domains"
-  gravity_Table_Count "vw_regex_blacklist" "regex denied filters"
-  gravity_Table_Count "vw_whitelist" "exact allowed domains"
-  gravity_Table_Count "vw_regex_whitelist" "regex allowed filters"
+  gravity_Table_Count "gravity" "gravity domains"
+  gravity_Table_Count "domainlist WHERE type = 1" "exact denied domains"
+  gravity_Table_Count "domainlist WHERE type = 3" "regex denied filters"
+  gravity_Table_Count "domainlist WHERE type = 0" "exact allowed domains"
+  gravity_Table_Count "domainlist WHERE type = 2" "regex allowed filters"
 }
 
 # Trap Ctrl-C


### PR DESCRIPTION
# What does this implement/fix?

Fix counting of domains at the end of `pihole -g`. The existing scheme used the SQL `VIEW`s for simplicity, however, they have the unintended side-effect of - when being queried without a `GROUP BY` clause - returning entries multiple times if they are assigned to several groups


**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/pi-hole/issues/5874.

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.