### PR TITLE
Remove redundant touching of logfiles from systemd Service

### DIFF
--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -8,13 +8,8 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 
 # Get file paths
 FTL_PID_FILE="$(getFTLConfigValue files.pid)"
-FTL_LOG_FILE="$(getFTLConfigValue files.log.ftl)"
-PIHOLE_LOG_FILE="$(getFTLConfigValue files.log.dnsmasq)"
-WEBSERVER_LOG_FILE="$(getFTLConfigValue files.log.webserver)"
 FTL_PID_FILE="${FTL_PID_FILE:-/run/pihole-FTL.pid}"
-FTL_LOG_FILE="${FTL_LOG_FILE:-/var/log/pihole/FTL.log}"
-PIHOLE_LOG_FILE="${PIHOLE_LOG_FILE:-/var/log/pihole/pihole.log}"
-WEBSERVER_LOG_FILE="${WEBSERVER_LOG_FILE:-/var/log/pihole/webserver.log}"
+
 
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
 mkdir -p /var/log/pihole
@@ -36,7 +31,4 @@ chown root:root /etc/pihole/logrotate
 
 # Touch files to ensure they exist (create if non-existing, preserve if existing)
 [ -f "${FTL_PID_FILE}" ] || install -D -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"
-[ -f "${FTL_LOG_FILE}" ] || install -m 640 -o pihole -g pihole /dev/null "${FTL_LOG_FILE}"
-[ -f "${PIHOLE_LOG_FILE}" ] || install -m 640 -o pihole -g pihole /dev/null "${PIHOLE_LOG_FILE}"
-[ -f "${WEBSERVER_LOG_FILE}" ] || install -m 640 -o pihole -g pihole /dev/null "${WEBSERVER_LOG_FILE}"
 [ -f /etc/pihole/dhcp.leases ] || install -m 644 -o pihole -g pihole /dev/null /etc/pihole/dhcp.leases


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Simplify the prestart script. Log file creation as was legacy introduced with the [first statup script](https://github.com/pi-hole/pi-hole/pull/1244) made for FTL. But today, FTL can handle this on its own.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
