### PR TITLE
Suppress 'stat' error on first start

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -541,16 +541,16 @@ gravity_DownloadBlocklists() {
     # it (in case it doesn't exist)
     # First, check if the directory is writable
     directory="$(dirname -- "${saveLocation}")"
-    directory_permissions=$(stat -c %a ${directory})
-    if [ $directory_permissions -lt 700 ]; then
+    directory_permissions=$(stat -c %a "${directory}")
+    if [ "$directory_permissions" -lt 700 ]; then
       echo -e "  ${CROSS} Unable to write to ${directory}"
       echo "      Please run pihole -g as root"
       echo ""
       continue
     fi
     # Then, check if the file is writable (if it exists)
-    saveLocation_permissions=$(stat -c %a ${saveLocation})
-    if [ -e "${saveLocation}" ] && [ ${saveLocation_permissions} -lt 600 ]; then
+    saveLocation_permissions=$(stat -c %a "${saveLocation}" 2>/dev/null)
+    if [ -e "${saveLocation}" ] && [ "${saveLocation_permissions}" -lt 600 ]; then
       echo -e "  ${CROSS} Unable to write to ${saveLocation}"
       echo "      Please run pihole -g as root"
       echo ""


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

I noticed the `stat` error below, when running a fresh docker-pi-hole container:

```
  [✓] Preparing new gravity database
  [✓] Creating new gravity databases
  [✓] Pulling blocklist source list into range
  [i] Using libz compression

stat: cannot stat '/etc/pihole/listsCache/list.1.raw.githubusercontent.com.domains': No such file or directory
  [i] Target: https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
  [✓] Status: Retrieval successful
  [✓] Parsed 132530 exact domains and 0 ABP-style domains (blocking, ignored 0 non-domain entries)
```

That's because the file does not exist at this point. It's safe to suppress this error. The file's existence is checked one line below.

**How does this PR accomplish the above?:**

`2>/dev/null` is added to the stats command.

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->


<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
