### PR TITLE
Revert "Use PID1 to determine which command to use when toggeling services"

### DIFF
--- a/advanced/Scripts/piholeARPTable.sh
+++ b/advanced/Scripts/piholeARPTable.sh
@@ -20,13 +20,6 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source=./advanced/Scripts/utils.sh
 source "${utilsfile}"
 
-readonly PI_HOLE_FILES_DIR="/etc/.pihole"
-SKIP_INSTALL="true"
-# shellcheck source="./automated install/basic-install.sh"
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
-# stop_service() is defined in basic-install.sh
-# restart_service() is defined in basic-install.sh
-
 # Determine database location
 DBFILE=$(getFTLConfigValue "files.database")
 if [ -z "$DBFILE" ]; then
@@ -40,7 +33,7 @@ flushARP(){
     fi
 
     # Stop FTL to prevent database access
-    if ! output=$(stop_service pihole-FTL 2>&1); then
+    if ! output=$(service pihole-FTL stop 2>&1); then
         echo -e "${OVER}  ${CROSS} Failed to stop FTL"
         echo "  Output: ${output}"
         return 1
@@ -72,7 +65,7 @@ flushARP(){
     fi
 
     # Start FTL again
-    if ! output=$(restart_service pihole-FTL 2>&1); then
+    if ! output=$(service pihole-FTL restart 2>&1); then
         echo -e "${OVER}  ${CROSS} Failed to restart FTL"
         echo "  Output: ${output}"
         return 1

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -17,12 +17,6 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "${utilsfile}"
 
-SKIP_INSTALL="true"
-# shellcheck source="./automated install/basic-install.sh"
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
-# stop_service() is defined in basic-install.sh
-# restart_service() is defined in basic-install.sh
-
 # In case we're running at the same time as a system logrotate, use a
 # separate logrotate state file to prevent stepping on each other's
 # toes.
@@ -110,14 +104,13 @@ else
     fi
 
     # Stop FTL to make sure it doesn't write to the database while we're deleting data
-    stop_service pihole-FTL >/dev/null
-
+    service pihole-FTL stop
 
     # Delete most recent 24 hours from FTL's database, leave even older data intact (don't wipe out all history)
     deleted=$(pihole-FTL sqlite3 -ni "${DBFILE}" "DELETE FROM query_storage WHERE timestamp >= strftime('%s','now')-86400; select changes() from query_storage limit 1")
 
     # Restart FTL
-    restart_service pihole-FTL >/dev/null
+    service pihole-FTL restart
     if [[ "$*" != *"quiet"* ]]; then
         echo -e "${OVER}  ${TICK} Deleted ${deleted} queries from long-term query database"
     fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -116,11 +116,11 @@ c=70
 PIHOLE_META_PACKAGE_CONTROL_APT=$(
     cat <<EOM
 Package: pihole-meta
-Version: 0.4
+Version: 0.3
 Maintainer: Pi-hole team <adblock@pi-hole.net>
 Architecture: all
 Description: Pi-hole dependency meta package
-Depends: awk,bash-completion,binutils,ca-certificates,cron|cron-daemon,curl,dialog,dnsutils,dns-root-data,git,grep,iproute2,iputils-ping,jq,libcap2,libcap2-bin,lshw,netcat-openbsd,procps,psmisc,sudo,unzip
+Depends: grep,dnsutils,binutils,git,iproute2,dialog,ca-certificates,cron | cron-daemon,curl,iputils-ping,psmisc,sudo,unzip,libcap2-bin,dns-root-data,libcap2,netcat-openbsd,procps,jq,lshw,bash-completion
 Section: contrib/metapackages
 Priority: optional
 EOM
@@ -130,12 +130,12 @@ EOM
 PIHOLE_META_PACKAGE_CONTROL_RPM=$(
     cat <<EOM
 Name: pihole-meta
-Version: 0.2
+Version: 0.1
 Release: 1
 License: EUPL
 BuildArch: noarch
 Summary: Pi-hole dependency meta package
-Requires: bash-completion,bind-utils,binutils,ca-certificates,chkconfig,cronie,curl,dialog,findutils,gawk,git,grep,iproute,jq,libcap,lshw,nmap-ncat,procps-ng,psmisc,sudo,unzip
+Requires: grep,curl,psmisc,sudo, unzip,jq,git,dialog,ca-certificates, bind-utils, iproute, procps-ng, chkconfig, binutils, cronie, findutils, libcap, nmap-ncat, lshw, bash-completion
 %description
 Pi-hole dependency meta package
 %prep
@@ -143,9 +143,6 @@ Pi-hole dependency meta package
 %files
 %install
 %changelog
-* Wed May 28 2025 Pi-hole Team - 0.2
-- Add gawk to the list of dependencies
-
 * Sun Sep 29 2024 Pi-hole Team - 0.1
 - First version being packaged
 EOM
@@ -229,15 +226,6 @@ is_command() {
     local check_command="$1"
 
     command -v "${check_command}" >/dev/null 2>&1
-}
-
-is_pid1() {
-    # Checks to see if the given command runs as PID 1
-    local is_pid1="$1"
-
-    # select PID 1, format output to show only CMD column without header
-    # quietly grep for a match on the function passed parameter
-    ps --pid 1 --format comm= | grep -q "${is_pid1}"
 }
 
 # Compatibility
@@ -1164,7 +1152,7 @@ installConfigs() {
     fi
 
     # Install pihole-FTL systemd or init.d service, based on whether systemd is the init system or not
-    if is_pid1 systemd; then
+    if ps -p 1 -o comm= | grep -q systemd; then
         install -T -m 0644 "${PI_HOLE_LOCAL_REPO}/advanced/Templates/pihole-FTL.systemd" '/etc/systemd/system/pihole-FTL.service'
 
         # Remove init.d service if present
@@ -1232,12 +1220,9 @@ stop_service() {
     # Can softfail, as process may not be installed when this is called
     local str="Stopping ${1} service"
     printf "  %b %s..." "${INFO}" "${str}"
-    # If systemd is PID 1,
-    if is_pid1 systemd; then
-        # use that to restart the service
+    if is_command systemctl; then
         systemctl -q stop "${1}" || true
     else
-        # Otherwise, fall back to the service command
         service "${1}" stop >/dev/null || true
     fi
     printf "%b  %b %s...\\n" "${OVER}" "${TICK}" "${str}"
@@ -1248,8 +1233,8 @@ restart_service() {
     # Local, named variables
     local str="Restarting ${1} service"
     printf "  %b %s..." "${INFO}" "${str}"
-    # If systemd is PID 1,
-    if is_pid1 systemd; then
+    # If systemctl exists,
+    if is_command systemctl; then
         # use that to restart the service
         systemctl -q restart "${1}"
     else
@@ -1264,8 +1249,8 @@ enable_service() {
     # Local, named variables
     local str="Enabling ${1} service to start on reboot"
     printf "  %b %s..." "${INFO}" "${str}"
-    # If systemd is PID1,
-    if is_pid1 systemd; then
+    # If systemctl exists,
+    if is_command systemctl; then
         # use that to enable the service
         systemctl -q enable "${1}"
     else
@@ -1280,8 +1265,8 @@ disable_service() {
     # Local, named variables
     local str="Disabling ${1} service"
     printf "  %b %s..." "${INFO}" "${str}"
-    # If systemd is PID1,
-    if is_pid1 systemd; then
+    # If systemctl exists,
+    if is_command systemctl; then
         # use that to disable the service
         systemctl -q disable "${1}"
     else
@@ -1292,8 +1277,8 @@ disable_service() {
 }
 
 check_service_active() {
-    # If systemd is PID1,
-    if is_pid1 systemd; then
+    # If systemctl exists,
+    if is_command systemctl; then
         # use that to check the status of the service
         systemctl -q is-enabled "${1}" 2>/dev/null
     else

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -13,11 +13,6 @@ source "/opt/pihole/COL_TABLE"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "/opt/pihole/utils.sh"
 
-SKIP_INSTALL="true"
-# shellcheck source="./automated install/basic-install.sh"
-source "${PI_HOLE_FILES_DIR}/automated install/basic-install.sh"
-# stop_service() is defined in basic-install.sh
-
 ADMIN_INTERFACE_DIR=$(getFTLConfigValue "webserver.paths.webroot")$(getFTLConfigValue "webserver.paths.webhome")
 readonly ADMIN_INTERFACE_DIR
 
@@ -107,7 +102,11 @@ removePiholeFiles() {
     # Remove FTL
     if command -v pihole-FTL &> /dev/null; then
         echo -ne "  ${INFO} Removing pihole-FTL..."
-        stop_service pihole-FTL
+        if [[ -x "$(command -v systemctl)" ]]; then
+            systemctl stop pihole-FTL
+        else
+            service pihole-FTL stop
+        fi
         ${SUDO} rm -f /etc/systemd/system/pihole-FTL.service
         if [[ -d '/etc/systemd/system/pihole-FTL.service.d' ]]; then
             read -rp "  ${QST} FTL service override directory /etc/systemd/system/pihole-FTL.service.d detected. Do you wish to remove this from your system? [y/N] " answer

--- a/test/_centos_10.Dockerfile
+++ b/test/_centos_10.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream10
 # Disable SELinux
 RUN echo "SELINUX=disabled" > /etc/selinux/config
-RUN yum install -y --allowerasing curl git
+RUN yum install -y --allowerasing curl git initscripts
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_centos_9.Dockerfile
+++ b/test/_centos_9.Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream9
 # Disable SELinux
 RUN echo "SELINUX=disabled" > /etc/selinux/config
-RUN yum install -y --allowerasing curl git
+RUN yum install -y --allowerasing curl git initscripts
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_fedora_40.Dockerfile
+++ b/test/_fedora_40.Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:40
-RUN dnf install -y git
+RUN dnf install -y git initscripts
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_fedora_41.Dockerfile
+++ b/test/_fedora_41.Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:41
-RUN dnf install -y git
+RUN dnf install -y git initscripts
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/_fedora_42.Dockerfile
+++ b/test/_fedora_42.Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:42
-RUN dnf install -y git gawk
+RUN dnf install -y git initscripts
 
 ENV GITDIR=/etc/.pihole
 ENV SCRIPTDIR=/opt/pihole

--- a/test/test_any_automated_install.py
+++ b/test/test_any_automated_install.py
@@ -66,14 +66,6 @@ def test_installPihole_fresh_install_readableFiles(host):
     mock_command("dialog", {"*": ("", "0")}, host)
     # mock git pull
     mock_command_passthrough("git", {"pull": ("", "0")}, host)
-    # mock PID 1 to pretend to be systemd
-    mock_command_2(
-        "ps",
-        {
-            "--pid 1": ("systemd", "0"),
-        },
-        host,
-    )
     # mock systemctl to not start FTL
     mock_command_2(
         "systemctl",
@@ -81,7 +73,6 @@ def test_installPihole_fresh_install_readableFiles(host):
             "enable pihole-FTL": ("", "0"),
             "restart pihole-FTL": ("", "0"),
             "start pihole-FTL": ("", "0"),
-            "stop pihole-FTL": ("", "0"),
             "*": ('echo "systemctl call with $@"', "0"),
         },
         host,
@@ -139,6 +130,13 @@ def test_installPihole_fresh_install_readableFiles(host):
     # readable macvendor.db
     check_macvendor = test_cmd.format("r", "/etc/pihole/macvendor.db", piholeuser)
     actual_rc = host.run(check_macvendor).rc
+    assert exit_status_success == actual_rc
+    # check readable and executable /etc/init.d/pihole-FTL
+    check_init = test_cmd.format("x", "/etc/init.d/pihole-FTL", piholeuser)
+    actual_rc = host.run(check_init).rc
+    assert exit_status_success == actual_rc
+    check_init = test_cmd.format("r", "/etc/init.d/pihole-FTL", piholeuser)
+    actual_rc = host.run(check_init).rc
     assert exit_status_success == actual_rc
     # check readable and executable manpages
     if maninstalled is True:


### PR DESCRIPTION
Reverts pi-hole/pi-hole#6245

The changes are causing problems with scripts that source other scripts with masked `readonly` variables and attempts to redeclare readonly variables.

https://github.com/pi-hole/pi-hole/issues/6259

A new PR should be done for that with an eye on `local -r <VARIABLE>` in the downstream scripts that source `pihole` where variables are declared as `readonly` and then the same variable name is attempted to be used and assigned in the downstream script.

I think we'll need to change the package version to 0.5 as we can't step back to version 0.3? @yubiuser can you see if that is true?