### PR TITLE
Offer to add local user to pihole group on fresh installations

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1617,6 +1617,60 @@ create_pihole_user() {
     fi
 }
 
+# offer to add the first local user (UID 1000) to the pihole group
+local_user_to_pihole_group(){
+    local username
+    local str="Checking for user with UID 1000"
+    printf "  %b %s..." "${INFO}" "${str}"
+
+    username=$(getent passwd 1000 | cut -d: -f1)
+
+    # No user with UID 1000 found
+    if [[ -z "${username}" ]]; then
+        str="No user with UID 1000 found"
+        printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
+        return
+    fi
+    # User with UID 1000 already in pihole group
+    if id -nG "${username}" | grep -q pihole; then
+        str="User ${username} already in pihole group"
+        printf "%b  %b %s\\n" "${OVER}" "${TICK}" "${str}"
+        return
+    fi
+
+    # User with UID 1000 not in pihole group
+    # Offer dialog to add user to pihole group
+    dialog --no-shadow --keep-tite \
+        --backtitle "Pi-hole Installation" \
+        --title "Add user to pihole group" \
+        --yesno "\\nFor privacy reasons certain Pi-hole CLI functions are only allowed to members of the newly created the local group 'pihole'.\
+\\n\\nYour first local user is '${username}' \
+\\n\\nWould you like to add '${username}' to the pihole group? \
+\\n\\n\\nP.S. Any user can be added to the group later manually. "\
+        "${r}" "${c}" && result=0 || result=$?
+
+    case ${result} in
+    "${DIALOG_OK}")
+        # If they chose yes,
+        printf "  %b Adding user ${username} to pihole group\\n" "${INFO}"
+        if usermod -aG pihole "${username}"; then
+            printf "  %b User ${username} added to pihole group\\n" "${TICK}"
+        else
+            printf "  %b Error adding user ${username} to pihole group\\n" "${CROSS}"
+        fi
+        ;;
+    "${DIALOG_CANCEL}")
+        # If they chose no,
+        printf "  %b Not adding user ${username} to pihole group\\n" "${INFO}"
+        ;;
+    "${DIALOG_ESC}")
+        # User pressed <ESC>
+        printf "  %b Escape pressed, exiting installer at user group choice.%b\\n" "${COL_LIGHT_RED}" "${COL_NC}"
+        exit 1
+        ;;
+    esac
+}
+
 # Install the logrotate script
 installLogrotate() {
     local str="Installing latest logrotate script"
@@ -2375,6 +2429,7 @@ main() {
         setLogging
         # Let the user decide the FTL privacy level
         setPrivacyLevel
+
     else
         # Setup adlist file if not exists
         installDefaultBlocklists
@@ -2384,6 +2439,10 @@ main() {
 
     # Create the pihole user
     create_pihole_user
+    if [[ "${fresh_install}" == true ]]; then
+        # Let the user decide if they want to put their local user into the pihole group
+        local_user_to_pihole_group
+    fi
 
     # Download and install FTL
     local binary


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Certain CLI functions e.g. `pihole -v` or `pihole api` require access to files in `/etc/pihole` which belong to `pihole:pihole`. This PR adds a dialog to offer to put the user with UID 1000 (usually the first local user) into the `pihole` group during installation.

To be discussed.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
