### PR TITLE
piholeDebug - Get default route robustly

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -497,16 +497,25 @@ ping_gateway() {
     ping_ipv4_or_ipv6 "${protocol}"
     # Check if we are using IPv4 or IPv6
     # Find the default gateways using IPv4 or IPv6
-    local gateway gateway_addr gateway_iface
+    local gateway gateway_addr gateway_iface default_route
 
     log_write "${INFO} Default IPv${protocol} gateway(s):"
 
-    while IFS= read -r gateway; do
-        log_write "     $(cut -d ' ' -f 3 <<< "${gateway}")%$(cut -d ' ' -f 5 <<< "${gateway}")"
-    done < <(ip -"${protocol}" route | grep default)
+    while IFS= read -r default_route; do
+        gateway_addr=$(jq -r '.gateway' <<< "${default_route}")
+        gateway_iface=$(jq -r '.dev' <<< "${default_route}")
+        log_write "     ${gateway_addr}%${gateway_iface}"
+    done < <(ip -j -"${protocol}" route | jq -c '.[] | select(.dst == "default")')
 
-    gateway_addr=$(ip -"${protocol}" route | grep default | cut -d ' ' -f 3 | head -n 1)
-    gateway_iface=$(ip -"${protocol}" route | grep default | cut -d ' ' -f 5 | head -n 1)
+    # Find the first default route
+    default_route=$(ip -j -"${protocol}" route show default)
+    if echo "$default_route" | grep 'gateway' | grep -q 'dev'; then
+        gateway_addr=$(echo "$default_route" | jq -r -c '.[0].gateway')
+        gateway_iface=$(echo "$default_route" | jq -r -c '.[0].dev')
+    else
+        log_write "     Unable to determine gateway address for IPv${protocol}"
+    fi
+
     # If there was at least one gateway
     if [ -n "${gateway_addr}" ]; then
         # Append the interface to the gateway address if it is a link-local address


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Get information about the default route in a more reliable way.

Problem with identifying this information noted on discourse and at bug https://github.com/pi-hole/FTL/issues/2525

**How does this PR accomplish the above?:**

Determine address and interface of default route by preceding 'via' and 'dev' fields in ip's json output, instead of field position in the plain text which is not always reliable.

Logs if unable to determine default gateway

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
