### PR TITLE
Fix formatting in chooseInterface function

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -694,10 +694,11 @@ chooseInterface() {
             status="OFF"
         done
         # Disable check for double quote here as we are passing a string with spaces
+        # shellcheck disable=SC2086
         PIHOLE_INTERFACE=$(dialog --no-shadow --keep-tite --output-fd 1 \
             --cancel-label "Exit" --ok-label "Select" \
             --radiolist "Choose An Interface (press space to toggle selection)" \
-            ${r} ${c} "${interfaceCount}" "${interfacesList}")
+            ${r} ${c} "${interfaceCount}" ${interfacesList})
 
         result=$?
         case ${result} in


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Fix formatting in chooseInterface function to ensure proper variable expansion - with quotes, the dialog command throws the error:

```
Expected at least 20 tokens for --radi, have 5.
Use --help to list options.
```

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_