### PR TITLE
Remove deprecated arpflush command in favor of networkflush

### DIFF
--- a/pihole
+++ b/pihole
@@ -96,15 +96,6 @@ flushFunc() {
   exit 0
 }
 
-# Deprecated function, should be removed in the future
-# use networkFlush instead
-arpFunc() {
-  shift
-  echo -e "  ${INFO} The 'arpflush' command is deprecated, use 'networkflush' instead"
-  "${PI_HOLE_SCRIPT_DIR}"/piholeNetworkFlush.sh "$@"
-  exit 0
-}
-
 networkFlush() {
   shift
   "${PI_HOLE_SCRIPT_DIR}"/piholeNetworkFlush.sh "$@"
@@ -575,7 +566,6 @@ case "${1}" in
   "setpassword"                   ) need_root=true;;
   "checkout"                      ) need_root=true;;
   "updatechecker"                 ) need_root=true;;
-  "arpflush"                      ) need_root=true;; # Deprecated, use networkflush instead
   "networkflush"                  ) need_root=true;;
   "-t" | "tail"                   ) need_root=true;;
   *                               ) helpFunc;;
@@ -610,7 +600,6 @@ case "${1}" in
   "setpassword"                   ) SetWebPassword "$@";;
   "checkout"                      ) piholeCheckoutFunc "$@";;
   "updatechecker"                 ) shift; updateCheckFunc "$@";;
-  "arpflush"                      ) arpFunc "$@";; # Deprecated, use networkflush instead
   "networkflush"                  ) networkFlush "$@";;
   "-t" | "tail"                   ) tailFunc "$2";;
   *                               ) helpFunc;;


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This PR removes the deprecated `arpflush` command from the pihole controller script. The command has been marked for removal with an inline comment stating "should be removed in the future" and users have been directed to use `networkflush` instead for several versions now.

The arpflush functionality was deprecated because networkflush provides the same capability with a clearer name. Since users have had multiple releases to migrate and have been seeing deprecation warnings, it's time to complete the deprecation cycle and remove the old command entirely.

This will reduce technical debt and simplify the codebase by eliminating an unnecessary code path that just redirects to networkflush anyway.

**Breaking change:** Users still calling `pihole arpflush` will need to update to `pihole networkflush`. The functionality is identical, just the command name changed.

---

**How does this PR accomplish the above?:**

The changes are straightforward - I removed three things from the pihole script:

1. The [arpFunc()](cci:1://file:///Users/10adnan75/Desktop/pi-hole/pihole:100:0-105:1) function definition (lines 99-106) that was handling the deprecated command
2. The case statement for "arpflush" in the privilege check section (line 578)  
3. The case statement for "arpflush" in the command routing section (line 613)

Total of 11 lines removed, no new code added.

I tested this by:
- Running `bash -n pihole` to check for syntax errors (none found)
- Searching the entire codebase for any remaining references to arpflush or arpFunc (none found)
- Verifying that networkflush still works as expected
- Confirming that trying to run `pihole arpflush` now shows the help menu instead

The networkflush command and all its functionality remain completely unchanged.

---

**Link documentation PRs if any are needed to support this PR:**

No documentation changes needed. The networkflush command is already documented and users have been told to use it via the deprecation warning.

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits.
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review.