### PR TITLE
Add ON DELETE CASCADE to FOREIGN KEY REFERENCES in gravity.db

### DIFF
--- a/advanced/Templates/gravity.db.sql
+++ b/advanced/Templates/gravity.db.sql
@@ -43,8 +43,8 @@ CREATE TABLE adlist
 
 CREATE TABLE adlist_by_group
 (
-    adlist_id INTEGER NOT NULL REFERENCES adlist (id),
-    group_id INTEGER NOT NULL REFERENCES "group" (id),
+    adlist_id INTEGER NOT NULL REFERENCES adlist (id) ON DELETE CASCADE,
+    group_id INTEGER NOT NULL REFERENCES "group" (id) ON DELETE CASCADE,
     PRIMARY KEY (adlist_id, group_id)
 );
 
@@ -75,8 +75,8 @@ INSERT INTO "info" VALUES('gravity_restored','false');
 
 CREATE TABLE domainlist_by_group
 (
-    domainlist_id INTEGER NOT NULL REFERENCES domainlist (id),
-    group_id INTEGER NOT NULL REFERENCES "group" (id),
+    domainlist_id INTEGER NOT NULL REFERENCES domainlist (id) ON DELETE CASCADE,
+    group_id INTEGER NOT NULL REFERENCES "group" (id) ON DELETE CASCADE,
     PRIMARY KEY (domainlist_id, group_id)
 );
 
@@ -91,8 +91,8 @@ CREATE TABLE client
 
 CREATE TABLE client_by_group
 (
-    client_id INTEGER NOT NULL REFERENCES client (id),
-    group_id INTEGER NOT NULL REFERENCES "group" (id),
+    client_id INTEGER NOT NULL REFERENCES client (id) ON DELETE CASCADE,
+    group_id INTEGER NOT NULL REFERENCES "group" (id) ON DELETE CASCADE,
     PRIMARY KEY (client_id, group_id)
 );
 


### PR DESCRIPTION
# What does this implement/fix?

There has been a report on Discourse (link below) that deleting groups which still have, e.g., domains assigned to them is not possible without *first* unassigning said domains from the respective groups. This behavior was different in v5 where deleting a group cascaded down in deleting all the domains, clients, etc. assigned to it.

I don't think that such a massive "cleanup" is actually a good idea as a wrong click can erase quite a bit of work users may have invested into their systems.

Hence, this PR seeks a middle ground: When a group is being deleted, we cascade this into the `domain<->group`, `client<->group`, and `adlist<->group` bindings, effectively disassigning the domains *without deleting them*. To me, this makes more sense.

This makes it possible to delete groups even when domains are assigned, making the latter orphans without any effect. They can later either be deleted on their own or adopted into new groups.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/deleting-a-group-is-not-possible-ftl-v6-0-4/77171

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.