### PR TITLE
installer: use a drop-in to disable systemd-resolved stub listener

### DIFF
--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -94,8 +94,9 @@ removePiholeFiles() {
     echo -e "  ${TICK} Removed config files"
 
     # Restore Resolved
-    if [[ -e /etc/systemd/resolved.conf.orig ]]; then
-        ${SUDO} cp -p /etc/systemd/resolved.conf.orig /etc/systemd/resolved.conf
+    if [[ -e /etc/systemd/resolved.conf.orig ]] || [[ -e /etc/systemd/resolved.conf.d/90-pi-hole-disable-stub-listener.conf ]]; then
+        ${SUDO} cp -p /etc/systemd/resolved.conf.orig /etc/systemd/resolved.conf &> /dev/null || true
+        ${SUDO} rm -f /etc/systemd/resolved.conf.d/90-pi-hole-disable-stub-listener.conf
         systemctl reload-or-restart systemd-resolved
     fi
 


### PR DESCRIPTION
systemd-resolved supports drop-in config snippets, e.g. by placing .conf files in /etc/systemd/resolved.conf.d. During install, use a drop-in config to set DNSStubListener=no, instead of modifying the main config.

This is generally better practice, and also prevents conflicts when distribution packages are upgraded, which may include new versions of /etc/systemd/resolved.conf.

---

**What does this PR aim to accomplish?:**

Improve the way systemd-resolved's stub resolver is disabled during install.

**How does this PR accomplish the above?:**

Use `/etc/systemd/resolved.conf.d/pi-hole-disable-stub-listener.conf` instead of modifying `/etc/systemd/resolved.conf` directly.

**Link documentation PRs if any are needed to support this PR:**

n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
