### PR TITLE
Add missing trailing / when setting permissions of /etc/pihole

### DIFF
--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -25,7 +25,7 @@ chmod 0755 /etc/pihole /var/log/pihole
 
 # allow pihole to access subdirs in /etc/pihole (sets execution bit on dirs)
 # credits https://stackoverflow.com/a/11512211
-find /etc/pihole -type d -exec chmod 0755 {} \;
+find /etc/pihole/ -type d -exec chmod 0755 {} \;
 
 # Touch files to ensure they exist (create if non-existing, preserve if existing)
 [ -f "${FTL_PID_FILE}" ] || install -D -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Ensures we set the permission on the **folder** `/etc/pihole` even when it's a symlink to somewhere else.

Reported here: https://github.com/pi-hole/pi-hole/issues/5979

**How does this PR accomplish the above?:**

Adding the tailing `/`

```
chris@T14Gen5:~$ ls -l test_sym
lrwxrwxrwx 1 chris chris 4 Feb 24 15:56 test_sym -> test
chris@T14Gen5:~$ find test_sym -type d
chris@T14Gen5:~$ find test_sym/ -type d
test_sym/
test_sym/sub2
test_sym/test_sub1
test_sym/test
```


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
