### PR TITLE
fix: check return codes in gravity_build_tree and database_recovery()

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -965,6 +965,8 @@ database_recovery() {
   local result
   local str="Checking integrity of existing gravity database (this can take a while)"
   local option="${1}"
+  local recoverySQL="${gravityDBfile}.recovery.sql"
+  trap 'rm -f "${recoverySQL}"' RETURN
   echo -ne "  ${INFO} ${str}..."
   result="$(pihole-FTL sqlite3 -ni "${gravityDBfile}" "PRAGMA integrity_check" 2>&1)"
 
@@ -993,17 +995,26 @@ database_recovery() {
   echo -ne "  ${INFO} ${str}..."
   # We have to remove any possibly existing recovery database or this will fail
   rm -f "${gravityDBfile}.recovered" >/dev/null 2>&1
-  if result="$(pihole-FTL sqlite3 -ni "${gravityDBfile}" ".recover" | pihole-FTL sqlite3 -ni "${gravityDBfile}.recovered" 2>&1)"; then
-    echo -e "${OVER}  ${TICK} ${str} - success"
-    mv "${gravityDBfile}" "${gravityDBfile}.old"
-    mv "${gravityDBfile}.recovered" "${gravityDBfile}"
-    echo -ne " ${INFO} ${gravityDBfile} has been recovered"
-    echo -ne " ${INFO} The old ${gravityDBfile} has been moved to ${gravityDBfile}.old"
+  # Stage .recover output to a temp file so each command's exit status can
+  # be checked independently. Piping would hide a failing .recover because
+  # bash reports the RHS exit status for the whole pipe.
+  if pihole-FTL sqlite3 -ni "${gravityDBfile}" ".recover" > "${recoverySQL}"; then
+    if result="$(pihole-FTL sqlite3 -ni "${gravityDBfile}.recovered" < "${recoverySQL}" 2>&1)"; then
+      echo -e "${OVER}  ${TICK} ${str} - success"
+      mv "${gravityDBfile}" "${gravityDBfile}.old"
+      mv "${gravityDBfile}.recovered" "${gravityDBfile}"
+      echo -ne " ${INFO} ${gravityDBfile} has been recovered"
+      echo -ne " ${INFO} The old ${gravityDBfile} has been moved to ${gravityDBfile}.old"
+    else
+      echo -e "${OVER}  ${CROSS} ${str} - the following errors happened:"
+      while IFS= read -r line; do echo "  - $line"; done <<<"$result"
+      echo -e "  ${CROSS} Recovery failed. Try \"pihole -g -r recreate\" instead."
+      return 1
+    fi
   else
-    echo -e "${OVER}  ${CROSS} ${str} - the following errors happened:"
-    while IFS= read -r line; do echo "  - $line"; done <<<"$result"
+    echo -e "${OVER}  ${CROSS} ${str} - .recover command failed"
     echo -e "  ${CROSS} Recovery failed. Try \"pihole -g -r recreate\" instead."
-    exit 1
+    return 1
   fi
   echo ""
 }
@@ -1171,7 +1182,7 @@ if [[ "${recreate_database:-}" == true ]]; then
 fi
 
 if [[ "${recover_database:-}" == true ]]; then
-  timeit database_recovery "$4"
+  timeit database_recovery "$4" || exit 1
 fi
 
 # Migrate scattered list files to the new cache directory
@@ -1204,8 +1215,12 @@ update_gravity_timestamp
 fix_owner_permissions "${gravityTEMPfile}"
 
 # Build the tree
-timeit gravity_build_tree gravity
-timeit gravity_build_tree antigravity
+if ! timeit gravity_build_tree gravity; then
+  exit 1
+fi
+if ! timeit gravity_build_tree antigravity; then
+  exit 1
+fi
 
 # Compute numbers to be displayed (do this after building the tree to get the
 # numbers quickly from the tree instead of having to scan the whole database)


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

> **Behavior change to flag:** This PR changes `pihole -g` from exit-0-on-silent-failure to exit-non-zero-on-failure for the `database_recovery` error paths. The weekly cron job will now correctly report failure on I/O errors that previously fell through silently. This is the intended behavior, but worth flagging for any orchestration that treats non-zero exit codes as restart signals.

**What does this PR aim to accomplish?:**

Two unchecked return codes in `gravity.sh` can silently degrade or completely break DNS blocking with no error logged.

`gravity_build_tree` is called twice (lines 1218 and 1221) with no exit status check. If either call fails (disk full, I/O error, database corruption), execution continues and `gravity_swap_databases` installs a database with no search indexes. FTL then performs full table scans on every DNS lookup against a potentially million-entry blocklist, causing DNS timeouts with no error in the logs. This runs on every `pihole -g`, including the weekly cron job.

`database_recovery()` pipes `.recover` output directly into a second `sqlite3` command. Without `pipefail`, bash evaluates the pipe on the RHS exit status only. If `.recover` fails, the second `sqlite3` receives empty input, exits 0, and the if-branch signals success. The empty `.recovered` database is then swapped into production, silently breaking DNS blocking. This is a bug in the error-recovery path itself: it triggers precisely when the database is already corrupt and makes the situation worse without any logged indication.

Neither issue has a specific crash report behind it, but both connect to open issues documenting real failures in the field. The gravity_build_tree gap relates to the class of bug described in #5244 ("gravity doesn't exit if there is a storage problem"). The recovery pipe silent-success path is a contributing factor in failures like those documented in #5168 ("Failed gravity update loses whole DB / configuration"). Both are logic gaps identified during a code review of the gravity update flow.

**How does this PR accomplish the above?:**

For `gravity_build_tree`: wrap both calls in `if !` guards and call `exit 1` on failure. No additional error message is needed; `gravity_build_tree` already prints `"Unable to build ${table} tree in ${gravityTEMPfile}"` and the sqlite3 error detail on failure. The `if ! timeit ...; then exit 1; fi` pattern matches lines 1192-1195 and 1234-1237 in the same flow. Confirmed `gravity_build_tree` only returns non-zero on genuine failure (sqlite3 `CREATE INDEX` error), so the hard-exit on failure is appropriate.

For `database_recovery`: stage the `.recover` SQL output to a temp file (`${gravityDBfile}.recovery.sql`) so each command's exit status is checked independently before proceeding. The error paths use `return 1` instead of `exit 1`, which lets a `RETURN` trap handle temp-file cleanup across all paths (success, failure, and interruption) without explicit `rm -f` in each branch. On failure, the function returns 1 with a clear error message; the call site uses `|| exit 1` to terminate the script. This eliminates the silent empty-database scenario entirely.

Considered `set -o pipefail` for `database_recovery`. Chose the temp-file approach to keep the change scoped to the function being fixed; enabling `pipefail` script-wide could surface latent issues elsewhere in `gravity.sh` that are out of scope for this PR. Happy to switch approaches if maintainers prefer.

**Link documentation PRs if any are needed to support this PR:**

No documentation changes needed.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*