### PR TITLE
Fix "LOGFILE: readonly variable" issue with pihole -t command

### DIFF
--- a/pihole
+++ b/pihole
@@ -389,8 +389,8 @@ tailFunc() {
   echo -e "  ${INFO} Press Ctrl-C to exit"
 
   # Get logfile path
-  readonly LOGFILE
-  LOGFILE=$(getFTLConfigValue files.log.dnsmasq)
+  # shellcheck disable=SC2155
+  readonly LOGFILE=$(getFTLConfigValue files.log.dnsmasq)
 
   # Strip date from each line
   # Color blocklist/denylist/wildcard entries as red


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

The variable declaration and assignment should be on the same line for a `readonly` variable

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_