### PR TITLE
Check if running in LXC before complaining about Kernel updates.

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1476,7 +1476,10 @@ notify_package_updates_available() {
     # Store the list of packages in a variable
     updatesToInstall=$(eval "${PKG_COUNT}")
 
-    if [[ -d "/lib/modules/$(uname -r)" ]]; then
+    # Determine if this is being run in a LXC, if so then ignore kernel update check but still do package update check
+    isLXC=$(grep -q "lxc" /proc/1/environ && echo 1 || echo 0)
+
+    if [[ -d "/lib/modules/$(uname -r)" ]] || [[ "$isLXC" -eq 1 ]]; then
         if [[ "${updatesToInstall}" -eq 0 ]]; then
             printf "%b  %b %s... up to date!\\n\\n" "${OVER}" "${TICK}" "${str}"
         else

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1477,6 +1477,7 @@ notify_package_updates_available() {
     updatesToInstall=$(eval "${PKG_COUNT}")
 
     # Determine if this is being run in a LXC, if so then ignore kernel update check but still do package update check
+    local isLXC
     isLXC=$(grep -q "lxc" /proc/1/environ && echo 1 || echo 0)
 
     if [[ -d "/lib/modules/$(uname -r)" ]] || [[ "$isLXC" -eq 1 ]]; then


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When installing or updating Pi-hole on a LXC container, the `Kernel update detected` message appears due to `/lib/modules/$(uname -r)` not existing, which it never will for unprivileged LXC containers.

**How does this PR accomplish the above?:**

isLXC is set based off the contents of `/proc/1/environ` and if it is set to 1, package update checks will proceed even if `/lib/modules/$(uname -r)`  doesn't exist

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
