### PR TITLE
Fix ownership permissions for containing directories in fix_owner_per…

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -71,8 +71,10 @@ fix_owner_permissions() {
   chown pihole:pihole "${1}"
   chmod 664 "${1}"
 
-  # Ensure the containing directory is group writable
-  chmod g+w "$(dirname -- "${1}")"
+  # Ensure the containing directory is owned by pihole:pihole
+  # so the pihole user can write to it without requiring group-write
+  # permissions (which would change the directory mode unexpectedly)
+  chown pihole:pihole "$(dirname -- "${1}")"
 }
 
 # Generate new SQLite3 file from schema template


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Prompted by https://github.com/pi-hole/docker-pi-hole/issues/2017

This PR updates the `fix_owner_permissions()` function in `gravity.sh` to improve how file and directory permissions are managed for the `pihole` user. Instead of modifying directory group-write permissions, the script now ensures the containing directory is owned by `pihole:pihole`, which avoids unexpected changes to directory modes.


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_