### PR TITLE
versions file should readable by others (make pihole -v work for non-root users)

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -52,7 +52,7 @@ rm -f "/etc/pihole/localversions"
 # Create new versions file if it does not exist
 VERSION_FILE="/etc/pihole/versions"
 touch "${VERSION_FILE}"
-chmod 644 "${VERSION_FILE}"
+chmod 640 "${VERSION_FILE}"
 
 # if /pihole.docker.tag file exists, we will use it's value later in this script
 DOCKER_TAG=$(cat /pihole.docker.tag 2>/dev/null)

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -52,7 +52,7 @@ rm -f "/etc/pihole/localversions"
 # Create new versions file if it does not exist
 VERSION_FILE="/etc/pihole/versions"
 touch "${VERSION_FILE}"
-chmod 640 "${VERSION_FILE}"
+chmod 644 "${VERSION_FILE}"
 
 # if /pihole.docker.tag file exists, we will use it's value later in this script
 DOCKER_TAG=$(cat /pihole.docker.tag 2>/dev/null)

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -12,8 +12,9 @@ FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
 mkdir -p /var/log/pihole
 chown -R pihole:pihole /etc/pihole/ /var/log/pihole/
-# allow all users read version file
-chmod 0664 /etc/pihole/versions
+
+# allow all users read version file (and use pihole -v)
+chmod 0644 /etc/pihole/versions
 
 # allow pihole to access subdirs in /etc/pihole (sets execution bit on dirs)
 find /etc/pihole/ /var/log/pihole/ -type d -exec chmod 0755 {} +

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -12,6 +12,9 @@ FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
 mkdir -p /var/log/pihole
 chown -R pihole:pihole /etc/pihole/ /var/log/pihole/
+# allow all users read version file
+chmod 0664 /etc/pihole/versions
+
 # allow pihole to access subdirs in /etc/pihole (sets execution bit on dirs)
 find /etc/pihole/ /var/log/pihole/ -type d -exec chmod 0755 {} +
 # Set all files (except TLS-related ones) to u+rw g+r


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We allow all users to run `pihole -v`, so they should have read access to `/etc/pihole/version`.
We do set those permissions in 

https://github.com/pi-hole/pi-hole/blob/567bb724b18bf174f033d0b8b289cc44a5e9c8eb/advanced/Scripts/updatecheck.sh#L50-L53

However, if we (re)start FTL after the updatescript run, it will reset the permissions to `0660` until the next updatecheck due to this line

https://github.com/pi-hole/pi-hole/blob/567bb724b18bf174f033d0b8b289cc44a5e9c8eb/advanced/Templates/pihole-FTL-prestart.sh#L17

**How does this PR accomplish the above?:**

Add an exception for `/etc/pihole/version` by setting its permissions to `0644` also at FTL start.

Fixes https://github.com/pi-hole/pi-hole/issues/5987

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
