### PR TITLE
Speed up pihole --query

### DIFF
--- a/advanced/Scripts/query.sh
+++ b/advanced/Scripts/query.sh
@@ -37,19 +37,16 @@ Options:
 }
 
 GenerateOutput() {
-    local data gravity_data lists_data num_gravity num_lists search_type_str
-    local gravity_data_csv lists_data_csv line current_domain url type color
+    local counts data num_gravity num_lists search_type_str
+    local gravity_data_csv lists_data_csv line url type color
     data="${1}"
 
-    # construct a new json for the list results where each object contains the domain and the related type
-    lists_data=$(printf %s "${data}" | jq '.search.domains | [.[] | {domain: .domain, type: .type}]')
-
-    # construct a new json for the gravity results where each object contains the adlist URL and the related domains
-    gravity_data=$(printf %s "${data}" | jq '.search.gravity  | group_by(.address,.type) | map({ address: (.[0].address), type: (.[0].type), domains: [.[] | .domain] })')
-
-    # number of objects in each json
-    num_gravity=$(printf %s "${gravity_data}" | jq length)
-    num_lists=$(printf %s "${lists_data}" | jq length)
+    # Get count of list and gravity matches
+    # Use JQ to count number of entries in lists and gravity
+    # (output is number of list matches then number of gravity matches)
+    counts=$(printf %s "${data}" | jq --raw-output '(.search.domains | length), (.search.gravity | group_by(.address,.type) | length)')
+    num_lists=$(echo "$counts" | sed -n '1p')
+    num_gravity=$(echo "$counts" | sed -n '2p')
 
     if [ "${partial}" = true ]; then
         search_type_str="partially"
@@ -62,7 +59,7 @@ GenerateOutput() {
     if [ "${num_lists}" -gt 0 ]; then
         # Convert the data to a csv, each line is a "domain,type" string
         # not using jq's @csv here as it quotes each value individually
-        lists_data_csv=$(printf %s "${lists_data}" | jq --raw-output '.[] | [.domain, .type] | join(",")')
+        lists_data_csv=$(printf %s "${data}" | jq --raw-output '.search.domains | map([.domain, .type] | join(",")) | join("\n")')
 
         # Generate output for each csv line, separating line in a domain and type substring at the ','
         echo "${lists_data_csv}" | while read -r line; do
@@ -73,9 +70,9 @@ GenerateOutput() {
     # Results from gravity
     printf "%s\n\n" "Found ${num_gravity} adlists ${search_type_str} matching '${COL_BLUE}${domain}${COL_NC}'."
     if [ "${num_gravity}" -gt 0 ]; then
-        # Convert the data to a csv, each line is a "URL,domain,domain,...." string
+        # Convert the data to a csv, each line is a "URL,type,domain,domain,...." string
         # not using jq's @csv here as it quotes each value individually
-        gravity_data_csv=$(printf %s "${gravity_data}" | jq --raw-output '.[] | [.address, .type, .domains[]] | join(",")')
+        gravity_data_csv=$(printf %s "${data}" | jq --raw-output '.search.gravity | group_by(.address,.type) | map([.[0].address, .[0].type, (.[] | .domain)] | join(",")) | join("\n")')
 
         # Generate line-by-line output for each csv line
         echo "${gravity_data_csv}" | while read -r line; do
@@ -97,15 +94,8 @@ GenerateOutput() {
 
             # cut off type, leaving "domain,domain,...."
             line=${line#*,}
-            # print each domain and remove it from the string until nothing is left
-            while [ ${#line} -gt 0 ]; do
-                current_domain=${line%%,*}
-                printf '    - %s\n' "${COL_GREEN}${current_domain}${COL_NC}"
-                # we need to remove the current_domain and the comma in two steps because
-                # the last domain won't have a trailing comma and the while loop wouldn't exit
-                line=${line#"${current_domain}"}
-                line=${line#,}
-            done
+            # Replace commas with newlines and format output
+            echo "${line}" | sed 's/,/\n/g' | sed "s/^/    - ${COL_GREEN}/" | sed "s/$/${COL_NC}/"
             printf "\n\n"
         done
     fi


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Speed up the `pihole --query` command

**How does this PR accomplish the above?:**

Simplifies the processing when querying the lists for domains.

Count list and gravity matches using jq in a single step, eliminating intermediate json.

Overall, reduces the number of times jq is called from 3 to 1 if no matches are found, and from 6 to 3 if there are matches in both local lists and gravity.

Eliminates the while loop for each list's final output and formatting.

Approximately 20% speedup for simple queries on test systems (Figures from a raspberry pi 2b running bookworm below, similar percentage noted on more capable systems). Most of this comes from the simplification of the jq processing.

Additional speedup for queries made with `--all`, much of which comes from eliminating the final while loop for output.
Such as worstish case query: `pihole --query --partial --all com` (many many lines of output not shown):

From:
```
real	8m50.663s
user	7m54.327s
sys	0m34.987s
```

to:
```
real	0m40.382s
user	0m18.300s
sys	0m1.798s
```

Search partials with matches

Before:
```
# time pihole --query zone --partial
Found 0 domains partially matching 'zone'.

Found 1 adlists partially matching 'zone'.

  - https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts (block)

    - fraud.adjoe.zone
    - prod.fraud.adjoe.zone
    - prod.adjoe.zone
    - iqzone.com
    - pssvc.iqzone.com
    - autozone.com.102.122.2o7.net
    - sanalytics.verizonenterprise.com
    - sanalytics.autozone.com
    - rewardszoneusa.com
    - www.freedownloadzone.com
    - www.rewardszoneusa.com
    - 1zone1.free.fr
    - advzone.ioe.vn
    - corezone.pl
    - www.corezone.pl
    - adzoneify.com
    - adzonex.com
    - aetherzone.lat
    - aetherzone.site
    - ahautozone.com



real	0m5.514s
user	0m2.996s
sys	0m0.199s
```

AFTER:
```
# time pihole --query zone --partial
Found 0 domains partially matching 'zone'.

Found 1 adlists partially matching 'zone'.

  - https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts (block)

    - fraud.adjoe.zone
    - prod.fraud.adjoe.zone
    - prod.adjoe.zone
    - iqzone.com
    - pssvc.iqzone.com
    - autozone.com.102.122.2o7.net
    - sanalytics.verizonenterprise.com
    - sanalytics.autozone.com
    - rewardszoneusa.com
    - www.freedownloadzone.com
    - www.rewardszoneusa.com
    - 1zone1.free.fr
    - advzone.ioe.vn
    - corezone.pl
    - www.corezone.pl
    - adzoneify.com
    - adzonex.com
    - aetherzone.lat
    - aetherzone.site
    - ahautozone.com



real	0m4.702s
user	0m2.151s
sys	0m0.231s
```


Search partials with no matches:

Before:
```
# time pihole --query qjaz --partial
Found 0 domains partially matching 'qjaz'.

Found 0 adlists partially matching 'qjaz'.


real	0m5.141s
user	0m2.779s
sys	0m0.157s
```

After:
```
# time pihole --query qjaz --partial
Found 0 domains partially matching 'qjaz'.

Found 0 adlists partially matching 'qjaz'.


real	0m4.329s
user	0m1.953s
sys	0m0.125s
```

Search no matches

Before:
```
# time pihole --query qjaz
Found 0 domains exactly matching 'qjaz'.

Found 0 adlists exactly matching 'qjaz'.

Hint: Try partial matching with
  pihole -q --partial qjaz


real	0m3.517s
user	0m2.749s
sys	0m0.202s
```

After:
```
# time pihole --query qjaz
Found 0 domains exactly matching 'qjaz'.

Found 0 adlists exactly matching 'qjaz'.

Hint: Try partial matching with
  pihole -q --partial qjaz


real	0m2.592s
user	0m1.857s
sys	0m0.157s
```


**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
