### PR TITLE
Loosen requirements for local file access for gravity

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -729,7 +729,7 @@ gravity_DownloadBlocklistFromUrl() {
     # to match the effective runtime user of FTL; otherwise, check the current user's read access
     # (e.g., in Docker or when invoked by a non-root user). The target must
     # resolve to a regular file and be readable by the evaluated user.
-  if [[ "${url}" == "file://"* ]]; then
+  if [[ "${url}" == "file:/"* ]]; then
     # Get the file path
     file_path=$(echo "${url}" | cut -d'/' -f3-)
     # Check if the file exists and is a regular file (i.e. not a socket, fifo, tty, block). Might still be a symlink.

--- a/gravity.sh
+++ b/gravity.sh
@@ -615,7 +615,7 @@ compareLists() {
 gravity_DownloadBlocklistFromUrl() {
   local url="${1}" adlistID="${2}" saveLocation="${3}" compression="${4}" gravity_type="${5}" domain="${6}"
   local listCurlBuffer str httpCode success="" ip customUpstreamResolver=""
-  local file_path permissions ip_addr port blocked=false download=true
+  local file_path ip_addr port blocked=false download=true
   # modifiedOptions is an array to store all the options used to check if the adlist has been changed upstream
   local modifiedOptions=()
 
@@ -724,29 +724,40 @@ gravity_DownloadBlocklistFromUrl() {
     fi
   fi
 
-  # If we are going to "download" a local file, we first check if the target
-  # file has a+r permission. We explicitly check for all+read because we want
-  # to make sure that the file is readable by everyone and not just the user
-  # running the script.
-  if [[ $url == "file://"* ]]; then
+  # If we "download" a local file (file://), verify read access before using it.
+    # When running as root (e.g., via pihole -g), check that the 'pihole' user can read the file
+    # to match the effective runtime user of FTL; otherwise, check the current user's read access
+    # (e.g., in Docker or when invoked by a non-root user). The target must
+    # resolve to a regular file and be readable by the evaluated user.
+  if [[ "${url}" == "file://"* ]]; then
     # Get the file path
-    file_path=$(echo "$url" | cut -d'/' -f3-)
+    file_path=$(echo "${url}" | cut -d'/' -f3-)
     # Check if the file exists and is a regular file (i.e. not a socket, fifo, tty, block). Might still be a symlink.
-    if [[ ! -f $file_path ]]; then
-      # Output that the file does not exist
-      echo -e "${OVER}  ${CROSS} ${file_path} does not exist"
-      download=false
-    else
-      # Check if the file or a file referenced by the symlink has a+r permissions
-      permissions=$(stat -L -c "%a" "$file_path")
-      if [[ $permissions == *4 || $permissions == *5 || $permissions == *6 || $permissions == *7 ]]; then
-        # Output that we are using the local file
-        echo -e "${OVER}  ${INFO} Using local file ${file_path}"
-      else
-        # Output that the file does not have the correct permissions
-        echo -e "${OVER}  ${CROSS} Cannot read file (file needs to have a+r permission)"
+    if [[ ! -f ${file_path} ]]; then
+        # Output that the file does not exist
+        echo -e "${OVER}  ${CROSS} ${file_path} does not exist"
         download=false
-      fi
+    else
+        if [ "$(id -un)" == "root" ]; then
+        # If we are root, we need to check if the pihole user has read permission
+        #  otherwise, we might read files that the pihole user should not be able to read
+      if sudo -u pihole test -r "${file_path}"; then
+                echo -e "${OVER}  ${INFO} Using local file ${file_path}"
+            else
+                echo -e "${OVER}  ${CROSS} Cannot read file (user 'pihole' lacks read permission)"
+                download=false
+            fi
+        else
+            # If we are not root, we just check if the current user has read permission
+            if [[ -r "${file_path}" ]]; then
+                # Output that we are using the local file
+                echo -e "${OVER}  ${INFO} Using local file ${file_path}"
+            else
+                # Output that the file is not readable by the current user
+                echo -e "${OVER}  ${CROSS} Cannot read file (current user '$(id -un)' lacks read permission)"
+                download=false
+            fi
+        fi
     fi
   fi
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -725,10 +725,10 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   # If we "download" a local file (file://), verify read access before using it.
-    # When running as root (e.g., via pihole -g), check that the 'pihole' user can read the file
-    # to match the effective runtime user of FTL; otherwise, check the current user's read access
-    # (e.g., in Docker or when invoked by a non-root user). The target must
-    # resolve to a regular file and be readable by the evaluated user.
+  # When running as root (e.g., via pihole -g), check that the 'pihole' user can read the file
+  # to match the effective runtime user of FTL; otherwise, check the current user's read access
+  # (e.g., in Docker or when invoked by a non-root user). The target must
+  # resolve to a regular file and be readable by the evaluated user.
   if [[ "${url}" == "file:/"* ]]; then
     # Get the file path
     file_path=$(echo "${url}" | cut -d'/' -f3-)
@@ -739,9 +739,9 @@ gravity_DownloadBlocklistFromUrl() {
         download=false
     else
         if [ "$(id -un)" == "root" ]; then
-        # If we are root, we need to check if the pihole user has read permission
-        #  otherwise, we might read files that the pihole user should not be able to read
-      if sudo -u pihole test -r "${file_path}"; then
+            # If we are root, we need to check if the pihole user has read permission
+            #  otherwise, we might read files that the pihole user should not be able to read
+            if sudo -u pihole test -r "${file_path}"; then
                 echo -e "${OVER}  ${INFO} Using local file ${file_path}"
             else
                 echo -e "${OVER}  ${CROSS} Cannot read file (user 'pihole' lacks read permission)"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When users add local files with `file:///` as adlists we currently check for `a+r` permissions. However, it's not necessary that everyone has read access to the file, but only the current user executing gravity. (From CLI this is `root`, from web interface via FTL `pihole`).
The current implementation prohibits files like `/etc/pihole/my_list.txt` to be used, because after a FTL restart the file will have `-rw-r-----` permission and not even `sudo pihole -g` will pass the test. 

**How does this PR accomplish the above?:**

Only check if the current user has read permission.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
