### PR TITLE
Make LOGFILE readonly after assignment

### DIFF
--- a/pihole
+++ b/pihole
@@ -389,8 +389,8 @@ tailFunc() {
   echo -e "  ${INFO} Press Ctrl-C to exit"
 
   # Get logfile path
-  readonly LOGFILE
   LOGFILE=$(getFTLConfigValue files.log.dnsmasq)
+  readonly LOGFILE
 
   # Strip date from each line
   # Color blocklist/denylist/wildcard entries as red


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes `pihole -t` erroring out with `/usr/local/bin/pihole: line 393: LOGFILE: readonly variable`

Shellcheck does insist that variable declaration and variable assignment happen on two different lines but `readonly` variables need to be assigned first and then set as `readonly`

https://www.shellcheck.net/wiki/SC2155
> 
> ### Problematic code in the case of readonly:
> 
> `readonly foo="$(mycmd)"`
> 
> Correct code:
> 
> ```
> foo="$(mycmd)"
> readonly foo
> ```
> 

**How does this PR accomplish the above?:**

Flip declaration and `readonly` assignment.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
