### PR TITLE
Fix for ARM64 CPU with 32bit OS

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1849,9 +1849,18 @@ get_binary_name() {
 
     # If the machine is aarch64 (armv8)
     if [[ "${machine}" == "aarch64" ]]; then
-        # If AArch64 is found (e.g., BCM2711 in Raspberry Pi 4)
-        printf "%b  %b Detected AArch64 (64 Bit ARM) architecture\\n" "${OVER}" "${TICK}"
-        l_binary="pihole-FTL-arm64"
+        if [[ "$(getconf LONG_BIT)" == "64" ]]; then
+            # If the OS is 64 bit, we use the arm64 binary
+            printf "%b  %b Detected AArch64 (64 Bit ARM) architecture\\n" "${OVER}" "${TICK}"
+            l_binary="pihole-FTL-arm64"
+        else
+            # If the OS is 32 bit, we use the armv7 binary (aarch64 is actually armv8)
+            # Even though the machine is 64 bit capable, this makes debugging
+            # very hard as 32bit tools like gdb, etc. cannot analyze the 64 bit
+            # binary. See FTL issue #2494 for such an example.
+            printf "%b  %b Detected AArch64 (64 Bit ARM) architecture with 32 bit OS\\n" "${OVER}" "${TICK}"
+            l_binary="pihole-FTL-armv7"
+        fi
     elif [[ "${machine}" == "arm"* ]]; then
         # ARM 32 bit
         # Get supported processor from other binaries installed on the system


### PR DESCRIPTION
# What does this implement/fix?

Install ARMv7 binary even when we detect a 64bit (aarch64) CPU but the operating system is 32bit. See FTL#2494 for reference. While the 64 bit binary can run just fine, debugging it is difficult as all system-provided tools (`file`, `gdb`, `addr2line`, etc.) cannot parse the 64 bit binary.

This PR is not meant to go straight it but rather serve as a ground for discussion: Do we want to change this? We can also leave it as is and then have to remember to instruct users to manually replace the binary in case we want to work with them on a crash. 64-bit binaries offer advantages in memory addressing and data handling that can lead to performance improvements in certain scenarios.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.