### PR TITLE
Add dependency check function to avoid installing the same version of pihole-meta package repeatedly 

### DIFF
--- a/advanced/Scripts/update.sh
+++ b/advanced/Scripts/update.sh
@@ -27,6 +27,7 @@ source "/opt/pihole/COL_TABLE"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "${PI_HOLE_INSTALL_DIR}/utils.sh"
 
+# check_for_meta_package() sourced from basic-install.sh
 # is_repo() sourced from basic-install.sh
 # make_repo() sourced from basic-install.sh
 # update_repo() source from basic-install.sh
@@ -112,11 +113,16 @@ main() {
     web_update=false
     FTL_update=false
 
+    # used as a signal to exit check_for_meta_package() early when
+    # the meta package is found as new data has NOT been downloaded yet
+    IS_UPDATE=true
 
-    # Install packages used by this installation script (necessary if users have removed e.g. git from their systems)
-    package_manager_detect
-    build_dependency_package
-    install_dependent_packages
+    # Check for supported package managers and install needed dependencies if missing
+    if ! check_for_meta_package; then
+        package_manager_detect
+        build_dependency_package
+        install_dependent_packages
+    fi
 
     # This is unlikely
     if ! is_repo "${PI_HOLE_FILES_DIR}" ; then

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -231,6 +231,10 @@ is_command() {
     command -v "${check_command}" >/dev/null 2>&1
 }
 
+VersionConverter() {
+  echo "$@" | tr -d '[:alpha:]' | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }';
+}
+
 # Compatibility
 package_manager_detect() {
 
@@ -366,6 +370,95 @@ build_dependency_package(){
 
     # Remove the build directory
     rm -rf "${tempdir}"
+}
+
+# Check for pihole-meta dependency package
+check_for_meta_package(){
+
+    local installed_version version_to_be_installed
+
+    local str="Checking for Pi-hole dependency package"
+    printf "  %b %s..." "${INFO}" "${str}"
+
+    if is_command apt-get; then
+       # Debian/Ubuntu check for pihole-meta package
+       if [[ $(dpkg -s pihole-meta 2> /dev/null) ]]; then
+          # we can check $IS_UPDATE to know if we are coming from update.sh
+          # and can exit early as the meta package hasn't change yet
+          if [[ "${IS_UPDATE}" == true ]]; then
+             printf " found.\n"
+             return 0
+          fi
+
+          installed_version=$(dpkg -s pihole-meta 2> /dev/null | grep '^Version:' | cut -d' ' -f2)
+          version_to_be_installed=$(echo "${PIHOLE_META_PACKAGE_CONTROL_APT}" | grep '^Version:' | cut -d' ' -f2)
+       else
+          # install the pihole-meta package as it is likely a fresh install or removed inadvertently
+          printf " not installed.\n"
+          return 1
+       fi
+
+    elif is_command rpm; then
+       # Fedora/CentOS check for pihole-meta package
+       if [[ $(rpm -q pihole-meta 2>/dev/null) ]]; then
+          # we can check $IS_UPDATE to know if coming from update.sh
+          # and can exit early as meta package hasn't changed yet
+          if [[ "${IS_UPDATE}" == true ]]; then
+             printf " found.\n"
+             return 0
+          fi
+
+          installed_version=$(rpm -q pihole-meta 2> /dev/null | grep '^Version:' | cut -d' ' -f2)
+          version_to_be_installed=$(echo "${PIHOLE_META_PACKAGE_CONTROL_RPM}" | grep '^Version:' | cut -d' ' -f2)
+       else
+          # install the pihole-meta package as it is likely a fresh install or removed inadvertently
+          printf " not installed."
+          return 1
+       fi
+
+    # If neither apt-get or yum/dnf package managers were found
+    else
+       # we cannot install the dependency package
+       printf "  %b No supported package manager found.\\n" "${CROSS}"
+       # so exit the installer
+       exit 1
+    fi
+
+    local installed_version_number version_number_to_be_installed
+
+    # convert version number so it is easier to compare
+    installed_version_number="$(VersionConverter "${installed_version}")"
+    version_number_to_be_installed="$(VersionConverter "${version_to_be_installed}")"
+
+    # If we make it here, pihole-meta package is installed so we should check to make
+    # sure we aren't installing the same version again needlessly during an update
+    if [[ version_number_to_be_installed -eq installed_version_number ]]; then
+       # do nothing as the newest available pihole-meta package is installed
+       printf " already installed and up to date.\n"
+       return 0
+
+    elif [[ version_number_to_be_installed -gt installed_version_number ]]; then
+       # install the new pihole-meta package
+       printf " needs to be upgraded.\n"
+       return 1
+
+    # We should also check for a lower version number as there is potential
+    # to end up here when going from Development branch back to Master branch
+    elif [[ version_number_to_be_installed -lt installed_version_number ]]; then
+
+       printf " needs to be downgraded.\n"
+       # Setup package manager commands so we can downgrade meta package
+       package_manager_detect
+
+       # remove currently installed meta package as version is lower than what is to soon be installed
+       local downgrade_str="Removing previously installed Pi-hole dependency package"
+       printf "  %b %s..." "${INFO}" "${downgrade_str}"
+       eval "${PKG_REMOVE}" "pihole-meta" &>/dev/null
+       printf "done.\n"
+       # install the new pihole-meta package
+       return 1
+    fi
+
 }
 
 # A function for checking if a directory is a git repository
@@ -2193,17 +2286,20 @@ main() {
     # Check for availability of either the "service" or "systemctl" commands
     check_service_command
 
-    # Check for supported package managers so that we may install dependencies
-    package_manager_detect
+    # Check for pihole-meta package
+    if ! check_for_meta_package; then
+        # Check for supported package managers and setup variables used to install dependencies
+        package_manager_detect
 
-    # Notify user of package availability
-    notify_package_updates_available
+        # Notify user of package update availability
+        notify_package_updates_available
 
-    # Build dependency package
-    build_dependency_package
+        # Build dependency package (pihole-meta)
+        build_dependency_package
 
-    # Install Pi-hole dependencies
-    install_dependent_packages
+        # Install Pi-hole dependencies
+        install_dependent_packages
+    fi
 
 
     # Check if there is a usable FTL binary available on this architecture - do


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

only installs `pihole-meta` package when the version number has changed or when not installed

potentially addresses #6272 and will 

Lessen the resource impact mentioned here

> running a package cache update is a resource intensive process on SD cards.

**How does this PR accomplish the above?:**

adds function `check_for_meta_package()` (name can be changed if needed/wanted) that will check if `pihole-meta` package is installed and only runs package management functions if `pihole-meta` package is missing or version number has changed.


also adds `VersionConverter()` from [PADD](https://github.com/pi-hole/PADD/blob/master/padd.sh#L1357) to make version number comparison easier.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
