### PR TITLE
Use PID1 to determine which command to use when toggeling services

### DIFF
--- a/advanced/Scripts/piholeARPTable.sh
+++ b/advanced/Scripts/piholeARPTable.sh
@@ -20,6 +20,13 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source=./advanced/Scripts/utils.sh
 source "${utilsfile}"
 
+readonly PI_HOLE_FILES_DIR="/etc/.pihole"
+SKIP_INSTALL="true"
+# shellcheck source="./automated install/basic-install.sh"
+source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
+# stop_service() is defined in basic-install.sh
+# restart_service() is defined in basic-install.sh
+
 # Determine database location
 DBFILE=$(getFTLConfigValue "files.database")
 if [ -z "$DBFILE" ]; then
@@ -33,7 +40,7 @@ flushARP(){
     fi
 
     # Stop FTL to prevent database access
-    if ! output=$(service pihole-FTL stop 2>&1); then
+    if ! output=$(stop_service pihole-FTL 2>&1); then
         echo -e "${OVER}  ${CROSS} Failed to stop FTL"
         echo "  Output: ${output}"
         return 1
@@ -65,7 +72,7 @@ flushARP(){
     fi
 
     # Start FTL again
-    if ! output=$(service pihole-FTL restart 2>&1); then
+    if ! output=$(restart_service pihole-FTL 2>&1); then
         echo -e "${OVER}  ${CROSS} Failed to restart FTL"
         echo "  Output: ${output}"
         return 1

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -17,6 +17,12 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "${utilsfile}"
 
+SKIP_INSTALL="true"
+# shellcheck source="./automated install/basic-install.sh"
+source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
+# stop_service() is defined in basic-install.sh
+# restart_service() is defined in basic-install.sh
+
 # In case we're running at the same time as a system logrotate, use a
 # separate logrotate state file to prevent stepping on each other's
 # toes.
@@ -104,13 +110,14 @@ else
     fi
 
     # Stop FTL to make sure it doesn't write to the database while we're deleting data
-    service pihole-FTL stop
+    stop_service pihole-FTL >/dev/null
+
 
     # Delete most recent 24 hours from FTL's database, leave even older data intact (don't wipe out all history)
     deleted=$(pihole-FTL sqlite3 -ni "${DBFILE}" "DELETE FROM query_storage WHERE timestamp >= strftime('%s','now')-86400; select changes() from query_storage limit 1")
 
     # Restart FTL
-    service pihole-FTL restart
+    restart_service pihole-FTL >/dev/null
     if [[ "$*" != *"quiet"* ]]; then
         echo -e "${OVER}  ${TICK} Deleted ${deleted} queries from long-term query database"
     fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -116,11 +116,11 @@ c=70
 PIHOLE_META_PACKAGE_CONTROL_APT=$(
     cat <<EOM
 Package: pihole-meta
-Version: 0.3
+Version: 0.4
 Maintainer: Pi-hole team <adblock@pi-hole.net>
 Architecture: all
 Description: Pi-hole dependency meta package
-Depends: grep,dnsutils,binutils,git,iproute2,dialog,ca-certificates,cron | cron-daemon,curl,iputils-ping,psmisc,sudo,unzip,libcap2-bin,dns-root-data,libcap2,netcat-openbsd,procps,jq,lshw,bash-completion
+Depends: awk,bash-completion,binutils,ca-certificates,cron|cron-daemon,curl,dialog,dnsutils,dns-root-data,git,grep,iproute2,iputils-ping,jq,libcap2,libcap2-bin,lshw,netcat-openbsd,procps,psmisc,sudo,unzip
 Section: contrib/metapackages
 Priority: optional
 EOM
@@ -130,12 +130,12 @@ EOM
 PIHOLE_META_PACKAGE_CONTROL_RPM=$(
     cat <<EOM
 Name: pihole-meta
-Version: 0.1
+Version: 0.2
 Release: 1
 License: EUPL
 BuildArch: noarch
 Summary: Pi-hole dependency meta package
-Requires: grep,curl,psmisc,sudo, unzip,jq,git,dialog,ca-certificates, bind-utils, iproute, procps-ng, chkconfig, binutils, cronie, findutils, libcap, nmap-ncat, lshw, bash-completion
+Requires: bash-completion,bind-utils,binutils,ca-certificates,chkconfig,cronie,curl,dialog,findutils,gawk,git,grep,iproute,jq,libcap,lshw,nmap-ncat,procps-ng,psmisc,sudo,unzip
 %description
 Pi-hole dependency meta package
 %prep
@@ -143,6 +143,9 @@ Pi-hole dependency meta package
 %files
 %install
 %changelog
+* Wed May 28 2025 Pi-hole Team - 0.2
+- Add gawk to the list of dependencies
+
 * Sun Sep 29 2024 Pi-hole Team - 0.1
 - First version being packaged
 EOM

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -235,7 +235,9 @@ is_pid1() {
     # Checks to see if the given command runs as PID 1
     local is_pid1="$1"
 
-    ps -p 1 -o comm= | grep -q "${is_pid1}"
+    # select PID 1, format output to show only CMD column without header
+    # quietly grep for a match on the function passed parameter
+    ps --pid 1 --format comm= | grep -q "${is_pid1}"
 }
 
 # Compatibility

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -13,6 +13,11 @@ source "/opt/pihole/COL_TABLE"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "/opt/pihole/utils.sh"
 
+SKIP_INSTALL="true"
+# shellcheck source="./automated install/basic-install.sh"
+source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
+# stop_service() is defined in basic-install.sh
+
 ADMIN_INTERFACE_DIR=$(getFTLConfigValue "webserver.paths.webroot")$(getFTLConfigValue "webserver.paths.webhome")
 readonly ADMIN_INTERFACE_DIR
 
@@ -102,11 +107,7 @@ removePiholeFiles() {
     # Remove FTL
     if command -v pihole-FTL &> /dev/null; then
         echo -ne "  ${INFO} Removing pihole-FTL..."
-        if [[ -x "$(command -v systemctl)" ]]; then
-            systemctl stop pihole-FTL
-        else
-            service pihole-FTL stop
-        fi
+        stop_service pihole-FTL
         ${SUDO} rm -f /etc/systemd/system/pihole-FTL.service
         if [[ -d '/etc/systemd/system/pihole-FTL.service.d' ]]; then
             read -rp "  ${QST} FTL service override directory /etc/systemd/system/pihole-FTL.service.d detected. Do you wish to remove this from your system? [y/N] " answer

--- a/test/_centos_10.Dockerfile
+++ b/test/_centos_10.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream10
 # Disable SELinux
 RUN echo "SELINUX=disabled" > /etc/selinux/config
-RUN yum install -y --allowerasing curl git initscripts
+RUN yum install -y --allowerasing curl git
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_centos_9.Dockerfile
+++ b/test/_centos_9.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream9
 # Disable SELinux
 RUN echo "SELINUX=disabled" > /etc/selinux/config
-RUN yum install -y --allowerasing curl git initscripts
+RUN yum install -y --allowerasing curl git
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_fedora_40.Dockerfile
+++ b/test/_fedora_40.Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:40
-RUN dnf install -y git initscripts
+RUN dnf install -y git
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_fedora_41.Dockerfile
+++ b/test/_fedora_41.Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:41
-RUN dnf install -y git initscripts
+RUN dnf install -y git
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_fedora_42.Dockerfile
+++ b/test/_fedora_42.Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:42
-RUN dnf install -y git
+RUN dnf install -y git gawk
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_fedora_42.Dockerfile
+++ b/test/_fedora_42.Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:42
-RUN dnf install -y git initscripts
+RUN dnf install -y git
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -66,6 +66,14 @@ def test_installPihole_fresh_install_readableFiles(host):
     mock_command("dialog", {"*": ("", "0")}, host)
     # mock git pull
     mock_command_passthrough("git", {"pull": ("", "0")}, host)
+    # mock PID 1 to pretend to be systemd
+    mock_command_2(
+        "ps",
+        {
+            "-p 1": ("systemd", "0"),
+        },
+        host,
+    )
     # mock systemctl to not start FTL
     mock_command_2(
         "systemctl",
@@ -73,6 +81,7 @@ def test_installPihole_fresh_install_readableFiles(host):
             "enable pihole-FTL": ("", "0"),
             "restart pihole-FTL": ("", "0"),
             "start pihole-FTL": ("", "0"),
+            "stop pihole-FTL": ("", "0"),
             "*": ('echo "systemctl call with $@"', "0"),
         },
         host,
@@ -130,13 +139,6 @@ def test_installPihole_fresh_install_readableFiles(host):
     # readable macvendor.db
     check_macvendor = test_cmd.format("r", "/etc/pihole/macvendor.db", piholeuser)
     actual_rc = host.run(check_macvendor).rc
-    assert exit_status_success == actual_rc
-    # check readable and executable /etc/init.d/pihole-FTL
-    check_init = test_cmd.format("x", "/etc/init.d/pihole-FTL", piholeuser)
-    actual_rc = host.run(check_init).rc
-    assert exit_status_success == actual_rc
-    check_init = test_cmd.format("r", "/etc/init.d/pihole-FTL", piholeuser)
-    actual_rc = host.run(check_init).rc
     assert exit_status_success == actual_rc
     # check readable and executable manpages
     if maninstalled is True:

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -70,7 +70,7 @@ def test_installPihole_fresh_install_readableFiles(host):
     mock_command_2(
         "ps",
         {
-            "-p 1": ("systemd", "0"),
+            "--pid 1": ("systemd", "0"),
         },
         host,
     )


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This is a follow up PR of https://github.com/pi-hole/pi-hole/pull/6043.

It uses the same logic to determine which process has PID1 (hence was the init system) to use the right command to toggle services. This should fix rare cases when users have more than one init system installed.

It also extends the use of service wrapper functions to all scripts we use.

Should fix https://github.com/pi-hole/pi-hole/issues/6071

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
