### PR TITLE
Treat FTL return data as strings - part II

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -226,7 +226,7 @@ GetFTLData() {
     # return only the data
     if [ "${status}" = 200 ]; then
         # response OK
-        echo "${data}"
+        printf %s "${data}"
     else
         # connection lost
         echo "${status}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Repetition of https://github.com/pi-hole/pi-hole/pull/5509
We need to treat the data returned from the FTL API literally, not interpret them by handling them over from `GetFTLData()` to any other function. This was done before, but got lost during v6 development. 

This PR supersedes https://github.com/pi-hole/pi-hole/pull/6080 and fixes https://github.com/pi-hole/pi-hole/issues/6055

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
