### PR TITLE
Use configured location for web repo when updating or repairing

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1808,6 +1808,12 @@ clone_or_reset_repos() {
     # If the user wants to repair/update,
     if [[ "${repair}" == true ]]; then
         printf "  %b Resetting local repos\\n" "${INFO}"
+
+        # import getFTLConfigValue from utils.sh
+        source "/opt/pihole/utils.sh"
+        # Use the configured Web repo location on repair/update
+        webInterfaceDir=$(getFTLConfigValue "webserver.paths.webroot")$(getFTLConfigValue "webserver.paths.webhome")
+
         # Reset the Core repo
         resetRepo ${PI_HOLE_LOCAL_REPO} ||
             {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Allow `pihole -up` to update the web repo correctly when user has specified a different web admin directory via web settings or pihole.toml, likewise for `pihole repair`.

Issue raised in https://github.com/pi-hole/pi-hole/issues/6449 and previously in https://github.com/pi-hole/pi-hole/issues/6005

**How does this PR accomplish the above?:**

Alteration to the repo update section of basic-install.sh to use the currently configured location, obtained from settings, instead of the previous hardcoded location. 

Imports utils.sh to allow access to settings, but only in cases of repair or update. New installations still placed in the default hard-coded location.

Example using non-standard configured directory as per issue 6449 above.

<img width="1454" height="170" alt="image" src="https://github.com/user-attachments/assets/907c038b-788b-4817-964d-bd2364d7df54" />

**Link documentation PRs if any are needed to support this PR:**

N/A


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
