### PR TITLE
Set dns.interface during installation

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -99,6 +99,7 @@ IPV6_ADDRESS=${IPV6_ADDRESS}
 # Give settings their default values. These may be changed by prompts later in the script.
 QUERY_LOGGING=
 PRIVACY_LEVEL=
+PIHOLE_INTERFACE=
 
 # Where old configs go to if a v6 migration is performed
 V6_CONF_MIGRATION_DIR="/etc/pihole/migration_backup_v6"
@@ -2328,6 +2329,10 @@ main() {
 
         if [ -n "${PRIVACY_LEVEL}" ]; then
             setFTLConfigValue "misc.privacylevel" "${PRIVACY_LEVEL}"
+        fi
+
+        if [ -n "${PIHOLE_INTERFACE}" ]; then
+            setFTLConfigValue "dns.interface" "${PIHOLE_INTERFACE}"
         fi
     fi
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

During fresh installation, we ask the user which interface should be used for Pi-hole. This populates `PIHOLE_INTERFACE`, but we never used the var for anything. This PR now sets the this as `dns.interface` which can be used by FTL if necessary.
Reported on discourse: https://discourse.pi-hole.net/t/problems-setting-up-new-v6-installation/79633

P.S. By default, the listening mode is `local` which means `dns.interface` is unused. But the web interface allows with a single click to switch to a different listening mode which will use the specified interface.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
