### PR TITLE
Do not overwrite TLS cert/key mode

### DIFF
--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -12,6 +12,7 @@ FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
 mkdir -p /var/log/pihole
 chown -R pihole:pihole /etc/pihole /var/log/pihole
+# allow pihole to access subdirs in /etc/pihole (sets execution bit on dirs)
 find /etc/pihole/ /var/log/pihole/ -type d -exec chmod 0755 {} +
 find /etc/pihole/ /var/log/pihole/ -type f ! \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0640 {} +
 find /etc/pihole/ /var/log/pihole/ -type f -name '*.pem' -o -name '*.crt' -exec chmod 0600 {} +

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -16,6 +16,7 @@ chown -R pihole:pihole /etc/pihole /var/log/pihole
 find /etc/pihole/ /var/log/pihole/ -type d -exec chmod 0755 {} +
 # Set all files (except TLS-related ones) to u+rw g+r
 find /etc/pihole/ /var/log/pihole/ -type f ! \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0640 {} +
+# Set TLS-related files to a more restrictive u+rw *only* (they may contain private keys)
 find /etc/pihole/ /var/log/pihole/ -type f -name '*.pem' -o -name '*.crt' -exec chmod 0600 {} +
 
 # Logrotate config file need to be owned by root

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -14,6 +14,7 @@ mkdir -p /var/log/pihole
 chown -R pihole:pihole /etc/pihole /var/log/pihole
 # allow pihole to access subdirs in /etc/pihole (sets execution bit on dirs)
 find /etc/pihole/ /var/log/pihole/ -type d -exec chmod 0755 {} +
+# Set all files (except TLS-related ones) to u+rw g+r
 find /etc/pihole/ /var/log/pihole/ -type f ! \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0640 {} +
 find /etc/pihole/ /var/log/pihole/ -type f -name '*.pem' -o -name '*.crt' -exec chmod 0600 {} +
 

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -10,22 +10,14 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
-# shellcheck disable=SC2174
-mkdir -pm 0640 /var/log/pihole
+mkdir -p /var/log/pihole
 chown -R pihole:pihole /etc/pihole /var/log/pihole
-chmod -R 0640 /var/log/pihole
-chmod -R 0660 /etc/pihole
+find /etc/pihole /var/log/pihole -type d -exec chmod 0755 {} +
+find /etc/pihole /var/log/pihole -type f ! \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0640 {} +
+find /etc/pihole /var/log/pihole -type f -name '*.pem' -o -name '*.crt' -exec chmod 0600 {} +
 
-# Logrotate config file need to be owned by root and must not be writable by group and others
+# Logrotate config file need to be owned by root
 chown root:root /etc/pihole/logrotate
-chmod 0644 /etc/pihole/logrotate
-
-# allow all users to enter the directories
-chmod 0755 /etc/pihole /var/log/pihole
-
-# allow pihole to access subdirs in /etc/pihole (sets execution bit on dirs)
-# credits https://stackoverflow.com/a/11512211
-find /etc/pihole/ -type d -exec chmod 0755 {} \;
 
 # Touch files to ensure they exist (create if non-existing, preserve if existing)
 [ -f "${FTL_PID_FILE}" ] || install -D -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -12,9 +12,9 @@ FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
 mkdir -p /var/log/pihole
 chown -R pihole:pihole /etc/pihole /var/log/pihole
-find /etc/pihole /var/log/pihole -type d -exec chmod 0755 {} +
-find /etc/pihole /var/log/pihole -type f ! \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0640 {} +
-find /etc/pihole /var/log/pihole -type f -name '*.pem' -o -name '*.crt' -exec chmod 0600 {} +
+find /etc/pihole/ /var/log/pihole/ -type d -exec chmod 0755 {} +
+find /etc/pihole/ /var/log/pihole/ -type f ! \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0640 {} +
+find /etc/pihole/ /var/log/pihole/ -type f -name '*.pem' -o -name '*.crt' -exec chmod 0600 {} +
 
 # Logrotate config file need to be owned by root
 chown root:root /etc/pihole/logrotate

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -127,10 +127,6 @@ def test_installPihole_fresh_install_readableFiles(host):
     check_localversion = test_cmd.format("r", "/etc/pihole/versions", piholeuser)
     actual_rc = host.run(check_localversion).rc
     assert exit_status_success == actual_rc
-    # readable logrotate
-    check_logrotate = test_cmd.format("r", "/etc/pihole/logrotate", piholeuser)
-    actual_rc = host.run(check_logrotate).rc
-    assert exit_status_success == actual_rc
     # readable macvendor.db
     check_macvendor = test_cmd.format("r", "/etc/pihole/macvendor.db", piholeuser)
     actual_rc = host.run(check_macvendor).rc


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

FTL correctly creates the cert and especially private key with 0600 mode. But the prestart scripts changes it to 0660.

After removing the dedicated webserver from Pi-hole setups, the pihole group has no purpose anymore, and files should not be writable to any other user than pihole itself, and the private TLS key not readable to anyone else either.

Additionally, this commit consolidates the chmod calls, applying 0755 to all directories and 0640 to all files, but the TLS key and cert.

**How does this PR accomplish the above?:**

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
