### PR TITLE
Improve gravity error message including curl exit code and errormsg

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -814,7 +814,7 @@ gravity_DownloadBlocklistFromUrl() {
       case "${httpCode}" in
         "200") echo -e "${OVER}  ${TICK} ${str} Retrieval successful" ;;
         "304") echo -e "${OVER}  ${TICK} ${str} No changes detected"  ;;
-        *) echo -e "${OVER}  ${TICK} ${str} Success (http_code=${COL_RED}${httpCode}${COL_NC})"  ;;
+        *) echo -e "${OVER}  ${TICK} ${str} Success (http_code=${COL_CYAN}${httpCode}${COL_NC})"  ;;
       esac
       success=true
     else
@@ -827,7 +827,7 @@ gravity_DownloadBlocklistFromUrl() {
         "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
         "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
         "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
-        *) echo -e "${OVER}  ${CROSS} ${str} Retrieval failed (exit_code=${COL_RED}${curlExitCode}${COL_NC} Msg: ${COL_CYAN}${curlErrorMsg}${COL_NC})" ;;
+        *) echo -e "${OVER}  ${CROSS} ${str} Retrieval failed (exit_code=${COL_CYAN}${curlExitCode}${COL_NC} Msg: ${COL_CYAN}${curlErrorMsg}${COL_NC})" ;;
       esac
     fi
     ;;

