### PR TITLE
Wipe version file before creating a new one

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -50,8 +50,12 @@ rm -f "/etc/pihole/GitHubVersions"
 rm -f "/etc/pihole/localbranches"
 rm -f "/etc/pihole/localversions"
 
-# Create new versions file if it does not exist
 VERSION_FILE="/etc/pihole/versions"
+
+# Remove the version file if it exists
+rm -f "${VERSION_FILE}"
+
+# Create new versions file
 touch "${VERSION_FILE}"
 chmod 644 "${VERSION_FILE}"
 

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -52,11 +52,8 @@ rm -f "/etc/pihole/localversions"
 
 VERSION_FILE="/etc/pihole/versions"
 
-# Remove the version file if it exists
-rm -f "${VERSION_FILE}"
-
-# Create new versions file
-touch "${VERSION_FILE}"
+# Truncates the file to zero length if it exists to clear it up, otherwise creates an empty file.
+truncate -s 0 "${VERSION_FILE}"
 chmod 644 "${VERSION_FILE}"
 
 # if /pihole.docker.tag file exists, we will use it's value later in this script

--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -30,9 +30,6 @@ addOrEditKeyValPair() {
   local key="${2}"
   local value="${3}"
 
-  # touch file to prevent grep error if file does not exist yet
-  touch "${file}"
-
   if grep -q "^${key}=" "${file}"; then
     # Key already exists in file, modify the value
     sed -i "/^${key}=/c\\${key}=${value}" "${file}"

--- a/test/test_any_utils.py
+++ b/test/test_any_utils.py
@@ -2,6 +2,7 @@ def test_key_val_replacement_works(host):
     """Confirms addOrEditKeyValPair either adds or replaces a key value pair in a given file"""
     host.run("""
     source /opt/pihole/utils.sh
+    touch ./testoutput
     addOrEditKeyValPair "./testoutput" "KEY_ONE" "value1"
     addOrEditKeyValPair "./testoutput" "KEY_TWO" "value2"
     addOrEditKeyValPair "./testoutput" "KEY_ONE" "value3"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We are using `/etc/pihole/versions` to store local and remote version of Pi-hole's components to populate the web interface and `pihole -v`.
Lately we have seen some reports (eg. [here](https://github.com/pi-hole/pi-hole/issues/6527), [here](https://github.com/pi-hole/pi-hole/issues/6362)) where running `pihole updatechecker` was not sufficient to fix incorrect version information in the file, but a removal was needed (interestingly, file size was always too large).

This PR removes the old version file before creating a new one every time `pihole updatechecker` runs.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
