### PR TITLE
All gravity related files and dirs should be owned by pihole:pihole

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -126,7 +126,7 @@ gravity_swap_databases() {
   oldAvail=false
   if [ "${availableBlocks}" -gt "$((gravityBlocks * 2))" ] && [ -f "${gravityDBfile}" ]; then
     oldAvail=true
-    cp "${gravityDBfile}" "${gravityOLDfile}"
+    cp -p "${gravityDBfile}" "${gravityOLDfile}"
   fi
 
   # Drop the gravity and antigravity tables + subsequent VACUUM the current
@@ -140,6 +140,7 @@ gravity_swap_databases() {
     # Check if the backup directory exists
     if [ ! -d "${gravityBCKdir}" ]; then
       mkdir -p "${gravityBCKdir}"
+      chown pihole:pihole "${gravityBCKdir}"
     fi
 
     # If multiple gravityBCKfile's are present (appended with a number), rotate them
@@ -1016,6 +1017,7 @@ migrate_to_listsCache_dir() {
   local str="Migrating the list's cache directory to new location"
   echo -ne "  ${INFO} ${str}..."
   mkdir -p "${listsCacheDir}"
+  chown pihole:pihole "${listsCacheDir}"
 
   # Move the old files to the new directory
   if mv "${piholeDir}"/list.* "${listsCacheDir}/" 2>/dev/null; then


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

`gravity` runs as root, so all new created dirs or copied files will be owned by `root` by default. This PR fixes 3 locations where we need to set `pihole:pihole` explicitly. 
Fixes https://github.com/pi-hole/pi-hole/issues/6185

P.S. On FTL restart, we execute `prestart.sh` which would also fix file/folder permissions.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