--- a/gravity.sh
+++ b/gravity.sh
@@ -776,10 +776,14 @@ gravity_DownloadBlocklistFromUrl() {
     # (https://github.com/pi-hole/pi-hole/pull/6605#discussion_r3112153347)
     # First we get the current curl version.
     curlVersion=$(curl --version | awk '{print $2;exit}')
-    # After that, we add "7.75", creating a list with 2 items.
-    # Then we sort the list (ascending order) and return the first item.
-    # If "7.75" is returned, it means that the current version is greater than or equal to "7.75.0".
-    if [[ "$(printf '%s\n' "${curlVersion}" 7.75 | sort -V | head -n1)" == 7.75 ]]; then
+    # After that, we pipe the current version along with the string '7.75' (the minimum version supporting the required option.)
+    # Then we sort the list in natural (version) order and return the first item which will be the lowest version seen.
+    # If it is "7.75" then the current version is greater than or equal to "7.75.0".
+    # Compatibility notes:
+    #   Busybox doesn't support some long flags:
+    #   - "sort -V" is short form of "sort --version-sort"
+    #   - "head -n1" is short form of "head --lines=1"
+    if [[ "$(printf '%s\n' "${curlVersion}" "7.75" | sort -V | head -n1)" == 7.75 ]]; then
         # Use the error message returned by curl
         curlOutputFormat='%{http_code}\n%{errormsg}'
     fi

--- a/gravity.sh
+++ b/gravity.sh
@@ -770,7 +770,7 @@ gravity_DownloadBlocklistFromUrl() {
 
   if [[ "${download}" == true ]]; then
     # Define the generic error message
-    curlOutputFormat='%{http_code}\nNo message available. Non supported curl version.'
+    curlOutputFormat='%{http_code};No message available. Non supported curl version.'
 
     # Check if the installed curl version supports the "-w %{errormsg}" option (available as of curl 7.75.0)
     # (https://github.com/pi-hole/pi-hole/pull/6605#discussion_r3112153347)
@@ -785,7 +785,7 @@ gravity_DownloadBlocklistFromUrl() {
     #   - "head -n1" is short form of "head --lines=1"
     if [[ "$(printf '%s\n' "${curlVersion}" "7.75" | sort -V | head -n1)" == 7.75 ]]; then
         # Use the error message returned by curl
-        curlOutputFormat='%{http_code}\n%{errormsg}'
+        curlOutputFormat='%{http_code};%{errormsg}'
     fi
 
     # This command will output the HTTP code and an error message, if available.
@@ -799,10 +799,7 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   # Retrieve http_code and errormsg values, returned by curl command
-  {
-    read -r httpCode;
-    read -r curlErrorMsg;
-  } < <( echo "${curlOutput}" )
+  IFS=";" read -r httpCode curlErrorMsg <<<"$curlOutput"
 
   case $url in
   # Did we "download" a local file?

--- a/gravity.sh
+++ b/gravity.sh
@@ -772,9 +772,13 @@ gravity_DownloadBlocklistFromUrl() {
     # Define the generic error message
     curlOutputFormat='%{http_code}\nNo message available. Non supported curl version.'
 
-    # Check if the installed curl version supports the "-w %{errormsg}" option
-    # (available as of curl 7.75.0)
+    # Check if the installed curl version supports the "-w %{errormsg}" option (available as of curl 7.75.0)
+    # (https://github.com/pi-hole/pi-hole/pull/6605#discussion_r3112153347)
+    # First we get the current curl version.
     curlVersion=$(curl --version | awk '{print $2;exit}')
+    # After that, we add "7.75", creating a list with 2 items.
+    # Then we sort the list (ascending order) and return the first item.
+    # If "7.75" is returned, it means that the current version is greater than or equal to "7.75.0".
     if [[ "$(printf '%s\n' "${curlVersion}" 7.75 | sort -V | head -n1)" == 7.75 ]]; then
         # Use the error message returned by curl
         curlOutputFormat='%{http_code}\n%{errormsg}'

--- a/gravity.sh
+++ b/gravity.sh
@@ -614,7 +614,7 @@ compareLists() {
 # Download specified URL and perform checks on HTTP status and file content
 gravity_DownloadBlocklistFromUrl() {
   local url="${1}" adlistID="${2}" saveLocation="${3}" compression="${4}" gravity_type="${5}" domain="${6}"
-  local listCurlBuffer str curlOutput httpCode curlErrorMsg="" curlExitCode="" curlOutputFormat=""
+  local listCurlBuffer str curlVersion curlOutput httpCode curlErrorMsg="" curlExitCode="" curlOutputFormat=""
   local success="" ip customUpstreamResolver="" file_path permissions ip_addr port blocked=false download=true
   # modifiedOptions is an array to store all the options used to check if the adlist has been changed upstream
   local modifiedOptions=()
@@ -758,10 +758,14 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   if [[ "${download}" == true ]]; then
+    # Define the generic error message
+    curlOutputFormat='%{http_code}\nNo message available. Non supported curl version.'
+
     # Check if the installed curl version supports the "-w %{errormsg}" option
     # (available as of curl 7.75.0)
-    curlOutputFormat='%{http_code}\nnomsg'
-    if curl --help --write-out | grep -q "errormsg" ; then
+    curlVersion=$(curl --version | awk '{print $2;exit}')
+    if [[ "$(printf '%s\n' "${curlVersion}" 7.75 | sort -V | head -n1)" == 7.75 ]]; then
+        # Use the error message returned by curl
         curlOutputFormat='%{http_code}\n%{errormsg}'
     fi
 
@@ -781,11 +785,6 @@ gravity_DownloadBlocklistFromUrl() {
     read -r curlErrorMsg;
   } < <( echo "${curlOutput}" )
 
-  # If curl is too old to return errormsg, we provide a generic message here
-  if [[ "${curlErrorMsg}" == "nomsg" ]]; then
-    curlErrorMsg="No message available. Non supported curl version."
-  fi
-
   case $url in
   # Did we "download" a local file?
   "file"*)
@@ -804,6 +803,7 @@ gravity_DownloadBlocklistFromUrl() {
       case "${httpCode}" in
         "200") echo -e "${OVER}  ${TICK} ${str} Retrieval successful" ;;
         "304") echo -e "${OVER}  ${TICK} ${str} No changes detected"  ;;
+        *) echo -e "${OVER}  ${TICK} ${str} Success (http_code=${COL_RED}${httpCode}${COL_NC})"  ;;
       esac
       success=true
     else

--- a/gravity.sh
+++ b/gravity.sh
@@ -614,8 +614,8 @@ compareLists() {
 # Download specified URL and perform checks on HTTP status and file content
 gravity_DownloadBlocklistFromUrl() {
   local url="${1}" adlistID="${2}" saveLocation="${3}" compression="${4}" gravity_type="${5}" domain="${6}"
-  local listCurlBuffer str httpCode success="" ip customUpstreamResolver=""
-  local file_path permissions ip_addr port blocked=false download=true
+  local listCurlBuffer str curlOutput httpCode curlErrorMsg="" curlExitCode="" curlOutputFormat=""
+  local success="" ip customUpstreamResolver="" file_path permissions ip_addr port blocked=false download=true
   # modifiedOptions is an array to store all the options used to check if the adlist has been changed upstream
   local modifiedOptions=()
 
@@ -758,7 +758,32 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   if [[ "${download}" == true ]]; then
-    httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression:+${compression}} ${customUpstreamResolver:+${customUpstreamResolver}} "${modifiedOptions[@]}" -w "%{http_code}" "${url}" -o "${listCurlBuffer}" 2>/dev/null)
+    # Check if the installed curl version supports the "-w %{errormsg}" option
+    # (available as of curl 7.75.0)
+    curlOutputFormat='%{http_code}\nnomsg'
+    if curl --help --write-out | grep -q "errormsg" ; then
+        curlOutputFormat='%{http_code}\n%{errormsg}'
+    fi
+
+    # This command will output the HTTP code and an error message, if available.
+    # Error messages are suppressed by "-s" option.
+    # By default curl returns exitcode=0 even an HTTP code happens (403, 404, 500, etc). To fix
+    # this, we use the "--fail" option to force curl to return a non-zero exit code.
+    # If curl version is older than 7.75.0, curl can't generate the errormsg output. In this case,
+    # the command will return "nomsg" and this will be replaced later by a generic error message.
+    curlOutput=$(curl --connect-timeout ${curl_connect_timeout} -s --fail -L ${compression:+${compression}} ${customUpstreamResolver:+${customUpstreamResolver}} "${modifiedOptions[@]}" -w "${curlOutputFormat}" "${url}" -o "${listCurlBuffer}")
+    curlExitCode="$?"
+  fi
+
+  # Retrieve http_code and errormsg values, returned by curl command
+  {
+    read -r httpCode;
+    read -r curlErrorMsg;
+  } < <( echo "${curlOutput}" )
+
+  # If curl is too old to return errormsg, we provide a generic message here
+  if [[ "${curlErrorMsg}" == "nomsg" ]]; then
+    curlErrorMsg="No message available. Non supported curl version."
   fi
 
   case $url in
@@ -773,27 +798,27 @@ gravity_DownloadBlocklistFromUrl() {
     ;;
   # Did we "download" a remote file?
   *)
-    # Determine "Status:" output based on HTTP response
-    case "${httpCode}" in
-    "200")
-      echo -e "${OVER}  ${TICK} ${str} Retrieval successful"
+    # Use the exit code to determine if curl was successful or not.
+    # Use HTTP code only to select the correct error message.
+    if [[ "${curlExitCode}" == "0" ]]; then
+      case "${httpCode}" in
+        "200") echo -e "${OVER}  ${TICK} ${str} Retrieval successful" ;;
+        "304") echo -e "${OVER}  ${TICK} ${str} No changes detected"  ;;
+      esac
       success=true
