### PR TITLE
fix: honor quiet mode in log flush helpers

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,12 +29,12 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     -
       name: Initialize CodeQL
-      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 #v4.35.2
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
       with:
         languages: 'python'
     -
       name: Autobuild
-      uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 #v4.35.2
+      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
     -
       name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 #v4.35.2
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,6 @@ jobs:
           severity: warning
           display-engine: sarif-fmt
 
-      - name: Secret Scanning with TruffleHog
-        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 #v3.94.3
-        with:
-          extra_args: --results=verified,unknown
 
       - name: Spell-Checking
         uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 #v2.2

--- a/advanced/Scripts/piholeDebug.sh
+++ b/advanced/Scripts/piholeDebug.sh
@@ -94,8 +94,9 @@ PIHOLE_GRAVITY_DB_FILE="$(get_ftl_conf_value "files.gravity")"
 PIHOLE_FTL_DB_FILE="$(get_ftl_conf_value "files.database")"
 
 PIHOLE_COMMAND="${BIN_DIRECTORY}/pihole"
+PIHOLE_COLTABLE_FILE="${BIN_DIRECTORY}/COL_TABLE"
 
-FTL_PID="/run/pihole-FTL.pid" # Hardcoded PID path — see GHSA-6w8x-p785-6pm4
+FTL_PID="$(get_ftl_conf_value "files.pid")"
 
 PIHOLE_LOG="${LOG_DIRECTORY}/pihole.log"
 PIHOLE_LOG_GZIPS="${LOG_DIRECTORY}/pihole.log.[0-9].*"
