### PR TITLE
Pi-hole Core v6.0.4

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1766,7 +1766,7 @@ displayFinalMessage() {
     if [[ "${#1}" -gt 0 ]]; then
         # set the password to the first argument.
         pwstring="$1"
-    elif [[ $(pihole-FTL --config webserver.api.pwhash) == '""' ]]; then
+    elif [[ -n $(pihole-FTL --config webserver.api.pwhash) ]]; then
         # Else if the password exists from previous setup, we'll load it later
         pwstring="unchanged"
     else
@@ -2518,7 +2518,7 @@ main() {
     # Add password to web UI if there is none
     pw=""
     # If no password is set,
-    if [[ $(pihole-FTL --config webserver.api.pwhash) == '""' ]]; then
+    if [[ -z $(pihole-FTL --config webserver.api.pwhash) ]]; then
         # generate a random password
         pw=$(tr -dc _A-Z-a-z-0-9 </dev/urandom | head -c 8)
         pihole setpassword "${pw}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2122,7 +2122,7 @@ get_binary_name() {
         else
             printf "%b  %b Detected 32bit (i686) architecture\\n" "${OVER}" "${TICK}"
         fi
-        l_binary="pihole-FTL-linux-386"
+        l_binary="pihole-FTL-386"
     fi
 
     # Returning a string value via echo

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1208,12 +1208,12 @@ remove_old_pihole_lighttpd_configs() {
         lighty-disable-mod pihole-admin >/dev/null || true
     fi
 
-    if [[ -f "${confavailable}" ]]; then
-        rm "${confavailable}"
+    if [[ -f "${confenabled}" || -L "${confenabled}" ]]; then
+        rm "${confenabled}"
     fi
 
-    if [[ -f "${confenabled}" ]]; then
-        rm "${confenabled}"
+    if [[ -f "${confavailable}" ]]; then
+        rm "${confavailable}"
     fi
 }
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2312,8 +2312,8 @@ migrate_dnsmasq_configs() {
     # avoid conflicts with other services on this system
 
     # Exit early if this is already Pi-hole v6.0
-    # We decide this on the presence of the file /etc/pihole/pihole.toml
-    if [[ -f "${PI_HOLE_V6_CONFIG}" ]]; then
+    # We decide this on the non-existence of the file /etc/pihole/setupVars.conf (either moved by previous migration or fresh install)
+    if [[ ! -f "/etc/pihole/setupVars.conf" ]]; then
         return 0
     fi
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2549,9 +2549,14 @@ main() {
 
     restart_service pihole-FTL
 
-    # write privacy level and logging to pihole.toml
+    # apply settings to pihole.toml
     # needs to be done after FTL service has been started, otherwise pihole.toml does not exist
-    # set on fresh installations by setPrivacyLevel() and setLogging(
+    # set on fresh installations by setDNS() and setPrivacyLevel() and setLogging()
+    if [ -n "${PIHOLE_DNS_1}" ]; then
+        local string="\"${PIHOLE_DNS_1}\""
+        [ -n "${PIHOLE_DNS_2}" ] && string+=", \"${PIHOLE_DNS_2}\""
+        setFTLConfigValue "dns.upstreams" "[ $string ]"
+    fi
     if [ -n "${QUERY_LOGGING}" ]; then
         setFTLConfigValue "dns.queryLogging" "${QUERY_LOGGING}"
     fi

--- a/pihole
+++ b/pihole
@@ -398,7 +398,10 @@ tailFunc() {
 
 piholeCheckoutFunc() {
   if [ -n "${DOCKER_VERSION}" ]; then
-    unsupportedFunc
+    echo -e "${CROSS} Function not supported in Docker images"
+    echo "Please build a custom image following the steps at"
+    echo "https://github.com/pi-hole/docker-pi-hole?tab=readme-ov-file#building-the-image-locally"
+    exit 0
   else
     if [[ "$2" == "-h" ]] || [[ "$2" == "--help" ]]; then
       echo "Switch Pi-hole subsystems to a different GitHub branch


### PR DESCRIPTION
This should fix all the migrations issues once and for all. Thanks to everyone involved in tracking down the issue. 

This should also fix "botched" previous migrations when it detects setupvars.cconf

## What's Changed
* Don't set a random password on v5 -> v6 updates by @yubiuser in https://github.com/pi-hole/pi-hole/pull/5960
* Only run migration code if setupVars.conf exists. by @PromoFaux in https://github.com/pi-hole/pi-hole/pull/5969
* Fix dnsmasq v5 to v6 config migration by @MichaIng in https://github.com/pi-hole/pi-hole/pull/5968
* Assure that Lighttpd conf-enabled symlink is removed by @MichaIng in https://github.com/pi-hole/pi-hole/pull/5974
* Print a more helpful message on pihole checkout in docker containers by @DL6ER in https://github.com/pi-hole/pi-hole/pull/5963


**Full Changelog**: https://github.com/pi-hole/pi-hole/compare/v6.0.3...v6.0.4