### PR TITLE
Do not hide error messages when dealing with services

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1355,9 +1355,9 @@ stop_service() {
     local str="Stopping ${1} service"
     printf "  %b %s..." "${INFO}" "${str}"
     if is_command systemctl; then
-        systemctl stop "${1}" &>/dev/null || true
+        systemctl -q stop "${1}" || true
     else
-        service "${1}" stop &>/dev/null || true
+        service "${1}" stop >/dev/null || true
     fi
     printf "%b  %b %s...\\n" "${OVER}" "${TICK}" "${str}"
 }
@@ -1370,10 +1370,10 @@ restart_service() {
     # If systemctl exists,
     if is_command systemctl; then
         # use that to restart the service
-        systemctl restart "${1}" &>/dev/null
+        systemctl -q restart "${1}"
     else
         # Otherwise, fall back to the service command
-        service "${1}" restart &>/dev/null
+        service "${1}" restart >/dev/null
     fi
     printf "%b  %b %s...\\n" "${OVER}" "${TICK}" "${str}"
 }
@@ -1386,10 +1386,10 @@ enable_service() {
     # If systemctl exists,
     if is_command systemctl; then
         # use that to enable the service
-        systemctl enable "${1}" &>/dev/null
+        systemctl -q enable "${1}"
     else
         #  Otherwise, use update-rc.d to accomplish this
-        update-rc.d "${1}" defaults &>/dev/null
+        update-rc.d "${1}" defaults >/dev/null
     fi
     printf "%b  %b %s...\\n" "${OVER}" "${TICK}" "${str}"
 }
@@ -1402,10 +1402,10 @@ disable_service() {
     # If systemctl exists,
     if is_command systemctl; then
         # use that to disable the service
-        systemctl disable "${1}" &>/dev/null
+        systemctl -q disable "${1}"
     else
         # Otherwise, use update-rc.d to accomplish this
-        update-rc.d "${1}" disable &>/dev/null
+        update-rc.d "${1}" disable >/dev/null
     fi
     printf "%b  %b %s...\\n" "${OVER}" "${TICK}" "${str}"
 }
@@ -1414,7 +1414,7 @@ check_service_active() {
     # If systemctl exists,
     if is_command systemctl; then
         # use that to check the status of the service
-        systemctl is-enabled "${1}" &>/dev/null
+        systemctl -q is-enabled "${1}" 2>/dev/null
     else
         # Otherwise, fall back to service command
         service "${1}" status &>/dev/null
@@ -1999,7 +1999,7 @@ FTLinstall() {
             curl -sSL "https://ftl.pi-hole.net/macvendor.db" -o "${PI_HOLE_CONFIG_DIR}/macvendor.db" || true
 
             # Stop pihole-FTL service if available
-            stop_service pihole-FTL &>/dev/null
+            stop_service pihole-FTL >/dev/null
 
             # Install the new version with the correct permissions
             install -T -m 0755 "${binary}" /usr/bin/pihole-FTL


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

If service start/stop/restart/enable/disable fails, it helps to debug the issue (like [here](https://discourse.pi-hole.net/t/upgrading-to-v6-pihole-up-didnt-disable-lighttpd/76307/30?u=michaing), if STDERR is not hidden, hence the error message can be seen. `systemctl` furthermore has the `-q` option to suppress non-error output. It works as well for `is-enabled`, but until a certain systemd version still throws an error, if the checked service does not exist at all. Once Debian Bullseye support is dropped by Pi-hole, also STDERR form `systemctl is-enabled` does not need to be suppressed anymore.

**How does this PR accomplish the above?:**

`&>/dev/null` is replaced with `>/dev/null` or systemd's `-q` option, to show errors from these commands.

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
