### PR TITLE
Fix API logic in api.sh

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -20,7 +20,7 @@
 TestAPIAvailability() {
 
     # as we are running locally, we can get the port value from FTL directly
-    local chaos_api_list authResponse authStatus authData
+    local chaos_api_list authResponse authStatus authData apiAvailable
 
     # Query the API URLs from FTL using CHAOS TXT local.api.ftl
     # The result is a space-separated enumeration of full URLs
@@ -59,7 +59,7 @@ TestAPIAvailability() {
         # Test if http status code was 200 (OK) or 401 (authentication required)
         if [ ! "${authStatus}" = 200 ] && [ ! "${authStatus}" = 401 ]; then
             # API is not available at this port/protocol combination
-            API_PORT=""
+            apiAvailable=false
         else
             # API is available at this URL combination
 
@@ -70,6 +70,8 @@ TestAPIAvailability() {
 
             # Check if 2FA is required
             needTOTP=$(echo "${authData}"| jq --raw-output .session.totp 2>/dev/null)
+
+            apiAvailable=true
 
             break
         fi
@@ -86,9 +88,9 @@ TestAPIAvailability() {
         fi
     done
 
-    # if API_PORT is empty, no working API port was found
-    if [ -n "${API_PORT}" ]; then
-        echo "API not available at: ${API_URL}"
+    # if apiAvailable is false, no working API was found
+    if [ "${apiAvailable}" = false ]; then
+        echo "API not available. Please check FTL.log"
         echo "Exiting."
         exit 1
     fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix the logic in `api.sh`. I noticed we had the leftover `API_PORT` which was intended to signal if we found a responding api. The check for emptiness war wrong in the first place (using `-n` instead of `-z`). 

This PR fixes the logic by better naming the variable and explicitly setting it to true/false.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
