### PR TITLE
Re-order authentication errors in verbose mode

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -150,7 +150,6 @@ LoginAPI() {
 
     # Try to login again until the session is valid
     while [ ! "${validSession}" = true ]  ; do
-        echo "Authentication failed. Please enter your Pi-hole password"
 
         # Print the error message if there is one
         if  [ ! "${sessionError}" = "null"  ] && [ "${1}" = "verbose" ]; then
@@ -159,6 +158,14 @@ LoginAPI() {
         # Print the session message if there is one
         if  [ ! "${sessionMessage}" = "null" ] && [ "${1}" = "verbose" ]; then
             echo "Error: ${sessionMessage}"
+        fi
+
+        if  [ "${1}" = "verbose" ]; then
+            # If we are not in verbose mode, no need to print the error message again
+            echo "Please enter your Pi-hole password"
+        else
+
+            echo "Authentication failed. Please enter your Pi-hole password"
         fi
 
         # secretly read the password


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We have a verbose mode in `pihole api` which prints more detailed information. I noticed, some information is duplicated and the order seems wrong (re-enter password before error message).

This PR re-order things.

Before

```
nanopi@nanopi:~$ pihole api verbose stats/summary
API Authentication: CLI password not available
Please enter your password:

Please enter the correct second factor.
(Can be any number if you used the app password)

API Authentication: Failed
Authentication failed. Please enter your Pi-hole password       <-------
Error: password incorrect                                         <--------
****
Please enter the correct second factor:
(Can be any number if you used the app password)

API Authentication: Failed
Authentication failed. Please enter your Pi-hole password          <-------
Error: Invalid 2FA token                                                 <-------
```

After

```
nanopi@nanopi:~$ pihole api verbose stats/summary
API Authentication: CLI password not available
Please enter your password:
*******
Please enter the correct second factor.
(Can be any number if you used the app password)

API Authentication: Failed
Error: password incorrect                                                                <-------
Please enter your Pi-hole password                                              <-------
****
Please enter the correct second factor:
(Can be any number if you used the app password)
23423324
API Authentication: Failed
Error: Invalid 2FA token                                                                 <-------
Please enter your Pi-hole password                                           <-------
```

After (non-verbose)

```
nanopi@nanopi:~$ pihole api stats/summary
Please enter your password:
******
Please enter the correct second factor.
(Can be any number if you used the app password)

Authentication failed. Please enter your Pi-hole password
```



---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
