### PR TITLE
Allow to get API URL from local.api.ftl even if DNS port has changed

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -19,13 +19,19 @@
 
 TestAPIAvailability() {
 
+    local chaos_api_list authResponse authStatus authData apiAvailable DNSport
+
     # as we are running locally, we can get the port value from FTL directly
-    local chaos_api_list authResponse authStatus authData apiAvailable
+    readonly utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
+    # shellcheck source=./advanced/Scripts/utils.sh
+    . "${utilsfile}"
+
+    DNSport=$(getFTLConfigValue dns.port)
 
     # Query the API URLs from FTL using CHAOS TXT local.api.ftl
     # The result is a space-separated enumeration of full URLs
     # e.g., "http://localhost:80/api/" "https://localhost:443/api/"
-    chaos_api_list="$(dig +short chaos txt local.api.ftl @127.0.0.1)"
+    chaos_api_list="$(dig +short -p "${DNSport}" chaos txt local.api.ftl @127.0.0.1)"
 
     # If the query was not successful, the variable is empty
     if [ -z "${chaos_api_list}" ]; then


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When we perform API request from CLI, we use `local.api.ftl` to determine the API URL. However, Pi-hole might not listen on port 53 to answer the TXT request to  `local.api.ftl`.
Solution is simple: first ask FTL which DNS port it listens too, then send the request.

Should fix https://github.com/pi-hole/pi-hole/issues/6251

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
