### PR TITLE
Do not try to upgrade gravity if it does not exist

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2295,10 +2295,13 @@ main() {
     # but before starting or resttarting the ftl service
     disable_resolved_stublistener
 
-    # Check if gravity database needs to be upgraded. If so, do it without rebuilding
-    # gravity altogether. This may be a very long running task needlessly blocking
-    # the update process.
-    /opt/pihole/gravity.sh --upgrade
+    if [[ "${fresh_install}" == false ]]; then
+        # Check if gravity database needs to be upgraded. If so, do it without rebuilding
+        # gravity altogether. This may be a very long running task needlessly blocking
+        # the update process.
+        # Only do this on updates, not on fresh installs as the database does not exit yet
+        /opt/pihole/gravity.sh --upgrade
+    fi
 
     printf "  %b Restarting services...\\n" "${INFO}"
     # Start services


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

On upgrades, we also update the gravity database schema as it might have changed. However, we don't need to do that on fresh installs, as the database does not exist yet. It is created later in the script with `runGravity`

https://github.com/pi-hole/pi-hole/blob/7aaaa49cf0fb2b548fa831256157b335a4909301/automated%20install/basic-install.sh#L2339-L2340

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
