### PR TITLE
taillog Prevent grep interpeting search term as an option

### DIFF
--- a/pihole
+++ b/pihole
@@ -396,7 +396,7 @@ tailFunc() {
   # Color blocklist/denylist/wildcard entries as red
   # Color A/AAAA/DHCP strings as white
   # Color everything else as gray
-  tail -f $LOGFILE | grep --line-buffered "${1}" | sed -E \
+  tail -f $LOGFILE | grep --line-buffered -- "${1}" | sed -E \
     -e "s,($(date +'%b %d ')| dnsmasq\[[0-9]*\]),,g" \
     -e "s,(.*(denied |gravity blocked ).*),${COL_RED}&${COL_NC}," \
     -e "s,.*(query\\[A|DHCP).*,${COL_NC}&${COL_NC}," \


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Allows `pihole tail` to search for string beginning with a hyphen.

At present, if a search string beginning with a hyphen is entered grep interpets it as a command. Only a single command line term is passed, so this typically results in a grep error message:

```
alpine:~$ sudo pihole tail -known
  [i] Press Ctrl-C to exit
grep: invalid option -- 'k'
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
```
**How does this PR accomplish the above?:**

Adds the option `--` before the user supplied string, preventing grep from misinterpreting it as an option.

```
alpine:~$ sudo pihole tail -known
  [i] Press Ctrl-C to exit
06:42:01: using only locally-known addresses for onion
06:42:01: using only locally-known addresses for bind
06:42:01: using only locally-known addresses for invalid
06:42:01: using only locally-known addresses for localhost
06:42:01: using only locally-known addresses for test
06:42:01: using only locally-known addresses for pi.hole
06:42:01: using only locally-known addresses for lan
```
**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
