### PR TITLE
Revert "fix(get_available_interfaces): only drop the loopback device (‘lo’), don’t filter every “lo” substring"

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -705,7 +705,7 @@ find_IPv4_information() {
 # Get available interfaces that are UP
 get_available_interfaces() {
     # There may be more than one so it's all stored in a variable
-    availableInterfaces=$(ip --oneline link show up | awk '{print $2}' | grep -v "^lo" | cut -d':' -f1 | cut -d'@' -f1)
+    availableInterfaces=$(ip --oneline link show up | grep -v "lo" | awk '{print $2}' | cut -d':' -f1 | cut -d'@' -f1)
 }
 
 # A function for displaying the dialogs the user sees when first running the installer


### PR DESCRIPTION
Reverts pi-hole/pi-hole#6224