### PR TITLE
Update `get_available_interfaces()` to correctly filter loopback device (`lo`)

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -574,7 +574,7 @@ Do you wish to continue with an IPv6-only installation?\\n\\n" \
 # Get available interfaces that are UP
 get_available_interfaces() {
     # There may be more than one so it's all stored in a variable
-    availableInterfaces=$(ip --oneline link show up | grep -v "lo" | awk '{print $2}' | cut -d':' -f1 | cut -d'@' -f1)
+    availableInterfaces=$(ip --oneline link show up | awk '{print $2}' |  grep -v "^lo" | cut -d':' -f1 | cut -d'@' -f1)
 }
 
 # A function for displaying the dialogs the user sees when first running the installer


### PR DESCRIPTION
The get_available_interfaces() helper currently does:

ip --oneline link show up | grep -v "lo" | awk '{print $2}'

it removes wlo1 from the output.
i have updated command to use 

ip --oneline link show up | awk '{print $2}' | grep -v "^lo"