### PR TITLE
Fix return status capture of FTL check_download exists

### DIFF
--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -186,7 +186,10 @@ checkout() {
 
         echo -e "  ${INFO} Checking for ${COL_YELLOW}${binary}${COL_NC} binary on https://ftl.pi-hole.net"
 
-        if check_download_exists "$path"; then
+        local download_status
+        check_download_exists "$path"
+        download_status=$?
+        if [ $download_status -eq 0 ]; then
             echo "  ${TICK} Binary exists"
             echo "${2}" > /etc/pihole/ftlbranch
             chmod 644 /etc/pihole/ftlbranch
@@ -210,15 +213,13 @@ checkout() {
             # Update local and remote versions via updatechecker
             /opt/pihole/updatecheck.sh
         else
-            local status
-            status=$?
-            if [ $status -eq 1 ]; then
+            if [ $download_status -eq 1 ]; then
                 # Binary for requested branch is not available, may still be
                 # int he process of being built or CI build job failed
                 printf "  %b Binary for requested branch is not available, please try again later.\\n" "${CROSS}"
                 printf "      If the issue persists, please contact Pi-hole Support and ask them to re-generate the binary.\\n"
                 exit 1
-            elif [ $status -eq 2 ]; then
+            elif [ $download_status -eq 2 ]; then
                 printf "  %b Unable to download from ftl.pi-hole.net. Please check your Internet connection and try again later.\\n" "${CROSS}"
                 exit 1
             else

--- a/advanced/Scripts/piholeCheckout.sh
+++ b/advanced/Scripts/piholeCheckout.sh
@@ -187,8 +187,7 @@ checkout() {
         echo -e "  ${INFO} Checking for ${COL_YELLOW}${binary}${COL_NC} binary on https://ftl.pi-hole.net"
 
         local download_status
-        check_download_exists "$path"
-        download_status=$?
+        check_download_exists "$path" && download_status=0 || download_status=$?
         if [ $download_status -eq 0 ]; then
             echo "  ${TICK} Binary exists"
             echo "${2}" > /etc/pihole/ftlbranch

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2042,8 +2042,9 @@ FTLcheckUpdate() {
 
         # Check whether or not the binary for this FTL branch actually exists. If not, then there is no update!
         local status
-        if ! check_download_exists "${path}"; then
-            status=$?
+        check_download_exists "${path}"
+        status=$?
+        if [ "${status}" -ne 0 ]; then
             if [ "${status}" -eq 1 ]; then
                 printf "  %b Branch \"%s\" is not available.\\n" "${INFO}" "${ftlBranch}"
                 printf "  %b Use %bpihole checkout ftl [branchname]%b to switch to a valid branch.\\n" "${INFO}" "${COL_GREEN}" "${COL_NC}"

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2042,8 +2042,7 @@ FTLcheckUpdate() {
 
         # Check whether or not the binary for this FTL branch actually exists. If not, then there is no update!
         local status
-        check_download_exists "${path}"
-        status=$?
+        check_download_exists "${path}" && status=0 || status=$?
         if [ "${status}" -ne 0 ]; then
             if [ "${status}" -eq 1 ]; then
                 printf "  %b Branch \"%s\" is not available.\\n" "${INFO}" "${ftlBranch}"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

I noticed that checking out a FTL branch where the binary does not exist on the server results in an 'unknown checkout error'. But I knew we had code in place to specify why it did not work. The logs revealed that the propagation of the return code did not work proberly


```

+ check_download_exists new/config_read_only/pihole-FTL-arm64
+ local status
++ curl --head --silent https://ftl.pi-hole.net/new/config_read_only/pihole-FTL-arm64
++ head -n 1
' status='HTTP/2 404 
+ grep -q 200
+ grep -q 404
+ return 1
+ local status
+ status=0
+ '[' 0 -eq 1 ']'
+ '[' 0 -eq 2 ']'
+ printf '  %b Unknown checkout error. Please contact Pi-hole Support\n' '[✗]'
  [✗] Unknown checkout error. Please contact Pi-hole Support

```

Before
<img width="1192" height="348" alt="2026-03-22_09-52" src="https://github.com/user-attachments/assets/462a04a9-b3e7-4d6a-ad7b-526be9fcee4c" />


After
<img width="1674" height="382" alt="2026-03-22_10-09" src="https://github.com/user-attachments/assets/25ea93a8-684b-4da9-997c-f9c5385c2479" />


**How does this PR accomplish the above?:**

Capture the return code before the if statement. Additionally, preventing exiting due to returning 1 while `set -e` is set,

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
