### PR TITLE
Install PADD and link to `pihole -c` as the successor to Chronometer

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -100,6 +100,23 @@ addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_VERSION" "${GITHUB_WEB_VERSION
 GITHUB_WEB_HASH="$(get_remote_hash web "${WEB_BRANCH}")"
 addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_WEB_HASH" "${GITHUB_WEB_HASH}"
 
+# get PADD versions
+
+PADD_VERSION="$(get_local_version /etc/.padd)"
+addOrEditKeyValPair "${VERSION_FILE}" "PADD_VERSION" "${PADD_VERSION}"
+
+PADD_BRANCH="$(get_local_branch /etc/.padd)"
+addOrEditKeyValPair "${VERSION_FILE}" "PADD_BRANCH" "${PADD_BRANCH}"
+
+PADD_HASH="$(get_local_hash /etc/.padd)"
+addOrEditKeyValPair "${VERSION_FILE}" "PADD_HASH" "${PADD_HASH}"
+
+GITHUB_PADD_VERSION="$(get_remote_version PADD "${PADD_BRANCH}")"
+addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_PADD_VERSION" "${GITHUB_PADD_VERSION}"
+
+GITHUB_PADD_HASH="$(get_remote_hash PADD "${PADD_BRANCH}")"
+addOrEditKeyValPair "${VERSION_FILE}" "GITHUB_PADD_HASH" "${GITHUB_PADD_HASH}"
+
 # get FTL versions
 
 FTL_VERSION="$(pihole-FTL version)"

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -48,10 +48,15 @@ main() {
         echo "    Version is ${FTL_VERSION:=N/A} (Latest: ${GITHUB_FTL_VERSION:=N/A})"
         echo "    Branch is ${FTL_BRANCH:=N/A}"
         echo "    Hash is ${FTL_HASH:=N/A} (Latest: ${GITHUB_FTL_HASH:=N/A})"
+        echo "PADD"
+        echo "    Version is ${PADD_VERSION:=N/A} (Latest: ${GITHUB_PADD_VERSION:=N/A})"
+        echo "    Branch is ${PADD_BRANCH:=N/A}"
+        echo "    Hash is ${PADD_HASH:=N/A} (Latest: ${GITHUB_PADD_HASH:=N/A})"
     else
         echo "Core version is ${CORE_VERSION:=N/A} (Latest: ${GITHUB_CORE_VERSION:=N/A})"
         echo "Web version is ${WEB_VERSION:=N/A} (Latest: ${GITHUB_WEB_VERSION:=N/A})"
         echo "FTL version is ${FTL_VERSION:=N/A} (Latest: ${GITHUB_FTL_VERSION:=N/A})"
+        echo "PADD version is ${PADD_VERSION:=N/A} (Latest: ${GITHUB_PADD_VERSION:=N/A})"
     fi
 }
 

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -65,11 +65,14 @@ coltable="/opt/pihole/COL_TABLE"
 # Root of the web server
 webroot="/var/www/html"
 
-# We clone (or update) two git repositories during the install. This helps to make sure that we always have the latest versions of the relevant files.
+# We clone (or update) three git repositories during the install. This helps to make sure that we always have the latest versions of the relevant files.
+# PADD is used to keep padd.sh, the successor to Chronometer.
 # web is used to set up the Web admin interface.
 # Pi-hole contains various setup scripts and files which are critical to the installation.
 # Search for "PI_HOLE_LOCAL_REPO" in this file to see all such scripts.
-# Two notable scripts are gravity.sh (used to generate the HOSTS file) and advanced/Scripts/webpage.sh (used to install the Web admin interface)
+# Three notable scripts are gravity.sh (used to generate the HOSTS file), advanced/Scripts/webpage.sh (used to install the Web admin interface), and padd.sh (used to display Pi-hole stats via command line, Chronometer's replacement)
+PADD_LOCAL_REPO="/etc/.padd"
+paddGitUrl="https://github.com/pi-hole/PADD.git"
 webInterfaceGitUrl="https://github.com/pi-hole/web.git"
 webInterfaceDir="${webroot}/admin"
 piholeGitUrl="https://github.com/pi-hole/pi-hole.git"
@@ -1263,6 +1266,32 @@ installScripts() {
         printf "\\t\\t%bError: Local repo %s not found, exiting installer%b\\n" "${COL_LIGHT_RED}" "${PI_HOLE_LOCAL_REPO}" "${COL_NC}"
         return 1
     fi
+
+    local strPadd="Installing script from ${PADD_LOCAL_REPO}"
+    printf "  %b %s..." "${INFO}" "${strPadd}"
+
+    # Clear out PADD file from PI_HOLE_BIN_DIR
+    rm -rf "${PI_HOLE_BIN_DIR}/padd" &> /dev/null
+
+    # Install padd.sh from local PADD repository as /usr/local/bin/padd
+    if is_repo "${PADD_LOCAL_REPO}"; then
+        # move into the directory
+        cd "${PADD_LOCAL_REPO}"
+        # Install the scripts by:
+        #  -o setting the owner to the user
+        #  -Dm755 create all leading components of destination except the last, then copy the source to the destination and setting the permissions to 755
+        #
+        # We put PADD in PI_HOLE_BIN_DIR the same as is done for pi-hole/docker-pi-hole.
+        # By using -T we can drop the .sh suffix.
+        install -o "${USER}" -Dm755 -T "${PADD_LOCAL_REPO}/padd.sh" "${PI_HOLE_BIN_DIR}/padd"
+        printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${strPadd}"
+
+    else
+        # Otherwise, show an error and exit
+        printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+        printf "\\t\\t%bError: Local repo %s not found, exiting installer%b\\n" "${COL_LIGHT_RED}" "${PADD_LOCAL_REPO}" "${COL_NC}"
+        return 1
+    fi
 }
 
 # Install the configs from PI_HOLE_LOCAL_REPO to their various locations
@@ -1850,6 +1879,12 @@ clone_or_reset_repos() {
                 printf "  %b Unable to reset %s, exiting installer%b\\n" "${COL_LIGHT_RED}" "${webInterfaceDir}" "${COL_NC}"
                 exit 1
             }
+        # Reset the PADD repo
+        resetRepo ${PADD_LOCAL_REPO} ||
+            {
+                printf "  %b Unable to reset %s, exiting installer%b\\n" "${COL_LIGHT_RED}" "${PADD_LOCAL_REPO}" "${COL_NC}"
+                exit 1
+            }
     # Otherwise, a fresh installation is happening
     else
         # so get git files for Core
@@ -1862,6 +1897,12 @@ clone_or_reset_repos() {
         getGitFiles ${webInterfaceDir} ${webInterfaceGitUrl} ||
             {
                 printf "  %b Unable to clone %s into ${webInterfaceDir}, exiting installer%b\\n" "${COL_LIGHT_RED}" "${webInterfaceGitUrl}" "${COL_NC}"
+                exit 1
+            }
+        # get the PADD git files
+        getGitFiles ${PADD_LOCAL_REPO} ${paddGitUrl} ||
+            {
+                printf "  %b Unable to clone %s into ${PADD_LOCAL_REPO}, exiting installer%b\\n" "${COL_LIGHT_RED}" "${paddGitUrl}" "${COL_NC}"
                 exit 1
             }
     fi

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -66,6 +66,12 @@ removePiholeFiles() {
     fi
     echo -e "${OVER}  ${TICK} Removed Web Interface"
 
+    # Only files in the PADD directory should be removed
+    echo -ne "  ${INFO} Removing PADD..."
+    ${SUDO} rm -rf /etc/.padd &> /dev/null
+    ${SUDO} rm -f /usr/local/bin/padd &> /dev/null
+    echo -e "${OVER}  ${TICK} Removed PADD"
+
     # Attempt to preserve backwards compatibility with older versions
     # to guarantee no additional changes were made to /etc/crontab after
     # the installation of pihole, /etc/crontab.pihole should be permanently

--- a/manpages/pihole.8
+++ b/manpages/pihole.8
@@ -119,6 +119,32 @@ Available commands and options:
                         (regular expressions are supported)
 .br
 
+\fB-c, padd\fR	[options]
+.br
+    Chronometer is now PADD (Pi-hole® Ad Detection Display)
+    Calculates stats and displays to an LCD.
+    Add '-h' for more info on PADD usage
+.br
+
+    (PADD Options):
+.br
+      --xoff [num]    set the x-offset, reference is the upper left corner, disables auto-centering
+.br
+      --yoff [num]    set the y-offset, reference is the upper left corner, disables auto-centering
+.br
+      --server <DOMAIN|IP>    domain or IP of your Pi-hole (default: localhost)
+.br
+      --secret <password>     your Pi-hole's password, required to access the API
+.br
+      --2fa <2fa>             your Pi-hole's 2FA code, if 2FA is enabled
+.br
+      -j, --json              output stats as JSON formatted string and exit
+.br
+      -v, --version           show PADD version info
+.br
+      -h, --help              display this help text
+.br
+
 \fB-g, updateGravity\fR
 .br
     Update the list of ad-serving domains

--- a/pihole
+++ b/pihole
@@ -126,8 +126,9 @@ queryFunc() {
   exit 0
 }
 
-chronometerFunc() {
-  echo "Chronometer is gone, use PADD (https://github.com/pi-hole/PADD)"
+paddFunc() {
+  shift
+  "${PI_HOLE_BIN_DIR}"/padd "$@"
   exit 0
 }
 
@@ -418,7 +419,8 @@ piholeCheckoutFunc() {
   Individual components:
     ${COL_PURPLE}core${COL_NC} ${COL_CYAN}branch${COL_NC}       Change the branch of Pi-hole's core subsystem
     ${COL_PURPLE}web${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of the web interface subsystem
-    ${COL_PURPLE}ftl${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of Pi-hole's FTL subsystem"
+    ${COL_PURPLE}ftl${COL_NC} ${COL_CYAN}branch${COL_NC}        Change the branch of Pi-hole's FTL subsystem
+    ${COL_PURPLE}PADD${COL_NC} ${COL_CYAN}branch${COL_NC}       Change the branch of Pi-hole's PADD subsystem"
 
       exit 0
     fi
@@ -490,6 +492,9 @@ Options:
   setpassword [pwd]   Set the password for the web interface
                         Without optional argument, password is read interactively.
                         When specifying a password directly, enclose it in single quotes.
+  -c, padd            Chronometer is now PADD (Pi-hole® Ad Detection Display)
+                        Calculates stats and displays to an LCD.
+                        Add '-h' for more info on PADD usage
   -g, updateGravity   Update the list of ad-serving domains
   -h, --help, help    Show this help dialog
   -l, logging         Specify whether the Pi-hole log should be used
@@ -522,7 +527,7 @@ need_root=1
 case "${1}" in
   "-h" | "help" | "--help"        ) helpFunc;;
   "-v" | "version"                ) versionFunc;;
-  "-c" | "chronometer"            ) chronometerFunc "$@";;
+  "-c" | "padd"                   ) paddFunc "$@";;
   "-q" | "query"                  ) queryFunc "$@";;
   "status"                        ) statusFunc "$2";;
   "tricorder"                     ) tricorderFunc;;


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Add PADD as the successor to Chronometer instead of the current message that is shown when running `pihole -c`.

