### PR TITLE
Do not skip root check for pihole user

### DIFF
--- a/pihole
+++ b/pihole
@@ -570,9 +570,9 @@ if [[ -z ${USER} ]]; then
   USER=$(whoami)
 fi
 
-# Check if the current user is neither root nor pihole and if the command
+# Check if the current user is not root and if the command
 # requires root. If so, exit with an error message.
-if [[ $EUID -ne 0 && ${USER} != "pihole" && need_root -eq 1 ]];then
+if [[ $EUID -ne 0 && need_root -eq 1 ]];then
   echo -e "  ${CROSS} The Pi-hole command requires root privileges, try:"
   echo -e "      ${COL_GREEN}sudo pihole $*${COL_NC}"
   exit 1


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Some 'pihole' commands need root powers. If we are not root but the command requires it, we error out. However, so far we made an exception for the `pihole` user. But this led to issues like https://discourse.pi-hole.net/t/unable-to-change-or-remove-password/80599.

This PR removes the exception.
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
