### PR TITLE
Improve curl error message including exit code and error message

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -761,7 +761,7 @@ gravity_DownloadBlocklistFromUrl() {
     # Check if the installed curl version supports the "-w %{errormsg}" option
     # (available as of curl 7.75.0)
     #curlOutputFormat='{ "http_code": "%{http_code}" }'
-    curlOutputFormat='%{http_code}\nnomsg'
+    curlOutputFormat='%{http_code}\nNo message available. Non supported curl version.'
     if curl --help --write-out | grep -q "errormsg" ; then
         curlOutputFormat='%{http_code}\n%{errormsg}'
     fi
@@ -781,11 +781,6 @@ gravity_DownloadBlocklistFromUrl() {
     read -r httpCode;
     read -r curlErrorMsg;
   } < <( echo "${curlOutput}" )
-
-  # If curl is too old to return errormsg, we provide a generic message here
-  if [[ "${curlErrorMsg}" == "nomsg" ]]; then
-    curlErrorMsg="No message available. Non supported curl version."
-  fi
 
   case $url in
   # Did we "download" a local file?


### PR DESCRIPTION
### What does this PR aim to accomplish?

Improve gravity error messages for `curl`, including exit code and error message, when available.

---

Gravity uses the `http_code` returned by `curl` to decide which status and messages should be shown.

The current gravity code considers `000` always as "Connection Refused", but `curl` answers with `000` for many different reasons, like:

- Timeout: exit_code=28
- DNS Resolution Failure: exit_code=6
- Connection Refused: exit_code=7
- Network Unreachability: exit_code=7 (different error message)
- Untrusted Certificate: exit_code=35 or 60 (or other values... I'm not sure).
- and others: "CA Certificate Issues", "Invalid URL", "Client Disconnection"...

Sometimes "Connection Refused" is not the correct error message. 
Showing the correct exit code and message returned by `curl` can simplify the debug process.

<img width="1085" height="903" alt="curl_messages" src="https://github.com/user-attachments/assets/862fc3fd-5dea-4e5c-99c7-8b276ad6e6bf" />


### How does this PR accomplish the above?

We start using `curl` exit code (`$?`) to decide if the command was successful or not.

Then we use the `http_code` returned by `curl` to define what is the correct error message. Also, when using recent `curl` versions, we use the `errormsg` variable to show the message returned by `curl`.

**Note:**
We tried other options using `-w "%{json}"` output, but all attempts only worked when using a very recent `curl` version, which would break gravity output on older OS.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
