### PR TITLE
Source needed files directly instead of using intermediate variables and remove readonly

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -22,9 +22,8 @@ TestAPIAvailability() {
     local chaos_api_list authResponse authStatus authData apiAvailable DNSport
 
     # as we are running locally, we can get the port value from FTL directly
-    readonly utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
     # shellcheck source=./advanced/Scripts/utils.sh
-    . "${utilsfile}"
+    . "/opt/pihole/utils.sh"
 
     DNSport=$(getFTLConfigValue dns.port)
 

--- a/advanced/Scripts/piholeARPTable.sh
+++ b/advanced/Scripts/piholeARPTable.sh
@@ -15,15 +15,12 @@ if [[ -f ${coltable} ]]; then
     source ${coltable}
 fi
 
-readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
-utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source=./advanced/Scripts/utils.sh
-source "${utilsfile}"
+source "/opt/pihole/utils.sh"
 
-readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 SKIP_INSTALL="true"
 # shellcheck source="./automated install/basic-install.sh"
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
+source "/etc/.pihole/automated install/basic-install.sh"
 # stop_service() is defined in basic-install.sh
 # restart_service() is defined in basic-install.sh
 

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -17,6 +17,7 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "${utilsfile}"
 
+readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 SKIP_INSTALL="true"
 # shellcheck source="./automated install/basic-install.sh"
 source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -12,15 +12,12 @@ colfile="/opt/pihole/COL_TABLE"
 # shellcheck source="./advanced/Scripts/COL_TABLE"
 source ${colfile}
 
-readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
-utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source="./advanced/Scripts/utils.sh"
-source "${utilsfile}"
+source "/opt/pihole/utils.sh"
 
-readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 SKIP_INSTALL="true"
 # shellcheck source="./automated install/basic-install.sh"
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
+source "/etc/.pihole/automated install/basic-install.sh"
 # stop_service() is defined in basic-install.sh
 # restart_service() is defined in basic-install.sh
 

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -13,12 +13,6 @@ source "/opt/pihole/COL_TABLE"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "/opt/pihole/utils.sh"
 
-readonly PI_HOLE_FILES_DIR="/etc/.pihole"
-SKIP_INSTALL="true"
-# shellcheck source="./automated install/basic-install.sh"
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
-# stop_service() is defined in basic-install.sh
-
 ADMIN_INTERFACE_DIR=$(getFTLConfigValue "webserver.paths.webroot")$(getFTLConfigValue "webserver.paths.webhome")
 readonly ADMIN_INTERFACE_DIR
 
@@ -51,7 +45,7 @@ readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 SKIP_INSTALL="true"
 # shellcheck source="./automated install/basic-install.sh"
 source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
-
+# stop_service() is defined in basic-install.sh
 # package_manager_detect() sourced from basic-install.sh
 package_manager_detect
 

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -13,6 +13,7 @@ source "/opt/pihole/COL_TABLE"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "/opt/pihole/utils.sh"
 
+readonly PI_HOLE_FILES_DIR="/etc/.pihole"
 SKIP_INSTALL="true"
 # shellcheck source="./automated install/basic-install.sh"
 source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes a copy&paste error in https://github.com/pi-hole/pi-hole/pull/6245.
`PI_HOLE_FILES_DIR` was not declared in all scripts using it now. 

Reported on Discourse: https://discourse.pi-hole.net/t/pi-hole-ftl-v6-2-release-sudo-pihole-flush-command-bug/80192/

Additionally, remove some `readonly` lines which cause trouble when we we source different scripts and variables are already defined.
This should fix: https://github.com/pi-hole/pi-hole/issues/6259

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
