### PR TITLE
Remove outdated dns-servers.conf

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1279,13 +1279,6 @@ installConfigs() {
     # Ensure that permissions are correctly set
     chown -R pihole:pihole /etc/pihole
 
-    # Install list of DNS servers
-    # Format: Name;Primary IPv4;Secondary IPv4;Primary IPv6;Secondary IPv6
-    # Some values may be empty (for example: DNS servers without IPv6 support)
-    echo "${DNS_SERVERS}" >"${PI_HOLE_CONFIG_DIR}/dns-servers.conf"
-    chmod 644 "${PI_HOLE_CONFIG_DIR}/dns-servers.conf"
-    chown pihole:pihole "${PI_HOLE_CONFIG_DIR}/dns-servers.conf"
-
     # Install empty custom.list file if it does not exist
     if [[ ! -r "${PI_HOLE_CONFIG_DIR}/hosts/custom.list" ]]; then
         if ! install -D -T -o pihole -g pihole -m 660 /dev/null "${PI_HOLE_CONFIG_DIR}/hosts/custom.list" &>/dev/null; then

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -119,11 +119,6 @@ def test_installPihole_fresh_install_readableFiles(host):
     assert exit_status_success == actual_rc
     check_leases = test_cmd.format("w", "/etc/pihole/dhcp.leases", piholeuser)
     actual_rc = host.run(check_leases).rc
-    # readable dns-servers.conf
-    assert exit_status_success == actual_rc
-    check_servers = test_cmd.format("r", "/etc/pihole/dns-servers.conf", piholeuser)
-    actual_rc = host.run(check_servers).rc
-    assert exit_status_success == actual_rc
     # readable install.log
     check_install = test_cmd.format("r", "/etc/pihole/install.log", piholeuser)
     actual_rc = host.run(check_install).rc


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Removes outdated `dns-servers.conf`.
It was used to show a pre-configured list of possible DNS servers in the web UI, but this data is now provided by FTL

https://github.com/pi-hole/web/blob/5c8945c81c98f6f17e5c138ffbfdcb0831e5a062/scripts/pi-hole/php/savesettings.php#L106-L135

https://github.com/pi-hole/FTL/blob/bbf4dae1a6fdebce5d3a8c57bc1e2cb29aa825d6/src/api/config.c#L59-L70

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
