### PR TITLE
Use port from dns.port in piholeDebug.sh

### DIFF
--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -725,7 +725,7 @@ dig_at() {
                 fi
 
               # Check if Pi-hole can use itself to block a domain
-                if local_dig="$(dig +tries=1 +time=2 -"${protocol}" "${random_url}" @"${local_address}" "${record_type}")"; then
+                if local_dig="$(dig +tries=1 +time=2 -"${protocol}" "${random_url}" @"${local_address}" "${record_type}" -p "$(get_ftl_conf_value "dns.port")")"; then
                     # If it can, show success
                     if [[ "${local_dig}" == *"status: NOERROR"* ]]; then
                         local_dig="NOERROR"


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

When a port other than default `53` is set as `dns.port`, `pihole debug` will not query the local Pi-hole properly.

Using: 
```bash
$ pihole-FTL --config dns.port
5333
```

Before:
```
[...]
*** [ DIAGNOSING ]: Ports in use
    udp:0.0.0.0:43436 is in use by avahi-daemon
    udp:0.0.0.0:5333 is in use by pihole-FTL
    udp:0.0.0.0:5353 is in use by avahi-daemon
[✗] udp:192.168.122.1:53 is in use by dnsmasq (https://docs.pi-hole.net/main/prerequisites/#ports)
    udp:0.0.0.0%virbr0:67 is in use by dnsmasq
    udp:[::]:5333 is in use by pihole-FTL
    udp:[::]:5353 is in use by avahi-daemon
    udp:[::]:50148 is in use by avahi-daemon
[✗] tcp:192.168.122.1:53 is in use by dnsmasq (https://docs.pi-hole.net/main/prerequisites/#ports)
    tcp:127.0.0.1:5939 is in use by teamviewerd
[✓] tcp:0.0.0.0:8083 is in use by pihole-FTL
    tcp:127.0.0.1:631 is in use by cupsd
    tcp:0.0.0.0:5333 is in use by pihole-FTL
    tcp:127.0.0.1:42455 is in use by github-desktop
    tcp:[::1]:631 is in use by cupsd
    tcp:[::]:5333 is in use by pihole-FTL

*** [ DIAGNOSING ]: Name resolution (IPv4) using a random blocked domain and a known ad-serving domain
[✗] Failed to resolve profitobody.com on lo (127.0.0.1)
[✗] Failed to resolve profitobody.com on enp3s0 (192.168.178.138)
[✓] No IPv4 address available on enxMAC
[✓] profitobody.com is NOERROR on virbr0 (192.168.122.1)
[✓] doubleclick.com is 142.251.37.14 via a remote, public DNS server (8.8.8.8)

*** [ DIAGNOSING ]: Name resolution (IPv6) using a random blocked domain and a known ad-serving domain
[✗] Failed to resolve aax-eu-dub.amazon.com on lo (::1)
[✗] Failed to resolve aax-eu-dub.amazon.com on enp3s0 (fde6:xx)
[✗] Failed to resolve aax-eu-dub.amazon.com on enp3s0 (fde6:xx)
[✗] Failed to resolve aax-eu-dub.amazon.com on enp3s0 (2001:xx)
[✗] Failed to resolve aax-eu-dub.amazon.com on enp3s0 (2001:xx)
[✗] Failed to resolve aax-eu-dub.amazon.com on enp3s0 (fe80::xx%enp3s0)
[✓] No IPv6 address available on enxMAC
[✓] No IPv6 address available on virbr0
[✓] doubleclick.com is 2a00:1450:4016:808::200e via a remote, public DNS server (2001:4860:4860::8888)
[...]
```

After:
```
[...]
*** [ DIAGNOSING ]: Ports in use
    udp:0.0.0.0:43436 is in use by <unknown>
    udp:0.0.0.0:5333 is in use by <unknown>
    udp:0.0.0.0:5353 is in use by <unknown>
[✗] udp:192.168.122.1:53 is in use by  (https://docs.pi-hole.net/main/prerequisites/#ports)
    udp:0.0.0.0%virbr0:67 is in use by <unknown>
    udp:[::]:5333 is in use by <unknown>
    udp:[::]:5353 is in use by <unknown>
    udp:[::]:50148 is in use by <unknown>
[✗] tcp:192.168.122.1:53 is in use by  (https://docs.pi-hole.net/main/prerequisites/#ports)
    tcp:127.0.0.1:5939 is in use by <unknown>
[✗] tcp:0.0.0.0:8083 is in use by  (https://docs.pi-hole.net/main/prerequisites/#ports)
    tcp:127.0.0.1:631 is in use by <unknown>
    tcp:0.0.0.0:5333 is in use by <unknown>
    tcp:127.0.0.1:42455 is in use by github-desktop
    tcp:[::1]:631 is in use by <unknown>
    tcp:[::]:5333 is in use by <unknown>

*** [ DIAGNOSING ]: Name resolution (IPv4) using a random blocked domain and a known ad-serving domain
[✓] shift12x-hiprex-system.com is NOERROR on lo (127.0.0.1)
[✓] shift12x-hiprex-system.com is NOERROR on enp3s0 (192.168.178.138)
[✓] No IPv4 address available on enxMAC
[✓] shift12x-hiprex-system.com is NOERROR on virbr0 (192.168.122.1)
[✓] doubleclick.com is 142.251.37.14 via a remote, public DNS server (8.8.8.8)

*** [ DIAGNOSING ]: Name resolution (IPv6) using a random blocked domain and a known ad-serving domain
[✓] mediaplex.com is NOERROR on lo (::1)
[✓] mediaplex.com is NOERROR on enp3s0 (fde6:xx)
[✓] mediaplex.com is NOERROR on enp3s0 (fde6:xx)
[✓] mediaplex.com is NOERROR on enp3s0 (2001:xx)
[✓] mediaplex.com is NOERROR on enp3s0 (2001:xx)
[✓] mediaplex.com is NOERROR on enp3s0 (fe80::xx%enp3s0)
[✓] No IPv6 address available on enxMAC
[✓] No IPv6 address available on virbr0
[✓] doubleclick.com is 2a00:1450:4016:808::200e via a remote, public DNS server (2001:4860:4860::8888)
[...]
```

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
