### PR TITLE
Set versions in /etc/pihole/versions to null if script fails

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -8,6 +8,8 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
+set -o pipefail
+
 function get_local_branch() {
     # Return active branch
     cd "${1}" 2>/dev/null || { echo "null"; return; }

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -10,32 +10,32 @@
 
 function get_local_branch() {
     # Return active branch
-    cd "${1}" 2>/dev/null || return 1
-    git rev-parse --abbrev-ref HEAD || return 1
+    cd "${1}" 2>/dev/null || { echo "null"; return; }
+    git rev-parse --abbrev-ref HEAD || echo "null"
 }
 
 function get_local_version() {
     # Return active version
-    cd "${1}" 2>/dev/null || return 1
-    git describe --tags --always 2>/dev/null || return 1
+    cd "${1}" 2>/dev/null || { echo "null"; return; }
+    git describe --tags --always 2>/dev/null || echo "null"
 }
 
 function get_local_hash() {
-    cd "${1}" 2>/dev/null || return 1
-    git rev-parse --short=8 HEAD || return 1
+    cd "${1}" 2>/dev/null || { echo "null"; return; }
+    git rev-parse --short=8 HEAD || echo "null"
 }
 
 function get_remote_version() {
     # if ${2} is = "master" we need to use the "latest" endpoint, otherwise, we simply return null
     if [[ "${2}" == "master" ]]; then
-        curl -s "https://api.github.com/repos/pi-hole/${1}/releases/latest" 2>/dev/null | jq --raw-output .tag_name || return 1
+        curl -s "https://api.github.com/repos/pi-hole/${1}/releases/latest" 2>/dev/null | jq --raw-output .tag_name || echo "null"
     else
         echo "null"
     fi
 }
 
 function get_remote_hash() {
-    git ls-remote "https://github.com/pi-hole/${1}" --tags "${2}" | awk '{print substr($0, 1,8);}' || return 1
+    git ls-remote "https://github.com/pi-hole/${1}" --tags "${2}" | awk '{print substr($0, 1,8);}' || echo "null"
 }
 
 # Source the utils file for addOrEditKeyValPair()

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -22,6 +22,15 @@ else
     loadVersionFile "${cachedVersions}"
 fi
 
+# Convert "null" or empty values to "N/A" for display
+normalize_version() {
+    if [ -z "${1}" ] || [ "${1}" = "null" ]; then
+        echo "N/A"
+    else
+        echo "${1}"
+    fi
+}
+
 main() {
     local details
     details=false
@@ -34,21 +43,21 @@ main() {
 
     if [ "${details}" = true ]; then
         echo "Core"
-        echo "    Version is ${CORE_VERSION:=N/A} (Latest: ${GITHUB_CORE_VERSION:=N/A})"
-        echo "    Branch is ${CORE_BRANCH:=N/A}"
-        echo "    Hash is ${CORE_HASH:=N/A} (Latest: ${GITHUB_CORE_HASH:=N/A})"
+        echo "    Version is $(normalize_version "${CORE_VERSION}") (Latest: $(normalize_version "${GITHUB_CORE_VERSION}"))"
+        echo "    Branch is $(normalize_version "${CORE_BRANCH}")"
+        echo "    Hash is $(normalize_version "${CORE_HASH}") (Latest: $(normalize_version "${GITHUB_CORE_HASH}"))"
         echo "Web"
-        echo "    Version is ${WEB_VERSION:=N/A} (Latest: ${GITHUB_WEB_VERSION:=N/A})"
-        echo "    Branch is ${WEB_BRANCH:=N/A}"
-        echo "    Hash is ${WEB_HASH:=N/A} (Latest: ${GITHUB_WEB_HASH:=N/A})"
+        echo "    Version is $(normalize_version "${WEB_VERSION}") (Latest: $(normalize_version "${GITHUB_WEB_VERSION}"))"
+        echo "    Branch is $(normalize_version "${WEB_BRANCH}")"
+        echo "    Hash is $(normalize_version "${WEB_HASH}") (Latest: $(normalize_version "${GITHUB_WEB_HASH}"))"
         echo "FTL"
-        echo "    Version is ${FTL_VERSION:=N/A} (Latest: ${GITHUB_FTL_VERSION:=N/A})"
-        echo "    Branch is ${FTL_BRANCH:=N/A}"
-        echo "    Hash is ${FTL_HASH:=N/A} (Latest: ${GITHUB_FTL_HASH:=N/A})"
+        echo "    Version is $(normalize_version "${FTL_VERSION}") (Latest: $(normalize_version "${GITHUB_FTL_VERSION}"))"
+        echo "    Branch is $(normalize_version "${FTL_BRANCH}")"
+        echo "    Hash is $(normalize_version "${FTL_HASH}") (Latest: $(normalize_version "${GITHUB_FTL_HASH}"))"
     else
-        echo "Core version is ${CORE_VERSION:=N/A} (Latest: ${GITHUB_CORE_VERSION:=N/A})"
-        echo "Web version is ${WEB_VERSION:=N/A} (Latest: ${GITHUB_WEB_VERSION:=N/A})"
-        echo "FTL version is ${FTL_VERSION:=N/A} (Latest: ${GITHUB_FTL_VERSION:=N/A})"
+        echo "Core version is $(normalize_version "${CORE_VERSION}") (Latest: $(normalize_version "${GITHUB_CORE_VERSION}"))"
+        echo "Web version is $(normalize_version "${WEB_VERSION}") (Latest: $(normalize_version "${GITHUB_WEB_VERSION}"))"
+        echo "FTL version is $(normalize_version "${FTL_VERSION}") (Latest: $(normalize_version "${GITHUB_FTL_VERSION}"))"
     fi
 }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When we failed to get the version/branch/hast info in `updatechecker.sh` we returned a mix of `null` or empty vars in `/etc/pihole/versions`.
This PR sets all values to `null` if we fails to get the relevant information.
This is a partly fix raised in https://github.com/pi-hole/web/issues/3728
The second fix is https://github.com/pi-hole/web/pull/3729

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
