### PR TITLE
Ensure gravity_Cleanup() checks the correct directory

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -572,7 +572,7 @@ gravity_DownloadBlocklists() {
     echo ""
   done
 
-  gravity_Blackbody=true
+  DownloadBlocklists_done=true
 }
 
 compareLists() {
@@ -932,13 +932,13 @@ gravity_Cleanup() {
   # invalid_domains location
   rm "${GRAVITY_TMPDIR}"/*.ph-non-domains 2>/dev/null
 
-  # Ensure this function only runs when gravity_SetDownloadOptions() has completed
-  if [[ "${gravity_Blackbody:-}" == true ]]; then
-    # Remove any unused .domains files
-    for file in "${piholeDir}"/*."${domainsExtension}"; do
-      # If list is not in active array, then remove it
+  # Ensure this function only runs when gravity_DownloadBlocklists() has completed
+  if [[ "${DownloadBlocklists_done:-}" == true ]]; then
+    # Remove any unused .domains/.etag/.sha files
+    for file in "${listsCacheDir}"/*."${domainsExtension}"; do
+      # If list is not in active array, then remove it and all associated files
       if [[ ! "${activeDomains[*]}" == *"${file}"* ]]; then
-        rm -f "${file}" 2>/dev/null ||
+        rm -f "${file}"* 2>/dev/null ||
           echo -e "  ${CROSS} Failed to remove ${file##*/}"
       fi
     done


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

ensure `gravity_Cleanup()` checks the correct directory (`listsCacheDir`) for list data when it's `Cleaning up stray matter`. 

**How does this PR accomplish the above?:**

changes 

https://github.com/pi-hole/pi-hole/blob/8797a0df05121225802508a0022543ccee9c47be/gravity.sh#L938

to check `listsCacheDir` instead of `piholeDir` for list data as the location was changed in #5869

also glob (`*`) here 
https://github.com/pi-hole/pi-hole/blob/8797a0df05121225802508a0022543ccee9c47be/gravity.sh#L941

with `"${file}"*` to remove `.etag` & `.sha1` as well.

should fix #6075 


**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [✔] I have read the above and my PR is ready for review. *Check this box to confirm*
