### PR TITLE
Revert "pihole api - use keepalive for curl queries"

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -55,7 +55,7 @@ TestAPIAvailability() {
         API_URL="${API_URL#\"}"
 
         # Test if the API is available at this URL, include delimiter for ease in splitting payload
-        authResponse=$(curl --connect-timeout 2 -skS -H "Connection: keep-alive" -w ">>%{http_code}" "${API_URL}auth")
+        authResponse=$(curl --connect-timeout 2 -skS -w ">>%{http_code}" "${API_URL}auth")
 
         # authStatus is the response http_code, eg. 200, 401.
         # Shell parameter expansion, remove everything up to and including the >> delim
@@ -184,7 +184,7 @@ LoginAPI() {
 }
 
 Authentication() {
-    sessionResponse=$(curl --connect-timeout 2 -skS -H "Connection: keep-alive" -X POST "${API_URL}auth" --user-agent "Pi-hole cli" --data "{\"password\":\"${password}\", \"totp\":${totp:-null}}")
+    sessionResponse="$(curl --connect-timeout 2 -skS -X POST "${API_URL}auth" --user-agent "Pi-hole cli" --data "{\"password\":\"${password}\", \"totp\":${totp:-null}}" )"
 
     if [ -z "${sessionResponse}" ]; then
         echo "No response from FTL server. Please check connectivity"
@@ -219,7 +219,7 @@ LogoutAPI() {
     # SID is not null (successful Authentication only), delete the session
     if [ "${validSession}" = true ] && [ ! "${SID}" = null ]; then
         # Try to delete the session. Omit the output, but get the http status code
-        deleteResponse=$(curl -skS -o /dev/null -w "%{http_code}" -X DELETE "${API_URL}auth" -H "Accept: application/json" -H "sid: ${SID}" -H "Connection: keep-alive")
+        deleteResponse=$(curl -skS -o /dev/null -w "%{http_code}" -X DELETE "${API_URL}auth"  -H "Accept: application/json" -H "sid: ${SID}")
 
         case "${deleteResponse}" in
             "401") echo "Logout attempt without a valid session. Unauthorized!";;
@@ -233,7 +233,7 @@ LogoutAPI() {
 GetFTLData() {
   local data response status
   # get the data from querying the API as well as the http status code
-  response=$(curl -skS -w "%{http_code}" -X GET "${API_URL}$1" -H "Accept: application/json" -H "sid: ${SID}" -H "Connection: keep-alive")
+  response=$(curl -skS -w "%{http_code}" -X GET "${API_URL}$1" -H "Accept: application/json" -H "sid: ${SID}" )
 
   if [ "${2}" = "raw" ]; then
     # return the raw response
@@ -260,7 +260,7 @@ GetFTLData() {
 PostFTLData() {
   local data response status
   # send the data to the API
-  response=$(curl -skS -w "%{http_code}" -X POST "${API_URL}$1" --data-raw "$2" -H "Accept: application/json" -H "sid: ${SID}" -H "Connection: keep-alive")
+  response=$(curl -skS -w "%{http_code}" -X POST "${API_URL}$1" --data-raw "$2" -H "Accept: application/json" -H "sid: ${SID}" )
   # data is everything from response without the last 3 characters
   if [ "${3}" = "status" ]; then
     # Keep the status code appended if requested


### PR DESCRIPTION
Reverts pi-hole/pi-hole#6365

Labelled both as `internal` so that the automatic release note generator doesn't pick them up.

Looking deeper into it (after some internal discussion with @DL6ER) adding the `keep-alive` header does not actually do anything.

From [here](https://reqbin.com/req/c-jjwwaevv/curl-command-with-keep-alive-connection-header#:~:text=HTTP%20versions%20support%20persistent%20connections):

> HTTP/1.1 considers all connections persistent unless otherwise specified and does not require additional -H "Connection: keep-alive" headers.


In fact:

```
curl -I http://127.0.0.1/api/auth
HTTP/1.1 404 Not Found
Cache-Control: no-cache, no-store, must-revalidate, private, max-age=0
Expires: 0
Pragma: no-cache
Content-Security-Policy: default-src 'self' 'unsafe-inline';
X-Frame-Options: ALLOW-FROM abc.com
X-XSS-Protection: 0
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Access-Control-Allow-Credentials: true
Content-Type: application/json; charset=utf-8
Content-Length: 100
Date: Sat, 26 Jul 2025 10:09:00 GMT
Connection: keep-alive
```


Note that 1.1 is default, and the existence of `Connection: keep-alive` here in the response. 