@@ -118,6 +119,7 @@ REQUIRED_FILES=("${PIHOLE_CRON_FILE}"
 "${PIHOLE_FTL_CONF_FILE}"
 "${PIHOLE_DNSMASQ_CONF_FILE}"
 "${PIHOLE_COMMAND}"
+"${PIHOLE_COLTABLE_FILE}"
 "${FTL_PID}"
 "${PIHOLE_LOG}"
 "${PIHOLE_LOG_GZIPS}"
@@ -288,7 +290,7 @@ check_ftl_version() {
 
 # Checks the core version of the Pi-hole codebase
 check_component_versions() {
-    # Check the Core version, branch, and commit
+    # Check the Web version, branch, and commit
     compare_local_version_to_git_version "${CORE_GIT_DIRECTORY}" "Core"
     # Check the Web version, branch, and commit
     compare_local_version_to_git_version "${WEB_GIT_DIRECTORY}" "Web"

--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -42,10 +42,34 @@ if [ -z "$WEBFILE" ]; then
     WEBFILE="/var/log/pihole/webserver.log"
 fi
 
+QUIET_MODE=false
+if [[ "$*" == *"quiet"* ]]; then
+    QUIET_MODE=true
+fi
+
+# Helper function to handle log rotation for a single file
+rotate_log() {
+    # This function copies x.log over to x.log.1
+    # and then empties x.log
+    # Note that moving the file is not an option, as
+    # dnsmasq would happily continue writing into the
+    # moved file (it will have the same file handler)
+    local logfile="$1"
+    if [[ "${QUIET_MODE}" != true ]]; then
+        echo -ne "  ${INFO} Rotating ${logfile} ..."
+    fi
+    cp -p "${logfile}" "${logfile}.1"
+    echo " " > "${logfile}"
+    chmod 640 "${logfile}"
+    if [[ "${QUIET_MODE}" != true ]]; then
+        echo -e "${OVER}  ${TICK} Rotated ${logfile} ..."
+    fi
+}
+
 # Helper function to handle log flushing for a single file
 flush_log() {
     local logfile="$1"
-    if [[ "$*" != *"quiet"* ]]; then
+    if [[ "${QUIET_MODE}" != true ]]; then
         echo -ne "  ${INFO} Flushing ${logfile} ..."
     fi
     echo " " > "${logfile}"
@@ -54,26 +78,34 @@ flush_log() {
         echo " " > "${logfile}.1"
         chmod 640 "${logfile}.1"
     fi
-    if [[ "$*" != *"quiet"* ]]; then
+    if [[ "${QUIET_MODE}" != true ]]; then
         echo -e "${OVER}  ${TICK} Flushed ${logfile} ..."
     fi
 }
 
 if [[ "$*" == *"once"* ]]; then
     # Nightly logrotation
-    # Logrotate once
-    if [[ "$*" != *"quiet"* ]]; then
-        echo -ne "  ${INFO} Running logrotate ..."
+    if command -v /usr/sbin/logrotate >/dev/null; then
+        # Logrotate once
+
+        if [[ "${QUIET_MODE}" != true ]]; then
+            echo -ne "  ${INFO} Running logrotate ..."
+        fi
+        mkdir -p "${STATEFILE%/*}"
+        /usr/sbin/logrotate --force --state "${STATEFILE}" /etc/pihole/logrotate
+    else
+        # Handle rotation for each log file
+        rotate_log "${LOGFILE}"
+        rotate_log "${FTLFILE}"
+        rotate_log "${WEBFILE}"
     fi
-    mkdir -p "${STATEFILE%/*}"
-    /usr/sbin/logrotate --force --state "${STATEFILE}" /etc/pihole/logrotate
 else
     # Manual flushing
     flush_log "${LOGFILE}"
     flush_log "${FTLFILE}"
     flush_log "${WEBFILE}"
 
-    if [[ "$*" != *"quiet"* ]]; then
+    if [[ "${QUIET_MODE}" != true ]]; then
         echo -ne "  ${INFO} Flushing database, DNS resolution temporarily unavailable ..."
     fi
 
@@ -85,7 +117,7 @@ else
 
     # Restart FTL
     service pihole-FTL restart
-    if [[ "$*" != *"quiet"* ]]; then
+    if [[ "${QUIET_MODE}" != true ]]; then
         echo -e "${OVER}  ${TICK} Deleted ${deleted} queries from long-term query database"
     fi
 fi

--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -8,36 +8,34 @@
 # This file is copyright under the latest version of the EUPL.
 # Please see LICENSE file for your rights under this license.
 
-set -o pipefail
-
 function get_local_branch() {
     # Return active branch
-    cd "${1}" 2>/dev/null || { echo "null"; return; }
-    git rev-parse --abbrev-ref HEAD || echo "null"
+    cd "${1}" 2>/dev/null || return 1
+    git rev-parse --abbrev-ref HEAD || return 1
 }
 
 function get_local_version() {
     # Return active version
-    cd "${1}" 2>/dev/null || { echo "null"; return; }
-    git describe --tags --always 2>/dev/null || echo "null"
+    cd "${1}" 2>/dev/null || return 1
+    git describe --tags --always 2>/dev/null || return 1
 }
 
 function get_local_hash() {
-    cd "${1}" 2>/dev/null || { echo "null"; return; }
-    git rev-parse --short=8 HEAD || echo "null"
+    cd "${1}" 2>/dev/null || return 1
+    git rev-parse --short=8 HEAD || return 1
 }
 
 function get_remote_version() {
     # if ${2} is = "master" we need to use the "latest" endpoint, otherwise, we simply return null
     if [[ "${2}" == "master" ]]; then
-        curl -s "https://api.github.com/repos/pi-hole/${1}/releases/latest" 2>/dev/null | jq --raw-output .tag_name || echo "null"
+        curl -s "https://api.github.com/repos/pi-hole/${1}/releases/latest" 2>/dev/null | jq --raw-output .tag_name || return 1
     else
         echo "null"
     fi
 }
 
 function get_remote_hash() {
-    git ls-remote "https://github.com/pi-hole/${1}" --tags "${2}" | awk '{print substr($0, 1,8);}' || echo "null"
+    git ls-remote "https://github.com/pi-hole/${1}" --tags "${2}" | awk '{print substr($0, 1,8);}' || return 1
 }
 
 # Source the utils file for addOrEditKeyValPair()
@@ -52,10 +50,9 @@ rm -f "/etc/pihole/GitHubVersions"
 rm -f "/etc/pihole/localbranches"
 rm -f "/etc/pihole/localversions"
 
+# Create new versions file if it does not exist
 VERSION_FILE="/etc/pihole/versions"
-
-# Truncates the file to zero length if it exists to clear it up, otherwise creates an empty file.
-truncate -s 0 "${VERSION_FILE}"
+touch "${VERSION_FILE}"
 chmod 644 "${VERSION_FILE}"
 
 # if /pihole.docker.tag file exists, we will use it's value later in this script

--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -30,6 +30,9 @@ addOrEditKeyValPair() {
   local key="${2}"
   local value="${3}"
 
+  # touch file to prevent grep error if file does not exist yet
+  touch "${file}"
+
   if grep -q "^${key}=" "${file}"; then
     # Key already exists in file, modify the value
     sed -i "/^${key}=/c\\${key}=${value}" "${file}"

--- a/advanced/Scripts/version.sh
+++ b/advanced/Scripts/version.sh
@@ -22,15 +22,6 @@ else
     loadVersionFile "${cachedVersions}"
 fi
 
-# Convert "null" or empty values to "N/A" for display
-normalize_version() {
-    if [ -z "${1}" ] || [ "${1}" = "null" ]; then
-        echo "N/A"
-    else
-        echo "${1}"
-    fi
-}
-
 main() {
     local details
     details=false
@@ -43,21 +34,21 @@ main() {
 
     if [ "${details}" = true ]; then
         echo "Core"
-        echo "    Version is $(normalize_version "${CORE_VERSION}") (Latest: $(normalize_version "${GITHUB_CORE_VERSION}"))"
-        echo "    Branch is $(normalize_version "${CORE_BRANCH}")"
-        echo "    Hash is $(normalize_version "${CORE_HASH}") (Latest: $(normalize_version "${GITHUB_CORE_HASH}"))"
+        echo "    Version is ${CORE_VERSION:=N/A} (Latest: ${GITHUB_CORE_VERSION:=N/A})"
+        echo "    Branch is ${CORE_BRANCH:=N/A}"
+        echo "    Hash is ${CORE_HASH:=N/A} (Latest: ${GITHUB_CORE_HASH:=N/A})"
         echo "Web"
-        echo "    Version is $(normalize_version "${WEB_VERSION}") (Latest: $(normalize_version "${GITHUB_WEB_VERSION}"))"
-        echo "    Branch is $(normalize_version "${WEB_BRANCH}")"
-        echo "    Hash is $(normalize_version "${WEB_HASH}") (Latest: $(normalize_version "${GITHUB_WEB_HASH}"))"
+        echo "    Version is ${WEB_VERSION:=N/A} (Latest: ${GITHUB_WEB_VERSION:=N/A})"
+        echo "    Branch is ${WEB_BRANCH:=N/A}"
+        echo "    Hash is ${WEB_HASH:=N/A} (Latest: ${GITHUB_WEB_HASH:=N/A})"
         echo "FTL"
-        echo "    Version is $(normalize_version "${FTL_VERSION}") (Latest: $(normalize_version "${GITHUB_FTL_VERSION}"))"
-        echo "    Branch is $(normalize_version "${FTL_BRANCH}")"
-        echo "    Hash is $(normalize_version "${FTL_HASH}") (Latest: $(normalize_version "${GITHUB_FTL_HASH}"))"
+        echo "    Version is ${FTL_VERSION:=N/A} (Latest: ${GITHUB_FTL_VERSION:=N/A})"
+        echo "    Branch is ${FTL_BRANCH:=N/A}"
+        echo "    Hash is ${FTL_HASH:=N/A} (Latest: ${GITHUB_FTL_HASH:=N/A})"
     else
-        echo "Core version is $(normalize_version "${CORE_VERSION}") (Latest: $(normalize_version "${GITHUB_CORE_VERSION}"))"
-        echo "Web version is $(normalize_version "${WEB_VERSION}") (Latest: $(normalize_version "${GITHUB_WEB_VERSION}"))"
-        echo "FTL version is $(normalize_version "${FTL_VERSION}") (Latest: $(normalize_version "${GITHUB_FTL_VERSION}"))"
+        echo "Core version is ${CORE_VERSION:=N/A} (Latest: ${GITHUB_CORE_VERSION:=N/A})"
+        echo "Web version is ${WEB_VERSION:=N/A} (Latest: ${GITHUB_WEB_VERSION:=N/A})"
+        echo "FTL version is ${FTL_VERSION:=N/A} (Latest: ${GITHUB_FTL_VERSION:=N/A})"
     fi
 }
 

--- a/advanced/Templates/pihole-FTL-poststop.sh
+++ b/advanced/Templates/pihole-FTL-poststop.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
 
+# Source utils.sh for getFTLConfigValue()
+PI_HOLE_SCRIPT_DIR='/opt/pihole'
+utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
+# shellcheck source="./advanced/Scripts/utils.sh"
+. "${utilsfile}"
+
+# Get file paths
+FTL_PID_FILE="$(getFTLConfigValue files.pid)"
+
 # Cleanup
-# Hardcoded PID path — see GHSA-6w8x-p785-6pm4
-rm -f /run/pihole/FTL.sock /dev/shm/FTL-* /run/pihole-FTL.pid
+rm -f /run/pihole/FTL.sock /dev/shm/FTL-* "${FTL_PID_FILE}"

--- a/advanced/Templates/pihole-FTL-prestart.sh
+++ b/advanced/Templates/pihole-FTL-prestart.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env sh
 
+# Source utils.sh for getFTLConfigValue()
+PI_HOLE_SCRIPT_DIR='/opt/pihole'
+utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
+# shellcheck source="./advanced/Scripts/utils.sh"
+. "${utilsfile}"
+
+# Get file paths
+FTL_PID_FILE="$(getFTLConfigValue files.pid)"
+FTL_LOG_FILE="$(getFTLConfigValue files.log.ftl)"
+PIHOLE_LOG_FILE="$(getFTLConfigValue files.log.dnsmasq)"
+WEBSERVER_LOG_FILE="$(getFTLConfigValue files.log.webserver)"
+FTL_PID_FILE="${FTL_PID_FILE:-/run/pihole-FTL.pid}"
+FTL_LOG_FILE="${FTL_LOG_FILE:-/var/log/pihole/FTL.log}"
+PIHOLE_LOG_FILE="${PIHOLE_LOG_FILE:-/var/log/pihole/pihole.log}"
+WEBSERVER_LOG_FILE="${WEBSERVER_LOG_FILE:-/var/log/pihole/webserver.log}"
+
 # Ensure that permissions are set so that pihole-FTL can edit all necessary files
 mkdir -p /var/log/pihole
 chown -R pihole:pihole /etc/pihole/ /var/log/pihole/
@@ -19,6 +35,8 @@ find /etc/pihole/ -type f \( -name '*.pem' -o -name '*.crt' \) -exec chmod 0600 
 chown root:root /etc/pihole/logrotate
 
 # Touch files to ensure they exist (create if non-existing, preserve if existing)
-# Hardcoded PID path — see GHSA-6w8x-p785-6pm4
-[ -f /run/pihole-FTL.pid ] || install -D -m 644 -o pihole -g pihole /dev/null /run/pihole-FTL.pid
+[ -f "${FTL_PID_FILE}" ] || install -D -m 644 -o pihole -g pihole /dev/null "${FTL_PID_FILE}"
+[ -f "${FTL_LOG_FILE}" ] || install -m 640 -o pihole -g pihole /dev/null "${FTL_LOG_FILE}"
+[ -f "${PIHOLE_LOG_FILE}" ] || install -m 640 -o pihole -g pihole /dev/null "${PIHOLE_LOG_FILE}"
+[ -f "${WEBSERVER_LOG_FILE}" ] || install -m 640 -o pihole -g pihole /dev/null "${WEBSERVER_LOG_FILE}"
 [ -f /etc/pihole/dhcp.leases ] || install -m 644 -o pihole -g pihole /dev/null /etc/pihole/dhcp.leases

--- a/advanced/Templates/pihole-FTL.service
+++ b/advanced/Templates/pihole-FTL.service
@@ -100,8 +100,11 @@ status() {
 # catch sudden termination
 trap 'cleanup; exit 1' INT HUP TERM ABRT
 
-# Get FTL's current PID (hardcoded PID path — see GHSA-6w8x-p785-6pm4)
-FTL_PID="$(getFTLPID /run/pihole-FTL.pid)"
+# Get FTL's PID file path
+FTL_PID_FILE="$(getFTLConfigValue files.pid)"
+
+# Get FTL's current PID
+FTL_PID="$(getFTLPID "${FTL_PID_FILE}")"
 
 case "$1" in
   stop)

--- a/advanced/Templates/pihole.cron
+++ b/advanced/Templates/pihole.cron
@@ -18,10 +18,10 @@
 #          early morning. Download any updates from the adlists
 #          Squash output to log, then splat the log to stdout on error to allow for
 #          standard crontab job error handling.
-59 1    * * 7   pihole    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole/pihole_updateGravity.log || cat /var/log/pihole/pihole_updateGravity.log
+59 1    * * 7   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updateGravity >/var/log/pihole/pihole_updateGravity.log || cat /var/log/pihole/pihole_updateGravity.log
 
 # Pi-hole: Flush the log daily at 00:00
-#          The flush script uses logrotate
+#          The flush script will use logrotate if available
 #          parameter "once": logrotate only once (default is twice)
 #          parameter "quiet": don't print messages
 00 00   * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole flush once quiet

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -112,19 +112,15 @@ fi
 r=20
 c=70
 
-# Version of Pi-hole's meta package on APT based systems
-# Must be incremented whenever dependencies in PIHOLE_META_PACKAGE_CONTROL_APT change
-PIHOLE_META_VERSION_APT=0.7
-
 # Content of Pi-hole's meta package control file on APT based systems
 PIHOLE_META_PACKAGE_CONTROL_APT=$(
     cat <<EOM
 Package: pihole-meta
-Version: ${PIHOLE_META_VERSION_APT}
+Version: 0.6
 Maintainer: Pi-hole team <adblock@pi-hole.net>
 Architecture: all
 Description: Pi-hole dependency meta package
-Depends: awk,bash-completion,binutils,ca-certificates,cron|cron-daemon,curl,dialog,bind9-dnsutils|dnsutils,dns-root-data,git,grep,iproute2,iputils-ping,jq,libcap2,libcap2-bin,logrotate,lshw,procps,psmisc,sudo,unzip
+Depends: awk,bash-completion,binutils,ca-certificates,cron|cron-daemon,curl,dialog,bind9-dnsutils|dnsutils,dns-root-data,git,grep,iproute2,iputils-ping,jq,libcap2,libcap2-bin,lshw,procps,psmisc,sudo,unzip
 Section: contrib/metapackages
 Priority: optional
 EOM
@@ -134,12 +130,12 @@ EOM
 PIHOLE_META_PACKAGE_CONTROL_RPM=$(
     cat <<EOM
 Name: pihole-meta
-Version: 0.4
+Version: 0.3
 Release: 1
 License: EUPL
 BuildArch: noarch
 Summary: Pi-hole dependency meta package
-Requires: bash-completion,bind-utils,binutils,ca-certificates,chkconfig,cronie,curl,dialog,findutils,gawk,git,grep,iproute,jq,libcap,logrotate,lshw,procps-ng,psmisc,sudo,unzip
+Requires: bash-completion,bind-utils,binutils,ca-certificates,chkconfig,cronie,curl,dialog,findutils,gawk,git,grep,iproute,jq,libcap,lshw,procps-ng,psmisc,sudo,unzip
 %description
 Pi-hole dependency meta package
 %prep
@@ -147,9 +143,6 @@ Pi-hole dependency meta package
 %files
 %install
 %changelog
-* Thu Dec 18 2025 Pi-hole Team - 0.4
-- Add logrotate to the list of dependencies
-
 * Mon Jul 14 2025 Pi-hole Team - 0.3
 - Remove nmap-ncat from the list of dependencies
 
@@ -287,6 +280,8 @@ package_manager_detect() {
         UPDATE_PKG_CACHE="${PKG_MANAGER} update"
         # The command we will use to actually install packages
         PKG_INSTALL="${PKG_MANAGER} -qq --no-install-recommends install"
+        # grep -c will return 1 if there are no matches. This is an acceptable condition, so we OR TRUE to prevent set -e exiting the script.
+        PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
         # The command we will use to remove packages (used in the uninstaller)
         PKG_REMOVE="${PKG_MANAGER} -y remove --purge"
 
@@ -301,6 +296,8 @@ package_manager_detect() {
 
         # These variable names match the ones for apt-get. See above for an explanation of what they are for.
         PKG_INSTALL="${PKG_MANAGER} install -y"
+        # CentOS package manager returns 100 when there are packages to update so we need to || true to prevent the script from exiting.
+        PKG_COUNT="${PKG_MANAGER} check-update | grep -E '(.i686|.x86|.noarch|.arm|.src|.riscv64)' | wc -l || true"
         # The command we will use to remove packages (used in the uninstaller)
         PKG_REMOVE="${PKG_MANAGER} remove -y"
 
@@ -309,6 +306,7 @@ package_manager_detect() {
         PKG_MANAGER="apk"
         UPDATE_PKG_CACHE="${PKG_MANAGER} update"
         PKG_INSTALL="${PKG_MANAGER} add"
+        PKG_COUNT="${PKG_MANAGER} list --upgradable -q | wc -l"
         PKG_REMOVE="${PKG_MANAGER} del"
 
     else
@@ -1375,8 +1373,8 @@ EOF
 }
 
 update_package_cache() {
-    # Update package cache on apt based OSes. Only called when pihole-meta is
-    # absent or outdated, so new dependencies can be resolved by apt.
+    # Update package cache on apt based OSes. Do this every time since
+    # it's quick and packages can be updated at any time.
 
     # Local, named variables
     local str="Update local cache of available packages"
@@ -1395,6 +1393,23 @@ update_package_cache() {
         printf "%b  %b %s\\n" "${OVER}" "${CROSS}" "${str}"
         printf "  %b Error: Unable to update package cache. Please try \"%s\"%b\\n" "${COL_RED}" "sudo ${UPDATE_PKG_CACHE}" "${COL_NC}"
         return 1
+    fi
+}
+
+# Let user know if they have outdated packages on their system and
+# advise them to run a package update at soonest possible.
+notify_package_updates_available() {
+    # Local, named variables
+    local str="Checking ${PKG_MANAGER} for upgraded packages"
+    printf "\\n  %b %s..." "${INFO}" "${str}"
+    # Store the list of packages in a variable
+    updatesToInstall=$(eval "${PKG_COUNT}")
+
+    if [[ "${updatesToInstall}" -eq 0 ]]; then
+        printf "%b  %b %s... up to date!\\n\\n" "${OVER}" "${TICK}" "${str}"
+    else
+        printf "%b  %b %s... %s updates available\\n" "${OVER}" "${TICK}" "${str}" "${updatesToInstall}"
+        printf "  %b %bIt is recommended to update your OS after installing the Pi-hole!%b\\n\\n" "${INFO}" "${COL_GREEN}" "${COL_NC}"
     fi
 }
 
@@ -2290,18 +2305,13 @@ main() {
     # Check for supported package managers so that we may install dependencies
     package_manager_detect
 
-    # Only update the apt package cache when pihole-meta is absent or outdated.
-    # On a fresh install the package won't exist yet so the cache update always
-    # runs. On upgrades it only runs when the meta version has bumped, meaning
-    # new dependencies may have been added. This saves time and I/O on
-    # resource-constrained hardware (e.g. SD cards).
+    # Update package cache only on apt based systems
     if is_command apt-get; then
-        local installed_meta_version
-        installed_meta_version=$(dpkg-query -W -f='${Version}' pihole-meta 2>/dev/null) || true
-        if dpkg --compare-versions "${installed_meta_version}" lt "${PIHOLE_META_VERSION_APT}"; then
             update_package_cache || exit 1
-        fi
     fi
+
+    # Notify user of package availability
+    notify_package_updates_available
 
     # Build dependency package
     build_dependency_package

--- a/gravity.sh
+++ b/gravity.sh
@@ -71,10 +71,8 @@ fix_owner_permissions() {
   chown pihole:pihole "${1}"
   chmod 664 "${1}"
 
-  # Ensure the containing directory is owned by pihole:pihole
-  # so the pihole user can write to it without requiring group-write
-  # permissions (which would change the directory mode unexpectedly)
-  chown pihole:pihole "$(dirname -- "${1}")"
+  # Ensure the containing directory is group writable
+  chmod g+w "$(dirname -- "${1}")"
 }
 
 # Generate new SQLite3 file from schema template
@@ -614,8 +612,8 @@ compareLists() {
 # Download specified URL and perform checks on HTTP status and file content
 gravity_DownloadBlocklistFromUrl() {
   local url="${1}" adlistID="${2}" saveLocation="${3}" compression="${4}" gravity_type="${5}" domain="${6}"
-  local listCurlBuffer str curlVersion curlOutput httpCode curlErrorMsg="" curlExitCode="" curlOutputFormat=""
-  local success="" ip customUpstreamResolver="" file_path ip_addr port blocked=false download=true
+  local listCurlBuffer str httpCode success="" ip customUpstreamResolver=""
+  local file_path permissions ip_addr port blocked=false download=true
   # modifiedOptions is an array to store all the options used to check if the adlist has been changed upstream
   local modifiedOptions=()
 
@@ -724,40 +722,29 @@ gravity_DownloadBlocklistFromUrl() {
     fi
   fi
 
-  # If we "download" a local file (file://), verify read access before using it.
-  # When running as root (e.g., via pihole -g), check that the 'pihole' user can read the file
-  # to match the effective runtime user of FTL; otherwise, check the current user's read access
-  # (e.g., in Docker or when invoked by a non-root user). The target must
-  # resolve to a regular file and be readable by the evaluated user.
-  if [[ "${url}" == "file:/"* ]]; then
+  # If we are going to "download" a local file, we first check if the target
+  # file has a+r permission. We explicitly check for all+read because we want
+  # to make sure that the file is readable by everyone and not just the user
+  # running the script.
+  if [[ $url == "file://"* ]]; then
     # Get the file path
-    file_path=$(echo "${url}" | cut -d'/' -f3-)
+    file_path=$(echo "$url" | cut -d'/' -f3-)
     # Check if the file exists and is a regular file (i.e. not a socket, fifo, tty, block). Might still be a symlink.
-    if [[ ! -f ${file_path} ]]; then
-        # Output that the file does not exist
-        echo -e "${OVER}  ${CROSS} ${file_path} does not exist"
-        download=false
+    if [[ ! -f $file_path ]]; then
+      # Output that the file does not exist
+      echo -e "${OVER}  ${CROSS} ${file_path} does not exist"
+      download=false
     else
-        if [ "$(id -un)" == "root" ]; then
-            # If we are root, we need to check if the pihole user has read permission
-            #  otherwise, we might read files that the pihole user should not be able to read
-            if sudo -u pihole test -r "${file_path}"; then
-                echo -e "${OVER}  ${INFO} Using local file ${file_path}"
-            else
-                echo -e "${OVER}  ${CROSS} Cannot read file (user 'pihole' lacks read permission)"
-                download=false
-            fi
-        else
-            # If we are not root, we just check if the current user has read permission
-            if [[ -r "${file_path}" ]]; then
-                # Output that we are using the local file
-                echo -e "${OVER}  ${INFO} Using local file ${file_path}"
-            else
-                # Output that the file is not readable by the current user
-                echo -e "${OVER}  ${CROSS} Cannot read file (current user '$(id -un)' lacks read permission)"
-                download=false
-            fi
-        fi
+      # Check if the file or a file referenced by the symlink has a+r permissions
+      permissions=$(stat -L -c "%a" "$file_path")
+      if [[ $permissions == *4 || $permissions == *5 || $permissions == *6 || $permissions == *7 ]]; then
+        # Output that we are using the local file
+        echo -e "${OVER}  ${INFO} Using local file ${file_path}"
+      else
+        # Output that the file does not have the correct permissions
+        echo -e "${OVER}  ${CROSS} Cannot read file (file needs to have a+r permission)"
+        download=false
+      fi
     fi
   fi
 
@@ -769,37 +756,8 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   if [[ "${download}" == true ]]; then
-    # Define the generic error message
-    curlOutputFormat='%{http_code};No message available. Non supported curl version.'
-
-    # Check if the installed curl version supports the "-w %{errormsg}" option (available as of curl 7.75.0)
-    # (https://github.com/pi-hole/pi-hole/pull/6605#discussion_r3112153347)
-    # First we get the current curl version.
-    curlVersion=$(curl --version | awk '{print $2;exit}')
-    # After that, we pipe the current version along with the string '7.75' (the minimum version supporting the required option.)
-    # Then we sort the list in natural (version) order and return the first item which will be the lowest version seen.
-    # If it is "7.75" then the current version is greater than or equal to "7.75.0".
-    # Compatibility notes:
-    #   Busybox doesn't support some long flags:
-    #   - "sort -V" is short form of "sort --version-sort"
-    #   - "head -n1" is short form of "head --lines=1"
-    if [[ "$(printf '%s\n' "${curlVersion}" "7.75" | sort -V | head -n1)" == 7.75 ]]; then
-        # Use the error message returned by curl
-        curlOutputFormat='%{http_code};%{errormsg}'
-    fi
-
-    # This command will output the HTTP code and an error message, if available.
-    # Error messages are suppressed by "-s" option.
-    # By default curl returns exitcode=0 even an HTTP code happens (403, 404, 500, etc). To fix
-    # this, we use the "--fail" option to force curl to return a non-zero exit code.
-    # If curl version is older than 7.75.0, curl can't generate the errormsg output. In this case,
-    # a generic message is returned.
-    curlOutput=$(curl --connect-timeout ${curl_connect_timeout} -s --fail -L ${compression:+${compression}} ${customUpstreamResolver:+${customUpstreamResolver}} "${modifiedOptions[@]}" -w "${curlOutputFormat}" "${url}" -o "${listCurlBuffer}")
-    curlExitCode="$?"
+    httpCode=$(curl --connect-timeout ${curl_connect_timeout} -s -L ${compression:+${compression}} ${customUpstreamResolver:+${customUpstreamResolver}} "${modifiedOptions[@]}" -w "%{http_code}" "${url}" -o "${listCurlBuffer}" 2>/dev/null)
   fi
-
-  # Retrieve http_code and errormsg values, returned by curl command
-  IFS=";" read -r httpCode curlErrorMsg <<<"$curlOutput"
 
   case $url in
   # Did we "download" a local file?
@@ -813,28 +771,27 @@ gravity_DownloadBlocklistFromUrl() {
     ;;
   # Did we "download" a remote file?
   *)
-    # Use the exit code to determine if curl was successful or not.
-    # Use HTTP code only to select the correct error message.
-    if [[ "${curlExitCode}" == "0" ]]; then
-      case "${httpCode}" in
-        "200") echo -e "${OVER}  ${TICK} ${str} Retrieval successful" ;;
-        "304") echo -e "${OVER}  ${TICK} ${str} No changes detected"  ;;
-        *) echo -e "${OVER}  ${TICK} ${str} Success (http_code=${COL_CYAN}${httpCode}${COL_NC})"  ;;
-      esac
+    # Determine "Status:" output based on HTTP response
+    case "${httpCode}" in
+    "200")
+      echo -e "${OVER}  ${TICK} ${str} Retrieval successful"
       success=true
-    else
-      case "${httpCode}" in
-        "403") echo -e "${OVER}  ${CROSS} ${str} Forbidden" ;;
-        "404") echo -e "${OVER}  ${CROSS} ${str} Not found" ;;
-        "408") echo -e "${OVER}  ${CROSS} ${str} Time-out" ;;
-        "451") echo -e "${OVER}  ${CROSS} ${str} Unavailable For Legal Reasons" ;;
-        "500") echo -e "${OVER}  ${CROSS} ${str} Internal Server Error" ;;
-        "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
-        "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
-        "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
-        *) echo -e "${OVER}  ${CROSS} ${str} Retrieval failed (exit_code=${COL_CYAN}${curlExitCode}${COL_NC} Msg: ${COL_CYAN}${curlErrorMsg}${COL_NC})" ;;
-      esac
-    fi
+      ;;
+    "304")
+      echo -e "${OVER}  ${TICK} ${str} No changes detected"
+      success=true
+      ;;
+    "000") echo -e "${OVER}  ${CROSS} ${str} Connection Refused" ;;
+    "403") echo -e "${OVER}  ${CROSS} ${str} Forbidden" ;;
+    "404") echo -e "${OVER}  ${CROSS} ${str} Not found" ;;
+    "408") echo -e "${OVER}  ${CROSS} ${str} Time-out" ;;
+    "451") echo -e "${OVER}  ${CROSS} ${str} Unavailable For Legal Reasons" ;;
+    "500") echo -e "${OVER}  ${CROSS} ${str} Internal Server Error" ;;
+    "504") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Gateway)" ;;
+    "521") echo -e "${OVER}  ${CROSS} ${str} Web Server Is Down (Cloudflare)" ;;
+    "522") echo -e "${OVER}  ${CROSS} ${str} Connection Timed Out (Cloudflare)" ;;
+    *) echo -e "${OVER}  ${CROSS} ${str} ${url} (${httpCode})" ;;
+    esac
     ;;
   esac
 
