### PR TITLE
source with dot (.) as it works with bash and sh

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -12,10 +12,10 @@
 
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 readonly utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
-source "${utilsfile}"
+. "${utilsfile}"
 
 readonly apifile="${PI_HOLE_SCRIPT_DIR}/api.sh"
-source "${apifile}"
+. "${apifile}"
 
 # Determine database location
 DBFILE=$(getFTLConfigValue "files.database")
@@ -39,7 +39,7 @@ typeId=""
 comment=""
 
 colfile="/opt/pihole/COL_TABLE"
-source ${colfile}
+. ${colfile}
 
 helpFunc() {
     echo "Usage: pihole ${abbrv} [options] <domain> <domain2 ...>

--- a/advanced/Scripts/piholeARPTable.sh
+++ b/advanced/Scripts/piholeARPTable.sh
@@ -12,12 +12,12 @@
 
 coltable="/opt/pihole/COL_TABLE"
 if [[ -f ${coltable} ]]; then
-    source ${coltable}
+    . ${coltable}
 fi
 
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
-source "${utilsfile}"
+. "${utilsfile}"
 
 # Determine database location
 DBFILE=$(getFTLConfigValue "files.database")

--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -10,7 +10,7 @@
 
 readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 SKIP_INSTALL="true"
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
+. "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
 
 # webInterfaceGitUrl set in basic-install.sh
 # webInterfaceDir set in basic-install.sh

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -27,7 +27,7 @@ PIHOLE_COLTABLE_FILE="${PIHOLE_SCRIPTS_DIRECTORY}/COL_TABLE"
 
 # These provide the colors we need for making the log more readable
 if [[ -f ${PIHOLE_COLTABLE_FILE} ]]; then
-    source ${PIHOLE_COLTABLE_FILE}
+    . ${PIHOLE_COLTABLE_FILE}
 else
     COL_NC='\e[0m' # No Color
     COL_RED='\e[1;91m'
@@ -42,7 +42,7 @@ else
 fi
 
 # shellcheck disable=SC1091
-source /etc/pihole/versions
+. /etc/pihole/versions
 
 # Read the value of an FTL config key. The value is printed to stdout.
 get_ftl_conf_value() {

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -9,11 +9,11 @@
 # Please see LICENSE file for your rights under this license.
 
 colfile="/opt/pihole/COL_TABLE"
-source ${colfile}
+. ${colfile}
 
 readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
-source "${utilsfile}"
+. "${utilsfile}"
 
 # In case we're running at the same time as a system logrotate, use a
 # separate logrotate state file to prevent stepping on each other's

--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -22,10 +22,10 @@ domain=""
 
 # Source color table
 colfile="/opt/pihole/COL_TABLE"
-source "${colfile}"
+. "${colfile}"
 
 # Source api functions
-source "${PI_HOLE_INSTALL_DIR}/api.sh"
+. "${PI_HOLE_INSTALL_DIR}/api.sh"
 
 Help() {
     echo "Usage: pihole -q [option] <domain>

--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -23,9 +23,9 @@ SKIP_INSTALL=true
 CHECK_ONLY=false
 
 # shellcheck disable=SC1090
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
+. "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
 # shellcheck disable=SC1091
-source "/opt/pihole/COL_TABLE"
+. "/opt/pihole/COL_TABLE"
 
 # is_repo() sourced from basic-install.sh
 # make_repo() sourced from basic-install.sh

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -40,7 +40,7 @@ function get_remote_hash() {
 
 # Source the utils file for addOrEditKeyValPair()
 # shellcheck disable=SC1091
-source /opt/pihole/utils.sh
+. /opt/pihole/utils.sh
 
 # Remove the below three legacy files if they exist
 rm -f "/etc/pihole/GitHubVersions"

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -17,12 +17,12 @@ cachedVersions="/etc/pihole/versions"
 
 if [ -f ${cachedVersions} ]; then
     # shellcheck disable=SC1090
-    source "$cachedVersions"
+    . "$cachedVersions"
 else
     echo "Could not find /etc/pihole/versions. Running update now."
     pihole updatechecker
     # shellcheck disable=SC1090
-    source "$cachedVersions"
+    . "$cachedVersions"
 fi
 
 main() {

--- a/advanced/Templates/pihole-FTL-poststop.sh
+++ b/advanced/Templates/pihole-FTL-poststop.sh
@@ -4,7 +4,7 @@
 PI_HOLE_SCRIPT_DIR='/opt/pihole'
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck disable=SC1090
-source "${utilsfile}"
+. "${utilsfile}"
 
 # Get file paths
 FTL_PID_FILE="$(getFTLConfigValue files.pid)"

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -4,7 +4,7 @@
 PI_HOLE_SCRIPT_DIR='/opt/pihole'
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck disable=SC1090
-source "${utilsfile}"
+. "${utilsfile}"
 
 # Get file paths
 FTL_PID_FILE="$(getFTLConfigValue files.pid)"

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -13,7 +13,7 @@
 PI_HOLE_SCRIPT_DIR="/opt/pihole"
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck disable=SC1090
-source "${utilsfile}"
+. "${utilsfile}"
 
 
 is_running() {

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -152,7 +152,7 @@ done
 # If the color table file exists,
 if [[ -f "${coltable}" ]]; then
     # source it
-    source "${coltable}"
+    . "${coltable}"
 # Otherwise,
 else
     # Set these values so the installer can still run in color
@@ -2399,7 +2399,7 @@ main() {
     # /opt/pihole/utils.sh should be installed by installScripts now, so we can use it
     if [ -f "${PI_HOLE_INSTALL_DIR}/utils.sh" ]; then
         # shellcheck disable=SC1091
-        source "${PI_HOLE_INSTALL_DIR}/utils.sh"
+        . "${PI_HOLE_INSTALL_DIR}/utils.sh"
     else
         printf "  %b Failure: /opt/pihole/utils.sh does not exist .\\n" "${CROSS}"
         exit 1

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -8,7 +8,7 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
-source "/opt/pihole/COL_TABLE"
+. "/opt/pihole/COL_TABLE"
 
 while true; do
     read -rp "  ${QST} Are you sure you would like to remove ${COL_WHITE}Pi-hole${COL_NC}? [y/N] " answer
@@ -37,7 +37,7 @@ fi
 
 readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 SKIP_INSTALL="true"
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
+. "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
 
 # package_manager_detect() sourced from basic-install.sh
 package_manager_detect

--- a/gravity.sh
+++ b/gravity.sh
@@ -17,13 +17,13 @@ PI_HOLE_SCRIPT_DIR="/opt/pihole"
 # Source utils.sh for GetFTLConfigValue
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck disable=SC1090
-source "${utilsfile}"
+. "${utilsfile}"
 
 coltable="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 # shellcheck disable=SC1090
-source "${coltable}"
+. "${coltable}"
 # shellcheck disable=SC1091
-source "/etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh"
+. "/etc/.pihole/advanced/Scripts/database_migration/gravity-db.sh"
 
 basename="pihole"
 PIHOLE_COMMAND="/usr/local/bin/${basename}"

--- a/pihole
+++ b/pihole
@@ -17,21 +17,21 @@ readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
 PI_HOLE_BIN_DIR="/usr/local/bin"
 
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
-source "${colfile}"
+. "${colfile}"
 
 readonly utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
-source "${utilsfile}"
+. "${utilsfile}"
 
 # Source api functions
 readonly apifile="${PI_HOLE_SCRIPT_DIR}/api.sh"
-source "${apifile}"
+. "${apifile}"
 
 versionsfile="/etc/pihole/versions"
 if [ -f "${versionsfile}" ]; then
     # Only source versionsfile if the file exits
     # fixes a warning during installation where versionsfile does not exist yet
     # but gravity calls `pihole -status` and thereby sourcing the file
-    source "${versionsfile}"
+    . "${versionsfile}"
 fi
 
 # TODO: We can probably remove the reliance on this function too, just tell people to pihole-FTL --config webserver.api.password "password"
@@ -423,7 +423,7 @@ piholeCheckoutFunc() {
       exit 0
     fi
 
-    source "${PI_HOLE_SCRIPT_DIR}"/piholeCheckout.sh
+    . "${PI_HOLE_SCRIPT_DIR}"/piholeCheckout.sh
     shift
     checkout "$@"
   fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

consistently source using dot (.) as it works with `sh` and `bash` 

and as mentioned in https://github.com/pi-hole/pi-hole/pull/6137#issuecomment-2773609697

> https://stackoverflow.com/a/11588636
> do note that the `source` alias available in bash and some other modern shells is not part of POSIX

so it seems this change would just remove some more Bash-isms

would also revert #6137

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [✔] I have read the above and my PR is ready for review. *Check this box to confirm*
