### PR TITLE
Fix find command syntax, remove log dir from search

### DIFF
--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -17,7 +17,7 @@ find /etc/pihole/ /var/log/pihole/ -type d -exec chmod 0755 {} +
 # Set all files (except TLS-related ones) to u+rw g+r
 find /etc/pihole/ /var/log/pihole/ -type f ! \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0640 {} +
 # Set TLS-related files to a more restrictive u+rw *only* (they may contain private keys)
-find /etc/pihole/ /var/log/pihole/ -type f -name '*.pem' -o -name '*.crt' -exec chmod 0600 {} +
+find /etc/pihole/ -type f \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0600 {} +
 
 # Logrotate config file need to be owned by root
 chown root:root /etc/pihole/logrotate


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes find command that is supposed to `chmod 600` `*.pem` and `*.crt` files in `/etc/pihole` but instead it only affects `*.crt` files.

**How does this PR accomplish the above?:**

Adds a group just like in command one line earlier.
Also removes `/var/log/pihole/` from this line as it doesn't make sense here.

Current:
```sh
~$ find /etc/pihole/ /var/log/pihole/ -type f -name '*.pem' -o -name '*.crt' -exec echo {} +
/etc/pihole/tls.crt /etc/pihole/tls_ca.crt
```
PR:
```sh
~$ find /etc/pihole/ -type f \( -name '*.pem' -o -name '*.crt' \) -exec echo {} +
/etc/pihole/tls.pem /etc/pihole/tls.crt /etc/pihole/tls_ca.crt
```
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
