### PR TITLE
Revert "Improve gravity on systems with low memory"

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -92,8 +92,7 @@ gravity_build_tree() {
   echo -ne "  ${INFO} ${str}..."
 
   # The index is intentionally not UNIQUE as poor quality adlists may contain domains more than once
-  # We use temp_store = FILE to avoid memory exhaustion on large databases
-  output=$({ pihole-FTL sqlite3 -ni "${gravityTEMPfile}" "PRAGMA temp_store = FILE; CREATE INDEX idx_gravity ON gravity (domain, adlist_id);"; } 2>&1)
+  output=$({ pihole-FTL sqlite3 -ni "${gravityTEMPfile}" "CREATE INDEX idx_gravity ON gravity (domain, adlist_id);"; } 2>&1)
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then


### PR DESCRIPTION
# What does this implement/fix?

Reverts pi-hole/pi-hole#5977 - merge only after/when https://github.com/pi-hole/FTL/pull/2321 has been merged. This change is not wrong but said FTL PR will set the default value of `PRAGMA temp_store = FILE` so setting this here again is simply superfluous.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.