### PR TITLE
systemd service - don't use deprecated PermissionsStartOnly

### DIFF
--- a/advanced/Templates/pihole-FTL.systemd
+++ b/advanced/Templates/pihole-FTL.systemd
@@ -17,15 +17,15 @@ StartLimitIntervalSec=60s
 
 [Service]
 User=pihole
-PermissionsStartOnly=true
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN CAP_SYS_NICE CAP_IPC_LOCK CAP_CHOWN CAP_SYS_TIME
 
-ExecStartPre=/opt/pihole/pihole-FTL-prestart.sh
+# Run prestart with elevated permissions
+ExecStartPre=+/opt/pihole/pihole-FTL-prestart.sh
 ExecStart=/usr/bin/pihole-FTL -f
 Restart=on-failure
 RestartSec=5s
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStopPost=/opt/pihole/pihole-FTL-poststop.sh
+ExecStopPost=+/opt/pihole/pihole-FTL-poststop.sh
 
 # Use graceful shutdown with a reasonable timeout
 TimeoutStopSec=60s


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Avoid use of deprecated directive "PermissionsStartOnly" in the systemd unit file. 

**How does this PR accomplish the above?:**

elevates Prestart and Poststop script permissions using "+" prefix instead, as per https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines

( PermissionsStartOnly was deprecated in systemd 241 and no longer appears in documentation since 2018 https://github.com/systemd/systemd/pull/10802 )

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
