### PR TITLE
Replace `head` with `sed` to avoid error messages on the web interface

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -782,8 +782,9 @@ gravity_DownloadBlocklistFromUrl() {
     # Compatibility notes:
     #   Busybox doesn't support some long flags:
     #   - "sort -V" is short form of "sort --version-sort"
-    #   - "head -n1" is short form of "head --lines=1"
-    if [[ "$(printf '%s\n' "${curlVersion}" "7.75" | sort -V | head -n1)" == 7.75 ]]; then
+    # Note: "sed '1q'" returns only the first line (like "head -n1"), but it doesn't generate an error message.
+    # (see https://github.com/pi-hole/pi-hole/issues/6615)
+    if [[ "$(printf '%s\n' "${curlVersion}" "7.75" | sort -V | sed '1q')" == 7.75 ]]; then
         # Use the error message returned by curl
         curlOutputFormat='%{http_code};%{errormsg}'
     fi


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fixes https://github.com/pi-hole/pi-hole/issues/6615

### How does this PR accomplish the above?

Replacing `head -n1` with `sed '1q'` to return the first line.

Both commands execute the same job, but apparently, in some cases, `head` command finishes reading its requested lines and immediately closes its input stream while sort is still trying to write the remaining output. On the other hand, `sed` will read the whole stream before closing the pipe.

Note: This issue usually doesn't happen on interactive terminals.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
