### PR TITLE
Function `gravity_CheckDNSResolutionAvailable()` should return 0 if DNS resolution is available

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -356,7 +356,7 @@ gravity_CheckDNSResolutionAvailable() {
       if getent hosts github.com &> /dev/null; then
         # If we reach this point, DNS resolution is available
         echo -e "${OVER}  ${TICK} DNS resolution is available"
-        break
+        return 0
       fi
       # Append one dot for each second waiting
       echo -ne "."


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix `gravity_CheckDNSResolutionAvailable()` return value when DNS resolution is available.

The previous code returned 1 even if DNS resolution became available during the for loop.

### How does this PR accomplish the above?

Returns `1` only if resolution is still unavailable after 40 attempts. Returns `0` if resolution is successful.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
