### PR TITLE
Fix readonly variable error in network flush

### DIFF
--- a/advanced/Scripts/api.sh
+++ b/advanced/Scripts/api.sh
@@ -22,7 +22,7 @@ TestAPIAvailability() {
     local chaos_api_list authResponse authStatus authData apiAvailable DNSport
 
     # as we are running locally, we can get the port value from FTL directly
-    PI_HOLE_SCRIPT_DIR="/opt/pihole"
+    : "${PI_HOLE_SCRIPT_DIR:=/opt/pihole}"
     utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
     # shellcheck source=./advanced/Scripts/utils.sh
     . "${utilsfile}"


### PR DESCRIPTION
Use POSIX parameter expansion to set PI_HOLE_SCRIPT_DIR default in api.sh, preventing conflict when sourced by scripts that declare the variable as readonly.

Fixes https://discourse.pi-hole.net/t/networkflush-line-25-pi-hole-script-dir-readonly/83996

Suggested fix from the thread did not address root of the issue: attempting to set 'readonly' twice.

## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

## What does this PR do?

When running `pihole networkflush`, the command fails with:
`/opt/pihole/api.sh: line 25: PI_HOLE_SCRIPT_DIR: readonly variable`

This occurs because `piholeNetworkFlush.sh` declares `PI_HOLE_SCRIPT_DIR`
as readonly, then sources `api.sh` which attempts to reassign it.

## How does it fix it?

Replaces the direct assignment in `api.sh` with POSIX parameter expansion
(`: "${PI_HOLE_SCRIPT_DIR:=/opt/pihole}"`), which only assigns when the
variable is unset or empty. When already set (even as readonly), no
assignment is attempted.

This pattern is already used in `advanced/Templates/pihole-FTL.openrc`
for the same variable.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ Check] I have read the above and my PR is ready for review. *Check this box to confirm*
