### PR TITLE
If there are no files to change, don't print an error

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -1082,7 +1082,7 @@ migrate_to_listsCache_dir() {
   fi
 
   # Update the list's paths in the corresponding .sha1 files to the new location
-  sed -i "s|${piholeDir}/|${listsCacheDir}/|g" "${listsCacheDir}"/*.sha1
+  sed -i "s|${piholeDir}/|${listsCacheDir}/|g" "${listsCacheDir}"/*.sha1 2>/dev/null
 }
 
 helpFunc() {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Within gravity, we move all downloaded files, `sha1` and `etags` to a cache folder and change the path within the `sha1` files. But if there are no `sha1` files to change, `sed` will print an error. This PR suppress the error.

See https://github.com/pi-hole/pi-hole/issues/5952 for a log of such an error.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
