### PR TITLE
Add webserver log to piholeLogFlush.sh

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -35,6 +35,10 @@ FTLFILE=$(getFTLConfigValue "files.log.ftl")
 if [ -z "$FTLFILE" ]; then
     FTLFILE="/var/log/pihole/FTL.log"
 fi
+WEBFILE=$(getFTLConfigValue "files.log.webserver")
+if [ -z "$WEBFILE" ]; then
+    WEBFILE="/var/log/pihole/webserver.log"
+fi
 
 if [[ "$*" == *"once"* ]]; then
     # Nightly logrotation
@@ -71,6 +75,17 @@ if [[ "$*" == *"once"* ]]; then
         if [[ "$*" != *"quiet"* ]]; then
             echo -e "${OVER}  ${TICK} Rotated ${FTLFILE} ..."
         fi
+        # Copy webserver.log over to webserver.log.1
+        # and empty out webserver.log
+        if [[ "$*" != *"quiet"* ]]; then
+            echo -ne "  ${INFO} Rotating ${WEBFILE} ..."
+        fi
+        cp -p "${WEBFILE}" "${WEBFILE}.1"
+        echo " " > "${WEBFILE}"
+        chmod 640 "${WEBFILE}"
+        if [[ "$*" != *"quiet"* ]]; then
+            echo -e "${OVER}  ${TICK} Rotated ${WEBFILE} ..."
+        fi
     fi
 else
     # Manual flushing
@@ -101,6 +116,20 @@ else
     fi
     if [[ "$*" != *"quiet"* ]]; then
         echo -e "${OVER}  ${TICK} Flushed ${FTLFILE} ..."
+    fi
+
+    # Flush both webserver.log and webserver.log.1 (if existing)
+    if [[ "$*" != *"quiet"* ]]; then
+        echo -ne "  ${INFO} Flushing ${WEBFILE} ..."
+    fi
+    echo " " > "${WEBFILE}"
+    chmod 640 "${WEBFILE}"
+    if [ -f "${WEBFILE}.1" ]; then
+        echo " " > "${WEBFILE}.1"
+        chmod 640 "${WEBFILE}.1"
+    fi
+    if [[ "$*" != *"quiet"* ]]; then
+        echo -e "${OVER}  ${TICK} Flushed ${WEBFILE} ..."
     fi
 
     if [[ "$*" != *"quiet"* ]]; then


### PR DESCRIPTION
webserver log was added to logrotate file in https://github.com/pi-hole/pi-hole/commit/64319fa96efcd1b8172afb85110ae0742d49185c but never to the script, intentional because it won't grow much or just forgotten?

**What does this PR aim to accomplish?:**

Have webserver log be rotated/flushed by the script, not just by logrotate.

**How does this PR accomplish the above?:**

Adds missing logic to handle webserver log just like pihole and FTL ones.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