-      ;;
-    "304")
-      echo -e "${OVER}  ${TICK} ${str} No changes detected"
-      success=true
-      ;;
-    "000") echo -e "${OVER}  ${CROSS} ${str} Connection Refused" ;;
-    "403") echo -e "${OVER}  ${CROSS} ${str} Forbidden" ;;
-    "404") echo -e "${OVER}  ${CROSS} ${str} Not found" ;;
-    "408") echo -e "${OVER}  ${CROSS} ${str} Time-out" ;;
-    "451") echo -e "${OVER}  ${CROSS} ${str} Unavailable For Legal Reasons" ;;
-    "500") echo -e "${OVER}  ${CROSS} ${str} Internal Server Error" ;;
-    "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
-    "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
-    "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
-    *) echo -e "${OVER}  ${CROSS} ${str} ${url} (${httpCode})" ;;
-    esac
+    else
+      case "${httpCode}" in
+        "403") echo -e "${OVER}  ${CROSS} ${str} Forbidden" ;;
+        "404") echo -e "${OVER}  ${CROSS} ${str} Not found" ;;
+        "408") echo -e "${OVER}  ${CROSS} ${str} Time-out" ;;
+        "451") echo -e "${OVER}  ${CROSS} ${str} Unavailable For Legal Reasons" ;;
+        "500") echo -e "${OVER}  ${CROSS} ${str} Internal Server Error" ;;
+        "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
+        "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
+        "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
+        *) echo -e "${OVER}  ${CROSS} ${str} Retrieval failed (exit_code=${COL_RED}${curlExitCode}${COL_NC} Msg: ${COL_CYAN}${curlErrorMsg}${COL_NC})" ;;
+      esac
+    fi
     ;;
   esac
 

--- a/gravity.sh
+++ b/gravity.sh
@@ -774,7 +774,7 @@ gravity_DownloadBlocklistFromUrl() {
     # By default curl returns exitcode=0 even an HTTP code happens (403, 404, 500, etc). To fix
     # this, we use the "--fail" option to force curl to return a non-zero exit code.
     # If curl version is older than 7.75.0, curl can't generate the errormsg output. In this case,
-    # the command will return "nomsg" and this will be replaced later by a generic error message.
+    # a generic message is returned.
     curlOutput=$(curl --connect-timeout ${curl_connect_timeout} -s --fail -L ${compression:+${compression}} ${customUpstreamResolver:+${customUpstreamResolver}} "${modifiedOptions[@]}" -w "${curlOutputFormat}" "${url}" -o "${listCurlBuffer}")
     curlExitCode="$?"
   fi


### PR DESCRIPTION
### What does this PR aim to accomplish?

Improve gravity error messages for `curl`, returning better error messages (when available) based on the exit code and HTTP code.

The current gravity uses `http_code` returned by `curl`, but `curl` answers with `000` for many different reasons, like:

- Timeout: exit_code=28
- DNS Resolution Failure: exit_code=6
- Connection Refused: exit_code=7
- Network Unreachability: exit_code=7 (different error message)
- Untrusted Certificate: exit_code=35 or 60 (or other values... I'm not sure).
- and others: "CA Certificate Issues", "Invalid URL", "Client Disconnection"...

Gravity shows "Connection Refused" for all these cases, but sometimes "Connection Refused" is not the correct error message.

This PR returns the correct exit code and uses HTTP code to show a message returned by `curl` (when available - `curl 7.75.0` and above).

<img width="1085" height="903" alt="curl_messages" src="https://github.com/user-attachments/assets/862fc3fd-5dea-4e5c-99c7-8b276ad6e6bf" />


### How does this PR accomplish the above?

Use `curl` exit code (`$?`) to decide if `curl` command was successful or not.

Then we use the `http_code` returned by `curl` to define what is the correct error message.
Also, when using recent `curl` versions, we use the `errormsg` variable to show the message returned by `curl`.

### Note

This PR replaces #6425, where you can find the related discussion and suggestions.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
