### PR TITLE
Only run migration code if setupVars.conf exists.

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2312,8 +2312,8 @@ migrate_dnsmasq_configs() {
     # avoid conflicts with other services on this system
 
     # Exit early if this is already Pi-hole v6.0
-    # We decide this on the presence of the file /etc/pihole/pihole.toml
-    if [[ -f "${PI_HOLE_V6_CONFIG}" ]]; then
+    # We decide this on the non-existence of the file /etc/pihole/setupVars.conf (either moved by previous migration or fresh install)
+    if [[ ! -f "/etc/pihole/setupVars.conf" ]]; then
         return 0
     fi
 


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

This is a change in the logic to the current code, which decides whether or not to migrate based on the existence of `pihole.toml`

However, the flaw in that logic is that even a fresh install will be treated as a migration - causing code to run that doesn't need to be (and, in fact, the web password not being set)

By checking for setupVars.conf instead, we can assume it doesn't exist for two reasons:
 - This is a fresh install
 - It is an update, but the file has already been migrated

The only thing I can think that _might_ cause issues at this point is that if a user has run an upgrade that has already been skipped due to previously mistaken logic, and has manually fixed things.... does this now have the potential to break _those_ installs by completing the migration steps automatically? (If nothing else, it would tidy up their /etc/pihole directory)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_