### PR TITLE
Remove misleading TODO comment for SetWebPassword

### DIFF
--- a/pihole
+++ b/pihole
@@ -38,7 +38,6 @@ if [ -f "${versionsfile}" ]; then
     source "${versionsfile}"
 fi
 
-# TODO: We can probably remove the reliance on this function too, just tell people to pihole-FTL --config webserver.api.password "password"
 SetWebPassword() {
     if [ -n "$2" ] ; then
         readonly PASSWORD="$2"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This PR removes a TODO comment that suggests deprecating the `SetWebPassword` function in favor of direct `pihole-FTL --config` commands. The TODO is misleading because removing this function would actually be a security and usability regression.

The comment in question was:
```bash
# TODO: We can probably remove the reliance on this function too, just tell people to pihole-FTL --config webserver.api.password "password"
```

While technically users could call pihole-FTL directly, the wrapper function provides several important benefits that justify keeping it:

**Security**: Direct command-line password setting exposes passwords in shell history. The interactive prompt with hidden input prevents this.

**User Experience**: The function provides password confirmation to catch typos, user-friendly error messages, and proper Ctrl+C handling to prevent broken terminals.

**Simplicity**: `pihole setpassword` is much easier to remember than the FTL config syntax.

**Compatibility**: The command is used in installation scripts, documentation, man pages, and likely many user scripts.

---

**How does this PR accomplish the above?:**

Simple one-line change - removed the misleading TODO comment from line 41 of the pihole script.

The `SetWebPassword` function itself remains completely unchanged and continues to provide:
- Interactive password entry with hidden input
- Password confirmation to prevent typos  
- No password exposure in shell history
- User-friendly error messages
- Safe Ctrl+C handling that resets terminal state

I tested this by:
- Running `bash -n pihole` to verify syntax (no errors)
- Confirming the function signature and behavior are unchanged
- Verifying this is purely a comment removal with no functional changes

---

**Link documentation PRs if any are needed to support this PR:**

No documentation changes needed. This only removes a misleading internal code comment.

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits.
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review.
