### PR TITLE
Install PADD and link it to pihole -c as the successor to Chronometer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: "3.10"
 

--- a/advanced/Scripts/COL_TABLE
+++ b/advanced/Scripts/COL_TABLE
@@ -1,5 +1,6 @@
+#!/usr/bin/env sh
 # Determine if terminal is capable of showing colors
-if ([ -t 1 ] && [ $(tput colors) -ge 8 ]) || [ "${WEBCALL}" ]; then
+if [ -t 1 ] && [ "$(tput colors)" -ge 8 ]; then
   # Bold and underline may not show up on all clients
   # If something MUST be emphasized, use both
   COL_BOLD='[1m'

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -100,6 +100,23 @@ addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_VERSION" "${GITHUB_WEB_VERSION
 GITHUB_WEB_HASH="$(get_remote_hash web "${WEB_BRANCH}")"
 addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_HASH" "${GITHUB_WEB_HASH}"
 
+# get PADD versions
+
+PADD_VERSION="$(get_local_version /etc/.padd)"
+addOrEditKeyValPair "${VERSION_FILE}" "PADD_VERSION" "${PADD_VERSION}"
+
+PADD_BRANCH="$(get_local_branch /etc/.padd)"
+addOrEditKeyValPair "${VERSION_FILE}" "PADD_BRANCH" "${PADD_BRANCH}"
+
+PADD_HASH="$(get_local_hash /etc/.padd)"
+addOrEditKeyValPair "${VERSION_FILE}" "PADD_HASH" "${PADD_HASH}"
+
+GITHUB_PADD_VERSION="$(get_remote_version PADD "${PADD_BRANCH}")"
+addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_PADD_VERSION" "${GITHUB_PADD_VERSION}"
+
+GITHUB_PADD_HASH="$(get_remote_hash PADD "${PADD_BRANCH}")"
+addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_PADD_HASH" "${GITHUB_PADD_HASH}"
+
 # get FTL versions
 
 FTL_VERSION="$(pihole-FTL version)"

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -48,10 +48,15 @@ main() {
         echo "    Version is ${FTL_VERSION:=N/A} (Latest: ${GITHUB_FTL_VERSION:=N/A})"
         echo "    Branch is ${FTL_BRANCH:=N/A}"
         echo "    Hash is ${FTL_HASH:=N/A} (Latest: ${GITHUB_FTL_HASH:=N/A})"
+        echo "PADD"
+        echo "    Version is ${PADD_VERSION:=N/A} (Latest: ${GITHUB_PADD_VERSION:=N/A})"
+        echo "    Branch is ${PADD_BRANCH:=N/A}"
+        echo "    Hash is ${PADD_HASH:=N/A} (Latest: ${GITHUB_PADD_HASH:=N/A})"
     else
         echo "Core version is ${CORE_VERSION:=N/A} (Latest: ${GITHUB_CORE_VERSION:=N/A})"
         echo "Web version is ${WEB_VERSION:=N/A} (Latest: ${GITHUB_WEB_VERSION:=N/A})"
         echo "FTL version is ${FTL_VERSION:=N/A} (Latest: ${GITHUB_FTL_VERSION:=N/A})"
+        echo "PADD version is ${PADD_VERSION:=N/A} (Latest: ${GITHUB_PADD_VERSION:=N/A})"
     fi
 }
 

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -66,6 +66,12 @@ removePiholeFiles() {
     fi
     echo -e "${OVER}  ${TICK} Removed Web Interface"
 
+    # Only files in the PADD directory should be removed
+    echo -ne "  ${INFO} Removing PADD..."
+    ${SUDO} rm -rf /etc/.padd &> /dev/null
+    ${SUDO} rm -f /usr/local/bin/padd &> /dev/null
+    echo -e "${OVER}  ${TICK} Removed PADD"
+
     # Attempt to preserve backwards compatibility with older versions
     # to guarantee no additional changes were made to /etc/crontab after
     # the installation of pihole, /etc/crontab.pihole should be permanently

--- a/gravity.sh
+++ b/gravity.sh
@@ -541,16 +541,14 @@ gravity_DownloadBlocklists() {
     # it (in case it doesn't exist)
     # First, check if the directory is writable
     directory="$(dirname -- "${saveLocation}")"
-    directory_permissions=$(stat -c %a ${directory})
-    if [ $directory_permissions -lt 700 ]; then
+    if [ ! -w "${directory}" ]; then
       echo -e "  ${CROSS} Unable to write to ${directory}"
       echo "      Please run pihole -g as root"
       echo ""
       continue
     fi
     # Then, check if the file is writable (if it exists)
-    saveLocation_permissions=$(stat -c %a ${saveLocation})
-    if [ -e "${saveLocation}" ] && [ ${saveLocation_permissions} -lt 600 ]; then
+    if [ -e "${saveLocation}" ] && [ ! -w "${saveLocation}" ]; then
       echo -e "  ${CROSS} Unable to write to ${saveLocation}"
       echo "      Please run pihole -g as root"
       echo ""

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -119,6 +119,32 @@ Available commands and options:
                         (regular expressions are supported)
 .br
 
+\fB-c, padd\fR	[options]
+.br
+    Chronometer is now PADD (Pi-hole® Ad Detection Display)
+    Calculates stats and displays to an LCD.
+    Add '-h' for more info on PADD usage
+.br
+
+    (PADD Options):
+.br
+      --xoff [num]    set the x-offset, reference is the upper left corner, disables auto-centering
+.br
+      --yoff [num]    set the y-offset, reference is the upper left corner, disables auto-centering
+.br
+      --server <DOMAIN|IP>    domain or IP of your Pi-hole (default: localhost)
+.br
+      --secret <password>     your Pi-hole's password, required to access the API
+.br
+      --2fa <2fa>             your Pi-hole's 2FA code, if 2FA is enabled
+.br
+      -j, --json              output stats as JSON formatted string and exit
+.br
+      -v, --version           show PADD version info
+.br
+      -h, --help              display this help text
+.br
+
 \fB-g, updateGravity\fR
 .br
     Update the list of ad-serving domains

--- a/pihole
+++ b/pihole
@@ -126,8 +126,9 @@ queryFunc() {
   exit 0
 }
 
-chronometerFunc() {
-  echo "Chronometer is gone, use PADD (https://github.com/pi-hole/PADD)"
+paddFunc() {
+  shift
+  "${PI_HOLE_BIN_DIR}"/padd "$@"
   exit 0
 }
 
@@ -418,7 +419,8 @@ piholeCheckoutFunc() {
   Individual components:
     ${COL_PURPLE}core${COL_NC} ${COL_CYAN}branch${COL_NC}       Change the branch of Pi-hole's core subsystem
     ${COL_PURPLE}web${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of the web interface subsystem
-    ${COL_PURPLE}ftl${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of Pi-hole's FTL subsystem"
+    ${COL_PURPLE}ftl${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of Pi-hole's FTL subsystem
+    ${COL_PURPLE}PADD${COL_NC} ${COL_CYAN}branch${COL_NC}       Change the branch of Pi-hole's PADD subsystem"
 
       exit 0
     fi
@@ -490,6 +492,9 @@ Options:
   setpassword [pwd]   Set the password for the web interface
                         Without optional argument, password is read interactively.
                         When specifying a password directly, enclose it in single quotes.
+  -c, padd            Chronometer is now PADD (Pi-hole® Ad Detection Display)
+                        Calculates stats and displays to an LCD.
+                        Add '-h' for more info on PADD usage
   -g, updateGravity   Update the list of ad-serving domains
   -h, --help, help    Show this help dialog
   -l, logging         Specify whether the Pi-hole log should be used
@@ -522,7 +527,7 @@ need_root=1
 case "${1}" in
   "-h" | "help" | "--help"        ) helpFunc;;
   "-v" | "version"                ) versionFunc;;
-  "-c" | "chronometer"            ) chronometerFunc "$@";;
+  "-c" | "padd"                   ) paddFunc "$@";;
   "-q" | "query"                  ) queryFunc "$@";;
   "status"                        ) statusFunc "$2";;
   "tricorder"                     ) tricorderFunc;;

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,5 +2,5 @@ pyyaml == 6.0.2
 pytest == 8.3.5
 pytest-xdist == 3.6.1
 pytest-testinfra == 10.1.1
-tox == 4.24.2
+tox == 4.25.0
 pytest-clarity == 1.0.1


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

add PADD as the successor to Chronometer instead of the current message that is shown when running `pihole -c`

if calculated correctly these changes would only increase the storage footprint of Pi-hole on bare metal installs by less than 1.5MB 

```
du -hs /etc/.padd /usr/local/bin/padd
1.3M	/etc/.padd
80K	/usr/local/bin/padd
```

**How does this PR accomplish the above?:**

1. adds `https://github.com/pi-hole/PADD.git` as `paddGitUrl` and `/etc/.padd/` as `PADD_LOCAL_REPO` to `automated install/basic-install.sh` as global variables for use as seen in the following steps.

2. extends functionality of `clone_or_reset_repos()` to clone `paddGitUrl` to `PADD_LOCAL_REPO`.

3. extends functionality of `installScripts()` to install `${PADD_LOCAL_REPO}/padd.sh` as `${PI_HOLE_BIN_DIR}/padd`, in the same location as [pi-hole/docker-pi-hole](https://github.com/pi-hole/docker-pi-hole/blob/78aee9e4b2089263359d6d7e2847028f237b7aef/src/Dockerfile#L57), which should allow part 3 to work on bare metal and docker. 

4. links `pihole -c` (`paddFunc()`, formerly ``chronometerFunc()``) to `${PI_HOLE_BIN_DIR}/padd` and ensures first argument is dropped before starting, which is likely to be `-c` since `padd` is being started with `pihole -c`.

5. extends functionality of `checkout()`, `advanced/Scripts/update.sh`, and `advanced/Scripts/updatecheck.sh` to ensure PADD is updated accordingly.   

6. extends functionality of `advanced/Scripts/version.sh` to ensure PADD version is shown.

7. ensures PADD is completely removed during uninstall.

_hopefully i did not miss anything_ if so please let me know

**Link documentation PRs if any are needed to support this PR:**

pi-hole/docs/pull/1209

adds PADD between Tail and Gravity where Chronometer was in v5 docs.
```
### PADD

| | |
| -------------- | -------------- |
| Help Command    | `pihole -c --help` or `padd --help` |
| Script Location | [`/usr/local/bin/padd`](https://github.com/pi-hole/PADD/blob/master/padd.sh) |
| Example Usage   | [`pihole -c`](https://discourse.pi-hole.net/t/the-pihole-command-with-examples/738#chronometer)  or just `padd`|

PADD (formerly Chronometer2) is a more expansive version of the original chronometer.sh that was included with Pi-Hole. PADD provides in-depth information about your Pi-hole.
```
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
8. I am willing to help maintain this change if there are issues with it later.
9. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
10. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
11. I have checked that another pull request for this purpose does not exist.
12. I have considered, and confirmed that this submission will be valuable to others.
13. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
14. I give this submission freely, and claim no ownership to its content.
---
- [✓] I have read the above and my PR is ready for review. 
