### PR TITLE
save/store listsCacheDir in same directory as gravity.db

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -29,9 +29,6 @@ PIHOLE_COMMAND="/usr/local/bin/${basename}"
 
 piholeDir="/etc/${basename}"
 
-# Gravity aux files directory
-listsCacheDir="${piholeDir}/listsCache"
-
 # Legacy (pre v5.0) list file locations
 whitelistFile="${piholeDir}/whitelist.txt"
 blacklistFile="${piholeDir}/blacklist.txt"
@@ -63,6 +60,9 @@ gravityDIR="$(dirname -- "${gravityDBfile}")"
 gravityOLDfile="${gravityDIR}/gravity_old.db"
 gravityBCKdir="${gravityDIR}/gravity_backups"
 gravityBCKfile="${gravityBCKdir}/gravity.db"
+
+# Gravity aux files directory
+listsCacheDir="${gravityDIR}/listsCache"
 
 fix_owner_permissions() {
   # Fix ownership and permissions for the specified file


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

store/save `listsCacheDir` in the same directory as `gravity.db` as they are related to each other

**How does this PR accomplish the above?:**

changes 
```bash
# Gravity aux files directory
listsCacheDir="${piholeDir}/listsCache"
```

to 

```bash
# Gravity aux files directory
listsCacheDir="${gravityDIR}/listsCache"
```

and moves it down a few lines (from 32-33 to 64-65)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