If calculated correctly the following changes would only increase the storage footprint of Pi-hole on bare metal installs by less than 1.5MB.

```
du -hs /etc/.padd /usr/local/bin/padd
1.3M	/etc/.padd
80K	/usr/local/bin/padd
```

**How does this PR accomplish the above?:**

1. Adds `https://github.com/pi-hole/PADD.git` as `paddGitUrl` and `/etc/.padd/` as `PADD_LOCAL_REPO` to `automated install/basic-install.sh` as global variables for use as seen in the following steps.

2. Extends functionality of `clone_or_reset_repos()` to clone `paddGitUrl` to `PADD_LOCAL_REPO`.

3. Extends functionality of `installScripts()` to install `${PADD_LOCAL_REPO}/padd.sh` as `${PI_HOLE_BIN_DIR}/padd`, in the same location as [pi-hole/docker-pi-hole](https://github.com/pi-hole/docker-pi-hole/blob/78aee9e4b2089263359d6d7e2847028f237b7aef/src/Dockerfile#L57), which should allow part 4 to work on bare metal and docker.

4. Links `pihole -c` (`paddFunc()`, formerly ``chronometerFunc()``) to `${PI_HOLE_BIN_DIR}/padd` and ensures first argument is dropped before starting, which is likely to be `-c` since `padd` is being started with `pihole -c`.

5. Extends functionality of `checkout()`, `advanced/Scripts/update.sh`, and `advanced/Scripts/updatecheck.sh` to ensure PADD is updated accordingly.

6. Extends functionality of `advanced/Scripts/version.sh` to ensure PADD version is shown.

7. Ensures PADD is completely removed during uninstall.

_Hopefully I did not miss anything_ if so, please let me know.

**Link documentation PRs if any are needed to support this PR:**

pi-hole/docs/pull/1209

Adds PADD between Tail and Gravity where Chronometer was in v5 docs.

```
### PADD

| | |
| -------------- | -------------- |
| Help Command    | `pihole -c --help` or `padd --help` |
| Script Location | [`/usr/local/bin/padd`](https://github.com/pi-hole/PADD/blob/master/padd.sh) |
| Example Usage   | [`pihole -c`](https://discourse.pi-hole.net/t/the-pihole-command-with-examples/738#chronometer)  or just `padd`|

PADD (formerly Chronometer2) is a more expansive version of the original chronometer.sh that was included with Pi-Hole. PADD provides in-depth information about your Pi-hole.
```

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
8. I am willing to help maintain this change if there are issues with it later.
9. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
10. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
11. I have checked that another pull request for this purpose does not exist.
12. I have considered, and confirmed that this submission will be valuable to others.
13. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
14. I give this submission freely, and claim no ownership to its content.
---
- [✓] I have read the above and my PR is ready for review. 
