### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,8 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   target-branch: development
-  versioning-strategy: increase
   groups:
-    github-actions:
+    github-actions-dependencies:
       patterns:
         - "*"
 - package-ecosystem: pip
@@ -21,8 +20,7 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   target-branch: development
-  versioning-strategy: increase
   groups:
-    github-actions:
+    python-dependencies:
       patterns:
         - "*"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes dependabot. There is no `versioning-strategy` for `github-actions` (See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--). 

And it's the default strategy for apps anyway is `increase`

![2025-06-09_19-06](https://github.com/user-attachments/assets/176ea090-653f-43bb-a763-cd839b1ddd30)


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
