### PR TITLE
Fix gravity waiting forever for DNS

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -348,17 +348,24 @@ gravity_CheckDNSResolutionAvailable() {
     echo -e "  ${CROSS} DNS resolution is currently unavailable"
   fi
 
-  str="Waiting until DNS resolution is available..."
+  str="Waiting 120 seconds if DNS resolution becomes available..."
   echo -ne "  ${INFO} ${str}"
-  until getent hosts github.com &> /dev/null; do
-  # Append one dot for each second waiting
-    str="${str}."
-    echo -ne "  ${OVER}  ${INFO} ${str}"
-    sleep 1
+
+  for ((i = 0; i < 120; i++)); do
+      if getent hosts github.com &> /dev/null; then
+        # If we reach this point, DNS resolution is available
+        echo -e "${OVER}  ${TICK} DNS resolution is available"
+        break
+      fi
+      # Append one dot for each second waiting
+      str="${str}."
+      echo -ne "  ${OVER}  ${INFO} ${str}"
+      sleep 1
   done
 
-  # If we reach this point, DNS resolution is available
-  echo -e "${OVER}  ${TICK} DNS resolution is available"
+  # DNS resolution is still unavailable after 120 seconds
+  return 1
+
 }
 
 # Function: try_restore_backup
@@ -1081,6 +1088,12 @@ for var in "$@"; do
   esac
 done
 
+# Check if DNS is available, no need to do any database manipulation if we're not able to download adlists
+if ! timeit gravity_CheckDNSResolutionAvailable; then
+  echo -e "   ${CROSS} No DNS resolution available. Please contact support."
+  exit 1
+fi
+
 # Remove OLD (backup) gravity file, if it exists
 if [[ -f "${gravityOLDfile}" ]]; then
   rm "${gravityOLDfile}"
@@ -1121,11 +1134,6 @@ if [[ "${forceDelete:-}" == true ]]; then
 fi
 
 # Gravity downloads blocklists next
-if ! timeit gravity_CheckDNSResolutionAvailable; then
-  echo -e "   ${CROSS} Can not complete gravity update, no DNS is available. Please contact support."
-  exit 1
-fi
-
 if ! gravity_DownloadBlocklists; then
   echo -e "   ${CROSS} Unable to create gravity database. Please try again later. If the problem persists, please contact support."
   exit 1

--- a/gravity.sh
+++ b/gravity.sh
@@ -359,8 +359,7 @@ gravity_CheckDNSResolutionAvailable() {
         break
       fi
       # Append one dot for each second waiting
-      str="${str}."
-      echo -ne "  ${OVER}  ${INFO} ${str}"
+      echo -ne "."
       sleep 1
   done
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -348,7 +348,7 @@ gravity_CheckDNSResolutionAvailable() {
     echo -e "  ${CROSS} DNS resolution is currently unavailable"
   fi
 
-  str="Waiting 120 seconds if DNS resolution becomes available..."
+  str="Waiting up to 120 seconds for DNS resolution..."
   echo -ne "  ${INFO} ${str}"
 
  # Default DNS timeout is two seconds, plus 1 second for each dot > 120 seconds

--- a/gravity.sh
+++ b/gravity.sh
@@ -351,7 +351,8 @@ gravity_CheckDNSResolutionAvailable() {
   str="Waiting 120 seconds if DNS resolution becomes available..."
   echo -ne "  ${INFO} ${str}"
 
-  for ((i = 0; i < 120; i++)); do
+ # Default DNS timeout is two seconds, plus 1 second for each dot > 120 seconds
+  for ((i = 0; i < 40; i++)); do
       if getent hosts github.com &> /dev/null; then
         # If we reach this point, DNS resolution is available
         echo -e "${OVER}  ${TICK} DNS resolution is available"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

During gravity run, we check if DNS is available. However, we waited forever if no DNS becomes available. This lead to unexpected consequences (see https://github.com/pi-hole/pi-hole/issues/6195).

This PR does two things: 
a) exit the loop if there is no DNS after 120 seconds. This should be enough time for short internet outages to recover from.
b) check DNS right at the start of gravity, before doing any database stuff to avoid running in a non-recoverable database situation.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
