### PR TITLE
fix: resolve readonly variable conflict in getFTLPID

### DIFF
--- a/advanced/Scripts/utils.sh
+++ b/advanced/Scripts/utils.sh
@@ -97,12 +97,12 @@ loadVersionFile() {
 # Example getFTLPID "/run/pihole-FTL.pid"
 #######################
 getFTLPID() {
-    local FTL_PID_FILE="${1}"
+    local _ftl_pid_file="${1}"
     local FTL_PID
 
-    if [ -s "${FTL_PID_FILE}" ]; then
+    if [ -s "${_ftl_pid_file}" ]; then
         # -s: FILE exists and has a size greater than zero
-        FTL_PID="$(cat "${FTL_PID_FILE}")"
+        FTL_PID="$(cat "${_ftl_pid_file}")"
         # Exploit prevention: unset the variable if there is malicious content
         # Verify that the value read from the file is numeric
         expr "${FTL_PID}" : "[^[:digit:]]" > /dev/null && unset FTL_PID


### PR DESCRIPTION
## Description

This PR fixes issue #6612 where running `pihole status` in Docker environments shows the error:
```
/opt/pihole/utils.sh: line 100: local: FTL_PID_FILE: readonly variable
```

## Root Cause

The `getFTLPID()` function in `utils.sh` declares a local variable `FTL_PID_FILE`, but this variable name conflicts with a readonly variable already defined in the parent `pihole` script. When `utils.sh` is sourced and `getFTLPID()` is called, the `local` declaration fails because the variable is readonly in the parent scope.

## Solution

Rename the local variable from `FTL_PID_FILE` to `_ftl_pid_file` (lowercase with underscore prefix) to avoid the naming conflict. This is a minimal, safe change that:

- Avoids the readonly variable conflict
- Maintains the same functionality
- Follows shell scripting best practices (local variables should not use ALL_CAPS names that might conflict with environment variables)

## Testing

The fix has been tested locally and resolves the error message without affecting the function's behavior.

## Related Issue

Closes #6612
