### PR TITLE
Skip apt cache update when pihole-meta is current

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -284,8 +284,6 @@ package_manager_detect() {
         UPDATE_PKG_CACHE="${PKG_MANAGER} update"
         # The command we will use to actually install packages
         PKG_INSTALL="${PKG_MANAGER} -qq --no-install-recommends install"
-        # grep -c will return 1 if there are no matches. This is an acceptable condition, so we OR TRUE to prevent set -e exiting the script.
-        PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
         # The command we will use to remove packages (used in the uninstaller)
         PKG_REMOVE="${PKG_MANAGER} -y remove --purge"
 
@@ -300,8 +298,6 @@ package_manager_detect() {
 
         # These variable names match the ones for apt-get. See above for an explanation of what they are for.
         PKG_INSTALL="${PKG_MANAGER} install -y"
-        # CentOS package manager returns 100 when there are packages to update so we need to || true to prevent the script from exiting.
-        PKG_COUNT="${PKG_MANAGER} check-update | grep -E '(.i686|.x86|.noarch|.arm|.src|.riscv64)' | wc -l || true"
         # The command we will use to remove packages (used in the uninstaller)
         PKG_REMOVE="${PKG_MANAGER} remove -y"
 
@@ -310,7 +306,6 @@ package_manager_detect() {
         PKG_MANAGER="apk"
         UPDATE_PKG_CACHE="${PKG_MANAGER} update"
         PKG_INSTALL="${PKG_MANAGER} add"
-        PKG_COUNT="${PKG_MANAGER} list --upgradable -q | wc -l"
         PKG_REMOVE="${PKG_MANAGER} del"
 
     else
@@ -1400,23 +1395,6 @@ update_package_cache() {
     fi
 }
 
-# Let user know if they have outdated packages on their system and
-# advise them to run a package update at soonest possible.
-notify_package_updates_available() {
-    # Local, named variables
-    local str="Checking ${PKG_MANAGER} for upgraded packages"
-    printf "\\n  %b %s..." "${INFO}" "${str}"
-    # Store the list of packages in a variable
-    updatesToInstall=$(eval "${PKG_COUNT}")
-
-    if [[ "${updatesToInstall}" -eq 0 ]]; then
-        printf "%b  %b %s... up to date!\\n\\n" "${OVER}" "${TICK}" "${str}"
-    else
-        printf "%b  %b %s... %s updates available\\n" "${OVER}" "${TICK}" "${str}" "${updatesToInstall}"
-        printf "  %b %bIt is recommended to update your OS after installing the Pi-hole!%b\\n\\n" "${INFO}" "${COL_GREEN}" "${COL_NC}"
-    fi
-}
-
 install_dependent_packages() {
     # Install meta dependency package
     local str="Installing Pi-hole dependency package"
@@ -2321,9 +2299,6 @@ main() {
             update_package_cache || exit 1
         fi
     fi
-
-    # Notify user of package availability
-    notify_package_updates_available
 
     # Build dependency package
     build_dependency_package

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2317,8 +2317,7 @@ main() {
     if is_command apt-get; then
         local installed_meta_version
         installed_meta_version=$(dpkg-query -W -f='${Version}' pihole-meta 2>/dev/null) || true
-        if [[ -z "${installed_meta_version}" ]] || \
-           dpkg --compare-versions "${installed_meta_version}" lt "${PIHOLE_META_VERSION_APT}"; then
+        if dpkg --compare-versions "${installed_meta_version}" lt "${PIHOLE_META_VERSION_APT}"; then
             update_package_cache || exit 1
         fi
     fi

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -112,11 +112,15 @@ fi
 r=20
 c=70
 
+# Version of Pi-hole's meta package on APT based systems
+# Must be incremented whenever dependencies in PIHOLE_META_PACKAGE_CONTROL_APT change
+PIHOLE_META_VERSION_APT=0.6
+
 # Content of Pi-hole's meta package control file on APT based systems
 PIHOLE_META_PACKAGE_CONTROL_APT=$(
     cat <<EOM
 Package: pihole-meta
-Version: 0.6
+Version: ${PIHOLE_META_VERSION_APT}
 Maintainer: Pi-hole team <adblock@pi-hole.net>
 Architecture: all
 Description: Pi-hole dependency meta package
@@ -125,9 +129,6 @@ Section: contrib/metapackages
 Priority: optional
 EOM
 )
-
-# Version of Pi-hole's meta package on APT based systems (must match Version: field in PIHOLE_META_PACKAGE_CONTROL_APT)
-PIHOLE_META_VERSION_APT=0.6
 
 # Content of Pi-hole's meta package control file on RPM based systems
 PIHOLE_META_PACKAGE_CONTROL_RPM=$(

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -126,6 +126,9 @@ Priority: optional
 EOM
 )
 
+# Version of Pi-hole's meta package on APT based systems (must match Version: field in PIHOLE_META_PACKAGE_CONTROL_APT)
+PIHOLE_META_VERSION_APT=0.6
+
 # Content of Pi-hole's meta package control file on RPM based systems
 PIHOLE_META_PACKAGE_CONTROL_RPM=$(
     cat <<EOM
@@ -1373,8 +1376,8 @@ EOF
 }
 
 update_package_cache() {
-    # Update package cache on apt based OSes. Do this every time since
-    # it's quick and packages can be updated at any time.
+    # Update package cache on apt based OSes. Only called when pihole-meta is
+    # absent or outdated, so new dependencies can be resolved by apt.
 
     # Local, named variables
     local str="Update local cache of available packages"
@@ -2305,9 +2308,18 @@ main() {
     # Check for supported package managers so that we may install dependencies
     package_manager_detect
 
-    # Update package cache only on apt based systems
+    # Only update the apt package cache when pihole-meta is absent or outdated.
+    # On a fresh install the package won't exist yet so the cache update always
+    # runs. On upgrades it only runs when the meta version has bumped, meaning
+    # new dependencies may have been added. This saves time and I/O on
+    # resource-constrained hardware (e.g. SD cards).
     if is_command apt-get; then
+        local installed_meta_version
+        installed_meta_version=$(dpkg-query -W -f='${Version}' pihole-meta 2>/dev/null)
+        if [[ -z "${installed_meta_version}" ]] || \
+           dpkg --compare-versions "${installed_meta_version}" lt "${PIHOLE_META_VERSION_APT}"; then
             update_package_cache || exit 1
+        fi
     fi
 
     # Notify user of package availability

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -2315,7 +2315,7 @@ main() {
     # resource-constrained hardware (e.g. SD cards).
     if is_command apt-get; then
         local installed_meta_version
-        installed_meta_version=$(dpkg-query -W -f='${Version}' pihole-meta 2>/dev/null)
+        installed_meta_version=$(dpkg-query -W -f='${Version}' pihole-meta 2>/dev/null) || true
         if [[ -z "${installed_meta_version}" ]] || \
            dpkg --compare-versions "${installed_meta_version}" lt "${PIHOLE_META_VERSION_APT}"; then
             update_package_cache || exit 1


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Stop running `apt-get update` unconditionally on every `pihole -up`. On resource-constrained hardware (SD cards, Raspberry Pi) this is an expensive I/O operation that serves no purpose when the `pihole-meta` dependency package has not changed.

Addresses https://github.com/pi-hole/pi-hole/discussions/6272

---

**How does this PR accomplish the above?:**

Adds `PIHOLE_META_VERSION_APT=0.6` as a standalone constant, mirroring the existing `PIHOLE_META_VERSION_APK` pattern already used for Alpine.

The `update_package_cache()` call in `main()` is then gated on whether the installed `pihole-meta` version is absent or older than `PIHOLE_META_VERSION_APT`, using `dpkg-query` and `dpkg --compare-versions`:

```bash
if is_command apt-get; then
    local installed_meta_version
    installed_meta_version=$(dpkg-query -W -f='${Version}' pihole-meta 2>/dev/null)
    if [[ -z "${installed_meta_version}" ]] || \
       dpkg --compare-versions "${installed_meta_version}" lt "${PIHOLE_META_VERSION_APT}"; then
        update_package_cache || exit 1
    fi
fi
```

Behaviour by scenario:

| Scenario | Result |
|---|---|
| Fresh install | `pihole-meta` not present → cache update runs |
| `pihole -up`, meta version unchanged | installed == `PIHOLE_META_VERSION_APT` → skipped |
| `pihole -up`, meta version bumped (new deps added) | installed < `PIHOLE_META_VERSION_APT` → cache update runs |
| Meta package manually removed | not present → cache update runs |

Alpine (`apk`) is unaffected — it was already excluded from this code path by the `is_command apt-get` guard.

---

**Relationship to prior work:**

#6282 separated `update_package_cache()` from `package_manager_detect()` and made the call site explicit, but ultimately kept the unconditional `apt-get update`. The review discussion in that PR raised the concern that skipping the cache update entirely could leave the system unable to resolve new dependencies if the meta package version had changed — a valid point that rules out a simple `fresh_install` guard.

The version-compare approach here directly addresses that concern: the cache is only skipped when the installed `pihole-meta` version already matches what is about to be built, meaning no new dependencies can have been introduced.

The same version-compare idea was also explored in #6383, which was closed due to an Alpine compatibility issue in that implementation. That issue does not apply here.


---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits.
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review.