### PR TITLE
Fix database integrity check in debug log

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1221,7 +1221,7 @@ database_integrity_check(){
     local database="${1}"
 
     log_write "${INFO} Checking integrity of ${database} ... (this can take several minutes)"
-    result="$(pihole-FTL "${database}" "PRAGMA integrity_check" 2>&1 & spinner)"
+    result="$(pihole-FTL sqlite3 -ni "${database}" "PRAGMA integrity_check" 2>&1 & spinner)"
     if [[ ${result} = "ok" ]]; then
       log_write "${TICK} Integrity of ${database} intact"
 

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -1137,7 +1137,7 @@ show_FTL_db_entries() {
 }
 
 check_dhcp_servers() {
-    echo_current_diagnostic "Discovering active DHCP servers (takes 10 seconds)"
+    echo_current_diagnostic "Discovering active DHCP servers (takes 6 seconds)"
 
     OLD_IFS="$IFS"
     IFS=$'\n'


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes a bug in the debug script where the database integrity check would fails despite the database is fine. Reason is that https://github.com/pi-hole/pi-hole/pull/5518 forgot one `-ni` flag for FTL's `sqlite` invocation

```
*** [ DIAGNOSING ]: Pi-hole FTL Query Database
-rw-r----- 1 pihole pihole 98M 10. Feb 20:01 /etc/pihole/pihole-FTL.db
[i] Checking integrity of /etc/pihole/pihole-FTL.db ... (this can take several minutes)
[✗] Integrity errors in /etc/pihole/pihole-FTL.db found.

    -- Loading resources from /root/.sqliterc
    integrity_check
    ok


nanopi@nanopi:~$ sudo cat /root/.sqliterc
.headers on
```

@DL6ER maybe FTL should not invoke it's `sqlite` engine on database files automatically when the `sqlite3` flag is not set?


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
