### PR TITLE
Prevent double error message output in gravity run with invalid file

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -796,47 +796,48 @@ gravity_DownloadBlocklistFromUrl() {
     # a generic message is returned.
     curlOutput=$(curl --connect-timeout ${curl_connect_timeout} -s --fail -L ${compression:+${compression}} ${customUpstreamResolver:+${customUpstreamResolver}} "${modifiedOptions[@]}" -w "${curlOutputFormat}" "${url}" -o "${listCurlBuffer}")
     curlExitCode="$?"
+
+
+    # Retrieve http_code and errormsg values, returned by curl command
+    IFS=";" read -r httpCode curlErrorMsg <<<"$curlOutput"
+
+    case $url in
+    # Did we "download" a local file?
+    "file"*)
+      if [[ -s "${listCurlBuffer}" ]]; then
+        echo -e "${OVER}  ${TICK} ${str} Retrieval successful"
+        success=true
+      else
+        echo -e "${OVER}  ${CROSS} ${str} Retrieval failed / empty list"
+      fi
+      ;;
+    # Did we "download" a remote file?
+    *)
+      # Use the exit code to determine if curl was successful or not.
+      # Use HTTP code only to select the correct error message.
+      if [[ "${curlExitCode}" == "0" ]]; then
+        case "${httpCode}" in
+          "200") echo -e "${OVER}  ${TICK} ${str} Retrieval successful" ;;
+          "304") echo -e "${OVER}  ${TICK} ${str} No changes detected"  ;;
+          *) echo -e "${OVER}  ${TICK} ${str} Success (http_code=${COL_CYAN}${httpCode}${COL_NC})"  ;;
+        esac
+        success=true
+      else
+        case "${httpCode}" in
+          "403") echo -e "${OVER}  ${CROSS} ${str} Forbidden" ;;
+          "404") echo -e "${OVER}  ${CROSS} ${str} Not found" ;;
+          "408") echo -e "${OVER}  ${CROSS} ${str} Time-out" ;;
+          "451") echo -e "${OVER}  ${CROSS} ${str} Unavailable For Legal Reasons" ;;
+          "500") echo -e "${OVER}  ${CROSS} ${str} Internal Server Error" ;;
+          "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
+          "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
+          "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
+          *) echo -e "${OVER}  ${CROSS} ${str} Retrieval failed (exit_code=${COL_CYAN}${curlExitCode}${COL_NC} Msg: ${COL_CYAN}${curlErrorMsg}${COL_NC})" ;;
+        esac
+      fi
+      ;;
+    esac
   fi
-
-  # Retrieve http_code and errormsg values, returned by curl command
-  IFS=";" read -r httpCode curlErrorMsg <<<"$curlOutput"
-
-  case $url in
-  # Did we "download" a local file?
-  "file"*)
-    if [[ -s "${listCurlBuffer}" ]]; then
-      echo -e "${OVER}  ${TICK} ${str} Retrieval successful"
-      success=true
-    else
-      echo -e "${OVER}  ${CROSS} ${str} Retrieval failed / empty list"
-    fi
-    ;;
-  # Did we "download" a remote file?
-  *)
-    # Use the exit code to determine if curl was successful or not.
-    # Use HTTP code only to select the correct error message.
-    if [[ "${curlExitCode}" == "0" ]]; then
-      case "${httpCode}" in
-        "200") echo -e "${OVER}  ${TICK} ${str} Retrieval successful" ;;
-        "304") echo -e "${OVER}  ${TICK} ${str} No changes detected"  ;;
-        *) echo -e "${OVER}  ${TICK} ${str} Success (http_code=${COL_CYAN}${httpCode}${COL_NC})"  ;;
-      esac
-      success=true
-    else
-      case "${httpCode}" in
-        "403") echo -e "${OVER}  ${CROSS} ${str} Forbidden" ;;
-        "404") echo -e "${OVER}  ${CROSS} ${str} Not found" ;;
-        "408") echo -e "${OVER}  ${CROSS} ${str} Time-out" ;;
-        "451") echo -e "${OVER}  ${CROSS} ${str} Unavailable For Legal Reasons" ;;
-        "500") echo -e "${OVER}  ${CROSS} ${str} Internal Server Error" ;;
-        "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
-        "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
-        "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
-        *) echo -e "${OVER}  ${CROSS} ${str} Retrieval failed (exit_code=${COL_CYAN}${curlExitCode}${COL_NC} Msg: ${COL_CYAN}${curlErrorMsg}${COL_NC})" ;;
-      esac
-    fi
-    ;;
-  esac
 
   local done="false"
   # Determine if the blocklist was downloaded and saved correctly

