### PR TITLE
Fix libcap capabilities not being granted on OpenRC distros

### DIFF
--- a/advanced/Templates/pihole-FTL.openrc
+++ b/advanced/Templates/pihole-FTL.openrc
@@ -13,7 +13,7 @@ extra_started_commands="reload"
 
 respawn_max=5
 respawn_period=60
-capabilities="^CAP_NET_BIND_SERVICE,CAP_NET_RAW,CAP_NET_ADMIN,CAP_SYS_NICE,CAP_IPC_LOCK,CAP_CHOWN,CAP_SYS_TIME"
+capabilities="^CAP_NET_BIND_SERVICE,^CAP_NET_RAW,^CAP_NET_ADMIN,^CAP_SYS_NICE,^CAP_IPC_LOCK,^CAP_CHOWN,^CAP_SYS_TIME"
 
 depend() {
     want net


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This pull request fixes most libcap capabilities not being granted to `pihole-FTL` when started via OpenRC (as is the case on Alpine, Gentoo, etc.). This PR also fixes #6454.

**How does this PR accomplish the above?:**

This PR fixes the above issue by changing each capability to be prefixed with `^`, instead of just the first one (which was likely the only capability being granted before this PR). I wrote this PR on behalf of @mgziminsky (see [this issue comment](https://github.com/pi-hole/pi-hole/issues/6454#issuecomment-3476576177), who as of writing seems to be having account access issues.

This change was tested and confirmed to fix #6454 on my Raspberry Pi 5 running Alpine v3.22.

**Link documentation PRs if any are needed to support this PR:**

No documentation PRs required, to my knowledge.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*

By the way, your link to the EUPL license links to v1.1, instead of 1.2, as the agreement above would suggest.
