### PR TITLE
Add recommended fields to the deb package

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -106,11 +106,13 @@ c=70
 PIHOLE_META_PACKAGE_CONTROL_APT=$(
     cat <<EOM
 Package: pihole-meta
-Version: 0.1
+Version: 0.2
 Maintainer: Pi-hole team <adblock@pi-hole.net>
 Architecture: all
 Description: Pi-hole dependency meta package
 Depends: grep,dnsutils,binutils,git,iproute2,dialog,ca-certificates,cron,curl,iputils-ping,psmisc,sudo,unzip,libcap2-bin,dns-root-data,libcap2,netcat-openbsd,procps,jq,lshw,bash-completion
+Section: contrib/metapackages
+Priority: optional
 EOM
 )
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

There are 2[ recommended fields](https://www.debian.org/doc/debian-policy/ch-controlfields.html#debian-binary-package-control-files-debian-control) in the control file of Debian packages. So far, we did not include them. This PR adds them now (`Section` and `Priority`).
The recommended 'style' for `Section` of packages outside of `main` is `area/section` where `section` is one of the following

> The Debian archive maintainers provide the authoritative list of sections. At present, they are: admin, cli-mono, comm, database, debug, devel, doc, editors, education, electronics, embedded, fonts, games, gnome, gnu-r, gnustep, graphics, hamradio, haskell, httpd, interpreters, introspection, java, javascript, kde, kernel, libdevel, libs, lisp, localization, mail, math, metapackages, misc, net, news, ocaml, oldlibs, otherosfs, perl, php, python, ruby, rust, science, shells, sound, tasks, tex, text, utils, vcs, video, web, x11, xfce, zope. The additional section debian-installer contains special packages used by the installer and is not used for normal Debian packages.

See: https://www.debian.org/doc/debian-policy/ch-archive.html#sections
____

Fixes https://github.com/pi-hole/pi-hole/issues/6036

Before:
![2025-03-06_13-33](https://github.com/user-attachments/assets/4188c15e-ebc8-4f09-8cd5-27d2ae4f914e)


Update:
![2025-03-06_13-36](https://github.com/user-attachments/assets/21630b03-8e96-4b3d-959f-4466f8cf7d07)


After
![2025-03-06_13-37](https://github.com/user-attachments/assets/ac4d2a79-ad1e-47b1-9266-c3b3cc2e4bb3)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
