### PR TITLE
When running with --unattended flag, ensure pre-seeded pihole.toml file exists

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -167,6 +167,17 @@ for var in "$@"; do
     esac
 done
 
+if [[ "${runUnattended}" == true ]]; then
+    # In order to run an unattended setup, a pre-seeded /etc/pihole/pihole.toml must exist
+    if [[ ! -f "${PI_HOLE_CONFIG_DIR}/pihole.toml" ]]; then
+        printf "  %b Error: \"%s\" not found. Cannot run unattended setup\\n" "${CROSS}" "${PI_HOLE_CONFIG_DIR}/pihole.toml"
+        exit 1
+    fi
+    printf "  %b Performing unattended setup, no dialogs will be displayed\\n" "${INFO}"
+    # also disable debconf-apt-progress dialogs
+    export DEBIAN_FRONTEND="noninteractive"
+fi
+
 # If the color table file exists,
 if [[ -f "${coltable}" ]]; then
     # source it
@@ -2240,15 +2251,6 @@ main() {
     if [[ "${funcOutput}" == "" ]]; then
         printf "  %b Upgrade/install aborted\\n" "${CROSS}" "${DISTRO_NAME}"
         exit 1
-    fi
-
-    if [[ "${fresh_install}" == false ]]; then
-        # if it's running unattended,
-        if [[ "${runUnattended}" == true ]]; then
-            printf "  %b Performing unattended setup, no dialogs will be displayed\\n" "${INFO}"
-            # also disable debconf-apt-progress dialogs
-            export DEBIAN_FRONTEND="noninteractive"
-        fi
     fi
 
     if [[ "${fresh_install}" == true ]]; then


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

See #6380 

Exits the installer early if no config file is found when passing in the `--unattended` flag. WIthout a config file, FTL cannot be configured.

```
root@adamtest:/etc/.pihole# ./automated\ install/basic-install.sh --unattended
   Error: "/etc/pihole/pihole.toml" not found. Cannot run unattended setup
```

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_