### PR TITLE
fix `modifiedOptions` building

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -601,7 +601,7 @@ compareLists() {
 # Download specified URL and perform checks on HTTP status and file content
 gravity_DownloadBlocklistFromUrl() {
   local url="${1}" adlistID="${2}" saveLocation="${3}" target="${4}" compression="${5}" gravity_type="${6}" domain="${7}"
-  local modifiedOptions="" listCurlBuffer str httpCode success="" ip cmd_ext
+  local modifiedOptions=() listCurlBuffer str httpCode success="" ip cmd_ext
   local file_path permissions ip_addr port blocked=false download=true
 
   # Create temp file to store content on disk instead of RAM
@@ -619,14 +619,14 @@ gravity_DownloadBlocklistFromUrl() {
       # Save HTTP ETag to the specified file. An ETag is a caching related header,
       # usually returned in a response. If no ETag is sent by the server, an empty
       # file is created and can later be used consistently.
-      modifiedOptions="--etag-save ${saveLocation}.etag"
+      modifiedOptions=("${modifiedOptions[@]}" --etag-save "${saveLocation}".etag)
 
       if [[ -f "${saveLocation}.etag" ]]; then
         # This option makes a conditional HTTP request for the specific ETag read
         # from the given file by sending a custom If-None-Match header using the
         # stored ETag. This way, the server will only send the file if it has
         # changed since the last request.
-        modifiedOptions="${modifiedOptions} --etag-compare ${saveLocation}.etag"
+        modifiedOptions=("${modifiedOptions[@]}" --etag-compare "${saveLocation}".etag)
       fi
     fi
 
@@ -639,7 +639,7 @@ gravity_DownloadBlocklistFromUrl() {
       # Interstingly, this option is not supported by raw.githubusercontent.com
       # URLs, however, it is still supported by many older web servers which may
       # not support the HTTP ETag method so we keep it as a fallback.
-      modifiedOptions="${modifiedOptions} -z ${saveLocation}"
+      modifiedOptions=("${modifiedOptions[@]}" -z "${saveLocation}")
     fi
   fi
 
@@ -769,7 +769,7 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   if [[ "${download}" == true ]]; then
-    httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L "${compression}" "${cmd_ext}" "${modifiedOptions}" -w "%{http_code}" "${url}" -o "${listCurlBuffer}" 2>/dev/null)
+    httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression} ${cmd_ext} "${modifiedOptions[@]}" -w "%{http_code}" ${url} -o ${listCurlBuffer} 2>/dev/null)
   fi
 
   case $url in


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

my attempt at fixing https://github.com/pi-hole/pi-hole/issues/6159

**How does this PR accomplish the above?:**

following the suggestion for command line variable building found here https://www.shellcheck.net/wiki/SC2086

> Just quoting this doesn't work. Instead, you should have used an array (bash, ksh, zsh):
>```
>options=(-j 5 -B) # ksh88: set -A options -- -j 5 -B
>[[ $debug == "yes" ]] && options=("${options[@]}" -d)
>make "${options[@]}" file
>```

this specifically `options=("${options[@]}" -d)` 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
