### PR TITLE
Update update.sh, updatecheck.sh and uninstall.sh to honour pihole.to…

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -12,7 +12,6 @@
 
 # Variables
 readonly ADMIN_INTERFACE_GIT_URL="https://github.com/pi-hole/web.git"
-readonly ADMIN_INTERFACE_DIR="/var/www/html/admin"
 readonly PI_HOLE_GIT_URL="https://github.com/pi-hole/pi-hole.git"
 readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 
@@ -26,12 +25,18 @@ CHECK_ONLY=false
 source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
 # shellcheck disable=SC1091
 source "/opt/pihole/COL_TABLE"
+# shellcheck disable=SC1091
+source "${PI_HOLE_INSTALL_DIR}/utils.sh"
 
 # is_repo() sourced from basic-install.sh
 # make_repo() sourced from basic-install.sh
 # update_repo() source from basic-install.sh
 # getGitFiles() sourced from basic-install.sh
 # FTLcheckUpdate() sourced from basic-install.sh
+# getFTLConfigValue() sourced from utils.sh
+
+# Honour configured paths for the web application.
+readonly ADMIN_INTERFACE_DIR=$(getFTLConfigValue "webserver.paths.webroot")$(getFTLConfigValue "webserver.paths.webhome")
 
 GitCheckUpdateAvail() {
     local directory
@@ -209,7 +214,7 @@ main() {
         echo ""
         echo -e "  ${INFO} Pi-hole Web Admin files out of date, updating local repo."
         getGitFiles "${ADMIN_INTERFACE_DIR}" "${ADMIN_INTERFACE_GIT_URL}"
-        echo -e "  ${INFO} If you had made any changes in '/var/www/html/admin/', they have been stashed using 'git stash'"
+        echo -e "  ${INFO} If you had made any changes in '${ADMIN_INTERFACE_DIR}', they have been stashed using 'git stash'"
     fi
 
     if [[ "${FTL_update}" == true ]]; then

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -42,6 +42,8 @@ function get_remote_hash() {
 # shellcheck disable=SC1091
 . /opt/pihole/utils.sh
 
+readonly ADMIN_INTERFACE_DIR=$(getFTLConfigValue "webserver.paths.webroot")$(getFTLConfigValue "webserver.paths.webhome")
+
 # Remove the below three legacy files if they exist
 rm -f "/etc/pihole/GitHubVersions"
 rm -f "/etc/pihole/localbranches"
@@ -85,13 +87,13 @@ addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_CORE_HASH" "${GITHUB_CORE_HASH}"
 
 # get Web versions
 
-WEB_VERSION="$(get_local_version /var/www/html/admin)"
+WEB_VERSION="$(get_local_version "${ADMIN_INTERFACE_DIR}")"
 addOrEditKeyValPair "${VERSION_FILE}" "WEB_VERSION" "${WEB_VERSION}"
 
-WEB_BRANCH="$(get_local_branch /var/www/html/admin)"
+WEB_BRANCH="$(get_local_branch "${ADMIN_INTERFACE_DIR}")"
 addOrEditKeyValPair "${VERSION_FILE}" "WEB_BRANCH" "${WEB_BRANCH}"
 
-WEB_HASH="$(get_local_hash /var/www/html/admin)"
+WEB_HASH="$(get_local_hash "${ADMIN_INTERFACE_DIR}")"
 addOrEditKeyValPair "${VERSION_FILE}" "WEB_HASH" "${WEB_HASH}"
 
 GITHUB_WEB_VERSION="$(get_remote_version web "${WEB_BRANCH}")"

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -9,6 +9,9 @@
 # Please see LICENSE file for your rights under this license.
 
 source "/opt/pihole/COL_TABLE"
+source "/opt/pihole/utils.sh"
+
+readonly ADMIN_INTERFACE_DIR=$(getFTLConfigValue "webserver.paths.webroot")$(getFTLConfigValue "webserver.paths.webhome")
 
 while true; do
     read -rp "  ${QST} Are you sure you would like to remove ${COL_WHITE}Pi-hole${COL_NC}? [y/N] " answer
@@ -53,17 +56,9 @@ removeMetaPackage() {
 }
 
 removePiholeFiles() {
-    # Only web directories/files that are created by Pi-hole should be removed
+    # Remove the web interface of Pi-hole
     echo -ne "  ${INFO} Removing Web Interface..."
-    ${SUDO} rm -rf /var/www/html/admin &> /dev/null
-
-
-    # If the web directory is empty after removing these files, then the parent html directory can be removed.
-    if [ -d "/var/www/html" ]; then
-        if [[ ! "$(ls -A /var/www/html)" ]]; then
-            ${SUDO} rm -rf /var/www/html &> /dev/null
-        fi
-    fi
+    ${SUDO} rm -rf "${ADMIN_INTERFACE_DIR}" &> /dev/null
     echo -e "${OVER}  ${TICK} Removed Web Interface"
 
     # Attempt to preserve backwards compatibility with older versions


### PR DESCRIPTION
…ml settings for webserver.paths.webroot and webserver.paths.webhome

**What does this PR aim to accomplish?:**

Attempt to address #5980

**How does this PR accomplish the above?:**

Update `advanced/Scripts/update.sh` to source `utils.sh` and build the `ADMIN_INTERFACE_DIR` variable from configuration in `pihole.toml` via the `getFTLConfigValue()` function. Also change a hard coded reference of `/var/www/html/admin` in output string to use the `ADMIN_INTERFACE_DIR` variable.

Update `advanced/Scripts/updatecheck.sh` to build an `ADMIN_INTERFACE_DIR` variable from configuration in `pihole.toml` via the `getFTLConfigValue()` function and change hard coded references to `/var/www/html/admin` to use the added `ADMIN_INTERFACE_DIR` variable.

Update `automated install/uninstall.sh` to source `utils.sh` and to build an `ADMIN_INTERFACE_DIR` variable from configuration in `pihole.toml` via the `getFTLConfigValue()` function. Add a check that if web UI path is not the default of `/var/www/html/admin` do not automatically delete the custom path, but tell user to delete manually. This is a bit of a work around to deal with potentially "unsafe" paths getting pulled from `pihole.toml` (and its a custom config, so possibly a fair ask).

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
