### PR TITLE
Remove duplicated code checking if adlist domain is blocked locally

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -646,32 +646,6 @@ gravity_DownloadBlocklistFromUrl() {
   str="Status:"
   echo -ne "  ${INFO} ${str} Pending..."
   blocked=false
-  case $(getFTLConfigValue dns.blocking.mode) in
-  "IP-NODATA-AAAA" | "IP")
-    # Get IP address of this domain
-    ip="$(dig "${domain}" +short)"
-    # Check if this IP matches any IP of the system
-    if [[ -n "${ip}" && $(grep -Ec "inet(|6) ${ip}" <<<"$(ip a)") -gt 0 ]]; then
-      blocked=true
-    fi
-    ;;
-  "NXDOMAIN")
-    if [[ $(dig "${domain}" | grep "NXDOMAIN" -c) -ge 1 ]]; then
-      blocked=true
-    fi
-    ;;
-  "NODATA")
-    if [[ $(dig "${domain}" | grep "NOERROR" -c) -ge 1 ]] && [[ -z $(dig +short "${domain}") ]]; then
-      blocked=true
-    fi
-    ;;
-  "NULL" | *)
-    if [[ $(dig "${domain}" +short | grep "0.0.0.0" -c) -ge 1 ]]; then
-      blocked=true
-    fi
-    ;;
-  esac
-
   # Check if this domain is blocked by Pi-hole but only if the domain is not a
   # local file or empty
   if [[ $url != "file"* ]] && [[ -n "${domain}" ]]; then


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We check if the adlist domain is blocked by Pi-hole which would prevent downloading the adlist during gravity run if the host's upstream is Pi-hole. Somehow, this code got duplicated.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