--- a/gravity.sh
+++ b/gravity.sh
@@ -764,49 +764,49 @@ gravity_DownloadBlocklistFromUrl() {
   # Check for allowed protocols
   if [[ $url != "http"* && $url != "https"* && $url != "file"* && $url != "ftp"* && $url != "ftps"* && $url != "sftp"* ]]; then
     echo -e "${OVER}  ${CROSS} ${str} Invalid protocol specified. Ignoring list."
-    echo -e "      Ensure your URL starts with a valid protocol like http:// , https:// or file:// ."
+    echo -e "    Ensure your URL starts with a valid protocol like http:// , https:// or file:// ."
     download=false
   fi
 
   if [[ "${download}" == true ]]; then
     httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression:+${compression}} ${customUpstreamResolver:+${customUpstreamResolver}} "${modifiedOptions[@]}" -w "%{http_code}" "${url}" -o "${listCurlBuffer}" 2>/dev/null)
-  fi
 
-  case $url in
-  # Did we "download" a local file?
-  "file"*)
-    if [[ -s "${listCurlBuffer}" ]]; then
-      echo -e "${OVER}  ${TICK} ${str} Retrieval successful"
-      success=true
-    else
-      echo -e "${OVER}  ${CROSS} ${str} Retrieval failed / empty list"
-    fi
-    ;;
-  # Did we "download" a remote file?
-  *)
-    # Determine "Status:" output based on HTTP response
-    case "${httpCode}" in
-    "200")
-      echo -e "${OVER}  ${TICK} ${str} Retrieval successful"
-      success=true
+    case $url in
+    # Did we "download" a local file?
+    "file"*)
+      if [[ -s "${listCurlBuffer}" ]]; then
+        echo -e "${OVER}  ${TICK} ${str} Retrieval successful"
+        success=true
+      else
+        echo -e "${OVER}  ${CROSS} ${str} Retrieval failed / empty list"
+      fi
       ;;
-    "304")
-      echo -e "${OVER}  ${TICK} ${str} No changes detected"
-      success=true
+    # Did we "download" a remote file?
+    *)
+      # Determine "Status:" output based on HTTP response
+      case "${httpCode}" in
+      "200")
+        echo -e "${OVER}  ${TICK} ${str} Retrieval successful"
+        success=true
+        ;;
+      "304")
+        echo -e "${OVER}  ${TICK} ${str} No changes detected"
+        success=true
+        ;;
+      "000") echo -e "${OVER}  ${CROSS} ${str} Connection Refused" ;;
+      "403") echo -e "${OVER}  ${CROSS} ${str} Forbidden" ;;
+      "404") echo -e "${OVER}  ${CROSS} ${str} Not found" ;;
+      "408") echo -e "${OVER}  ${CROSS} ${str} Time-out" ;;
+      "451") echo -e "${OVER}  ${CROSS} ${str} Unavailable For Legal Reasons" ;;
+      "500") echo -e "${OVER}  ${CROSS} ${str} Internal Server Error" ;;
+      "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
+      "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
+      "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
+      *) echo -e "${OVER}  ${CROSS} ${str} ${url} (${httpCode})" ;;
+      esac
       ;;
-    "000") echo -e "${OVER}  ${CROSS} ${str} Connection Refused" ;;
-    "403") echo -e "${OVER}  ${CROSS} ${str} Forbidden" ;;
-    "404") echo -e "${OVER}  ${CROSS} ${str} Not found" ;;
-    "408") echo -e "${OVER}  ${CROSS} ${str} Time-out" ;;
-    "451") echo -e "${OVER}  ${CROSS} ${str} Unavailable For Legal Reasons" ;;
-    "500") echo -e "${OVER}  ${CROSS} ${str} Internal Server Error" ;;
-    "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
-    "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
-    "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
-    *) echo -e "${OVER}  ${CROSS} ${str} ${url} (${httpCode})" ;;
     esac
-    ;;
-  esac
+  fi
 
   local done="false"
   # Determine if the blocklist was downloaded and saved correctly


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

(View with without whitespace to see we're just moving a `fi` down 30 or so lines!)

Discovered an existing bug while testing #6605, where an adlist with an invalid protocol produces two error lines in gravity output - one correct, one spurious.

When a URL fails the protocol check (lines 752–756), download is set to false and an appropriate error is printed. However, because the `case $url in` block ran unconditionally after the curl guard, the remote URL (*) branch would also execute with an uninitialised `httpCode`, producing a second meaningless error line.

This was verified against the live `pihole/pihole:latest` Docker image with an adlist entry of `invalidproto://example.com/list.txt`

Before (current `master`):
```
[✗] Status: Invalid protocol specified. Ignoring list.
      Ensure your URL starts with a valid protocol like http:// , https:// or file://
[✗] Status: invalidproto://example.com/list.txt ()
```

After this fix:
```
[✗] Status: Invalid protocol specified. Ignoring list.
    Ensure your URL starts with a valid protocol like http:// , https:// or file://
[✗] List download failed: no cached list available
```

Note: this bug also affects the `file://` branches (file not found, bad permissions) in the same way — those checks already print their own error before setting `download=false`, but the case block would still fire with an empty `listCurlBuffer`, printing "Retrieval failed / empty list" as a second line.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_