### PR TITLE
fix for pihole -q command failing on regex filters

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -45,10 +45,10 @@ GenerateOutput() {
     data="${1}"
 
     # construct a new json for the list results where each object contains the domain and the related type
-    lists_data=$(printf %s "${data}" | jq '.search.domains | [.[] | {domain: .domain, type: .type}]')
+    lists_data=$(printf %s "${data}" | sed 's/\\/\\\\/g' | jq '.search.domains | [.[] | {domain: .domain, type: .type}]')
 
     # construct a new json for the gravity results where each object contains the adlist URL and the related domains
-    gravity_data=$(printf %s "${data}" | jq '.search.gravity  | group_by(.address,.type) | map({ address: (.[0].address), type: (.[0].type), domains: [.[] | .domain] })')
+    gravity_data=$(printf %s "${data}" | sed 's/\\/\\\\/g' | jq '.search.gravity  | group_by(.address,.type) | map({ address: (.[0].address), type: (.[0].type), domains: [.[] | .domain] })')
 
     # number of objects in each json
     num_gravity=$(printf %s "${gravity_data}" | jq length)


### PR DESCRIPTION

**What does this PR aim to accomplish?:**
It fixes the bug when a domain filter contains regEx. When `pihole -q` command is invoked, it will call query.sh which uses `jq` to perform parsing and it will fail when `jq` encounters backslash.

**How does this PR accomplish the above?:**
Changes made to query.sh script to escape backslash before piping to `jq` since regex strings will contain backslash which `jq` will not be able to parse.

**Link documentation PRs if any are needed to support this PR:**
https://github.com/pi-hole/pi-hole/issues/6055

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ x] I have read the above and my PR is ready for review. *Check this box to confirm*
