### PR TITLE
Update Firewalld tests to match v6 ports

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -388,14 +388,6 @@ check_firewalld() {
                 else
                     log_write "${CROSS} ${COL_RED}  Local Interface Not Detected${COL_NC} (${FAQ_HARDWARE_REQUIREMENTS_FIREWALLD})"
                 fi
-                # check FTL custom zone port: 4711
-                local firewalld_ftl_zone_ports
-                firewalld_ftl_zone_ports=$(firewall-cmd --zone=ftl --list-ports)
-                if [[ "${firewalld_ftl_zone_ports}" =~ "4711/tcp" ]]; then
-                    log_write "${TICK} ${COL_GREEN}  FTL Port 4711/tcp Detected${COL_NC}";
-                else
-                    log_write "${CROSS} ${COL_RED}  FTL Port 4711/tcp Not Detected${COL_NC} (${FAQ_HARDWARE_REQUIREMENTS_FIREWALLD})"
-                fi
             else
                 log_write "${CROSS} ${COL_RED}FTL Custom Zone Not Detected${COL_NC} (${FAQ_HARDWARE_REQUIREMENTS_FIREWALLD})"
             fi

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -367,7 +367,7 @@ check_firewalld() {
             # test common required service ports
             local firewalld_enabled_services
             firewalld_enabled_services=$(firewall-cmd --list-services)
-            local firewalld_expected_services=("http" "dns" "dhcp" "dhcpv6")
+            local firewalld_expected_services=("http" "https" "dns" "dhcp" "dhcpv6" "ntp")
             for i in "${firewalld_expected_services[@]}"; do
                 if [[ "${firewalld_enabled_services}" =~ ${i} ]]; then
                     log_write "${TICK} ${COL_GREEN}  Allow Service: ${i}${COL_NC}";


### PR DESCRIPTION
### What does this PR aim to accomplish?

Port 4711 was used by Pi-hole v5, but this port is not used by Pi-hole v6.

Also add HTTPS and NTP services.
 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
