### PR TITLE
Give FTL 60 seconds for graceful shutdown

### DIFF
--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -12,6 +12,7 @@
 # Source utils.sh for getFTLConfigValue(), getFTLPID()
 PI_HOLE_SCRIPT_DIR="/opt/pihole"
 utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
+# shellcheck source="./advanced/Scripts/utils.sh"
 . "${utilsfile}"
 
 
@@ -56,13 +57,16 @@ start() {
 stop() {
   if is_running; then
     kill "${FTL_PID}"
-    for i in 1 2 3 4 5; do
+    # Give FTL 60 seconds to gracefully stop
+    i=1
+    while [ "${i}" -le 60 ]; do
       if ! is_running; then
         break
       fi
 
       printf "."
       sleep 1
+      i=$((i + 1))
     done
     echo
 

--- a/advanced/Templates/pihole-FTL.systemd
+++ b/advanced/Templates/pihole-FTL.systemd
@@ -28,7 +28,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 ExecStopPost=/opt/pihole/pihole-FTL-poststop.sh
 
 # Use graceful shutdown with a reasonable timeout
-TimeoutStopSec=10s
+TimeoutStopSec=60s
 
 # Make /usr, /boot, /etc and possibly some more folders read-only...
 ProtectSystem=full


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

On low-end hardware it might take more then 10/5 seconds to shutdown FTL. Instead of killing it right away, give it 60 seconds to shutdown. 
With v6 we have an increase in database errors which might be due to database corruption during forceful shutdown.
Fixes https://github.com/pi-hole/pi-hole/issues/6170

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
