### PR TITLE
Allow simple `pihole api` output, containing only the JSON payload

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -301,14 +301,23 @@ secretRead() {
 }
 
 apiFunc() {
-  local data response status status_col
+  local data response status status_col verbose
+
+  # Define if the output will be verbose (default) or silent
+  verbose="verbose"
+  if [ "$1" = "silent" ] || [ "$1" = "-s" ]; then
+    verbose=""
+    shift
+  fi
 
   # Authenticate with the API
-  LoginAPI verbose
-  echo ""
+  LoginAPI "${verbose}"
 
-  echo "Requesting: ${COL_PURPLE}GET ${COL_CYAN}${API_URL}${COL_YELLOW}$1${COL_NC}"
-  echo ""
+  if [ "${verbose}" = "verbose" ]; then
+    echo ""
+    echo "Requesting: ${COL_PURPLE}GET ${COL_CYAN}${API_URL}${COL_YELLOW}$1${COL_NC}"
+    echo ""
+  fi
 
   # Get the data from the API
   response=$(GetFTLData "$1" raw)
@@ -325,11 +334,18 @@ apiFunc() {
   else
     status_col="${COL_RED}"
   fi
-  echo "Status: ${status_col}${status}${COL_NC}"
+
+  # Only print the status in verbose mode or if the status is not 200
+  if [ "${verbose}" = "verbose" ] || [ "${status}" != 200 ]; then
+    echo "Status: ${status_col}${status}${COL_NC}"
+  fi
 
   # Output the data. Format it with jq if available and data is actually JSON.
   # Otherwise just print it
-  echo "Data:"
+  if [ "${verbose}" = "verbose" ]; then
+    echo "Data:"
+  fi
+
   if command -v jq >/dev/null && echo "${data}" | jq . >/dev/null 2>&1; then
     echo "${data}" | jq .
   else
@@ -337,5 +353,5 @@ apiFunc() {
   fi
 
   # Delete the session
-  LogoutAPI verbose
+  LogoutAPI "${verbose}"
 }

--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -301,19 +301,19 @@ secretRead() {
 }
 
 apiFunc() {
-  local data response status status_col verbose
+  local data response status status_col verbosity
 
-  # Define if the output will be verbose (default) or silent
-  verbose="verbose"
-  if [ "$1" = "silent" ] || [ "$1" = "-s" ]; then
-    verbose=""
+  # Define if the output will be silent (default) or verbose
+  verbosity="silent"
+  if [ "$1" = "verbose" ]; then
+    verbosity="verbose"
     shift
   fi
 
   # Authenticate with the API
-  LoginAPI "${verbose}"
+  LoginAPI "${verbosity}"
 
-  if [ "${verbose}" = "verbose" ]; then
+  if [ "${verbosity}" = "verbose" ]; then
     echo ""
     echo "Requesting: ${COL_PURPLE}GET ${COL_CYAN}${API_URL}${COL_YELLOW}$1${COL_NC}"
     echo ""
@@ -336,13 +336,13 @@ apiFunc() {
   fi
 
   # Only print the status in verbose mode or if the status is not 200
-  if [ "${verbose}" = "verbose" ] || [ "${status}" != 200 ]; then
+  if [ "${verbosity}" = "verbose" ] || [ "${status}" != 200 ]; then
     echo "Status: ${status_col}${status}${COL_NC}"
   fi
 
   # Output the data. Format it with jq if available and data is actually JSON.
   # Otherwise just print it
-  if [ "${verbose}" = "verbose" ]; then
+  if [ "${verbosity}" = "verbose" ]; then
     echo "Data:"
   fi
 
@@ -353,5 +353,5 @@ apiFunc() {
   fi
 
   # Delete the session
-  LogoutAPI "${verbose}"
+  LogoutAPI "${verbosity}"
 }

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -23,7 +23,7 @@ pihole -r
 .br
 \fBpihole -g\fR
 .br
-\fBpihole\fR -\fBq\fR [options]
+\fBpihole\fR \fB-q\fR [options]
 .br
 \fBpihole\fR \fB-l\fR (\fBon|off|off noflush\fR)
 .br
@@ -43,7 +43,7 @@ pihole -r
 .br
 \fBpihole\fR \fBcheckout\fR repo [branch]
 .br
-\fBpihole\fR \api\fR endpoint
+\fBpihole\fR \fBapi\fR [verbose] endpoint
 .br
 \fBpihole\fR \fBhelp\fR
 .br
@@ -234,10 +234,14 @@ Available commands and options:
       branchname        Update subsystems to the specified branchname
 .br
 
-\fBapi\fR endpoint
+\fBapi\fR [verbose] endpoint
 .br
     Query the Pi-hole API at <endpoint>
 .br
+
+      verbose           Show authentication and status messages
+.br
+
 .SH "EXAMPLE"
 
 Some usage examples
@@ -321,6 +325,11 @@ Switching Pi-hole subsystem branches
 \fBpihole api stats/summary\fR
 .br
     Queries FTL for the stats/summary endpoint
+.br
+
+\fBpihole api verbose stats/summary\fR
+.br
+    Same as above, but shows authentication and status messages
 .br
 
 .SH "COLOPHON"

--- a/pihole
+++ b/pihole
@@ -601,6 +601,6 @@ case "${1}" in
   "updatechecker"                 ) shift; updateCheckFunc "$@";;
   "arpflush"                      ) arpFunc "$@";;
   "-t" | "tail"                   ) tailFunc "$2";;
-  "api"                           ) apiFunc "$2";;
+  "api"                           ) shift; apiFunc "$@";;
   *                               ) helpFunc;;
 esac

--- a/pihole
+++ b/pihole
@@ -493,6 +493,7 @@ Debugging Options:
                       Add an optional argument to filter the log
                       (regular expressions are supported)
   api <endpoint>      Query the Pi-hole API at <endpoint>
+                        Precede <endpoint> with 'verbose' option to show authentication and status messages
 
 
 Options:


### PR DESCRIPTION
### What does this PR aim to accomplish?

The current output of `pihole api <endpoint>` is too complex and can't be easily parsed by scripts, because it contains a lot of text messages mixed with the JSON payload:

```js
API Authentication: Trying to use CLI password
API Authentication: Success

Requesting: GET http://127.0.0.1:80/api/<endpoint>

Status: 200
Data:
{
  JSON payload
  ...
}
API Logout: Success (session deleted)
```

The PR changes the output to hide all authentication and status messages by default.

### How does this PR accomplish the above?

This PR changes the default `pihole api` output to show only a JSON payload:
```js
{
  JSON payload
  ...
}
```

It also adds an option `pihole api verbose <endpoint>` to show the original output, containing authentication and status messages.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
