### PR TITLE
Remove `readonly` from list.sh to avoid errors

### DIFF
--- a/advanced/Scripts/list.sh
+++ b/advanced/Scripts/list.sh
@@ -9,12 +9,12 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
-readonly PI_HOLE_SCRIPT_DIR="/opt/pihole"
-readonly utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
+PI_HOLE_SCRIPT_DIR="/opt/pihole"
+utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "${utilsfile}"
 
-readonly apifile="${PI_HOLE_SCRIPT_DIR}/api.sh"
+apifile="${PI_HOLE_SCRIPT_DIR}/api.sh"
 # shellcheck source="./advanced/Scripts/api.sh"
 source "${apifile}"
 


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix issues when some variables marked as `readonly` are declared multiple times, in a file and also in a sourced file.

### How does this PR accomplish the above?

Removing `readonly` from `list.sh`

**Link documentation PRs if any are needed to support this PR:**

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