@@ -855,10 +812,6 @@ gravity_DownloadBlocklistFromUrl() {
       fix_owner_permissions "${saveLocation}"
       # Compare lists if they are identical
       compareLists "${adlistID}" "${saveLocation}"
-      # Set permissions for the *.etag file
-      if [[ -f "${saveLocation}.etag" ]]; then
-          fix_owner_permissions "${saveLocation}.etag"
-      fi
       # Add domains to database table file
       pihole-FTL "${gravity_type}" parseList "${saveLocation}" "${gravityTEMPfile}" "${adlistID}"
       done="true"

--- a/pihole
+++ b/pihole
@@ -16,9 +16,6 @@ PI_HOLE_SCRIPT_DIR="/opt/pihole"
 # error due to modifying a readonly variable.
 PI_HOLE_BIN_DIR="/usr/local/bin"
 
-# Hardcoded PID path — see GHSA-6w8x-p785-6pm4
-readonly FTL_PID_FILE="/run/pihole-FTL.pid"
-
 readonly colfile="${PI_HOLE_SCRIPT_DIR}/COL_TABLE"
 # shellcheck source=./advanced/Scripts/COL_TABLE
 source "${colfile}"
@@ -159,8 +156,11 @@ versionFunc() {
 }
 
 reloadDNS() {
-  local svcOption svc str output status pid icon sigrtmin
+  local svcOption svc str output status pid icon FTL_PID_FILE sigrtmin
   svcOption="${1:-reload}"
+
+  # get the current path to the pihole-FTL.pid
+  FTL_PID_FILE="$(getFTLConfigValue files.pid)"
 
   # Determine if we should reload or restart
   if [[ "${svcOption}" =~ "reload-lists" ]]; then
@@ -169,7 +169,7 @@ reloadDNS() {
     # Note 2: We cannot use killall here as it does
     #         not know about real-time signals
 
-    pid="$(getFTLPID "${FTL_PID_FILE}")"
+    pid="$(getFTLPID ${FTL_PID_FILE})"
     if [[ "$pid" -eq "-1" ]]; then
       svc="true"
       str="FTL is not running"
@@ -185,7 +185,7 @@ reloadDNS() {
   elif [[ "${svcOption}" =~ "reload" ]]; then
     # Reloading of the DNS cache has been requested
     # Note: This will NOT re-read any *.conf files
-    pid="$(getFTLPID "${FTL_PID_FILE}")"
+    pid="$(getFTLPID ${FTL_PID_FILE})"
     if [[ "$pid" -eq "-1" ]]; then
       svc="true"
       str="FTL is not running"
@@ -343,9 +343,11 @@ analyze_ports() {
 
 statusFunc() {
     # Determine if there is pihole-FTL service is listening
-    local pid port block_status
+    local pid port ftl_pid_file block_status
 
-    pid="$(getFTLPID "${FTL_PID_FILE}")"
+    ftl_pid_file="$(getFTLConfigValue files.pid)"
+
+    pid="$(getFTLPID ${ftl_pid_file})"
 
     if [[ "$pid" -eq "-1" ]]; then
         case "${1}" in

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml == 6.0.3
-pytest == 9.0.3
+pytest == 9.0.2
 pytest-xdist == 3.8.0
 pytest-testinfra == 10.2.2
-tox == 4.52.1
+tox == 4.51.0
 pytest-clarity == 1.0.1

--- a/test/test_any_utils.py
+++ b/test/test_any_utils.py
@@ -2,7 +2,6 @@ def test_key_val_replacement_works(host):
     """Confirms addOrEditKeyValPair either adds or replaces a key value pair in a given file"""
     host.run("""
     source /opt/pihole/utils.sh
-    touch ./testoutput
     addOrEditKeyValPair "./testoutput" "KEY_ONE" "value1"
     addOrEditKeyValPair "./testoutput" "KEY_TWO" "value2"
     addOrEditKeyValPair "./testoutput" "KEY_ONE" "value3"


### PR DESCRIPTION
## Summary
- detect quiet mode once at script startup
- reuse the quiet flag inside rotate_log() and flush_log()
- suppress helper output when `pihole flush once quiet` is used

Closes #6289
