### PR TITLE
Improve gravity error handling

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -163,7 +163,7 @@ gravity_swap_databases() {
   mv "${gravityTEMPfile}" "${gravityDBfile}"
   echo -e "${OVER}  ${TICK} ${str}"
 
-  if $oldAvail; then
+  if ${oldAvail}; then
     echo -e "  ${TICK} The old database remains available"
   fi
 }
@@ -217,7 +217,7 @@ database_table_from_file() {
   # Get MAX(id) from domainlist when INSERTing into this table
   if [[ "${table}" == "domainlist" ]]; then
     rowid="$(pihole-FTL sqlite3 -ni "${gravityDBfile}" "SELECT MAX(id) FROM domainlist;")"
-    if [[ -z "$rowid" ]]; then
+    if [[ -z "${rowid}" ]]; then
       rowid=0
     fi
     rowid+=1
@@ -541,10 +541,10 @@ gravity_DownloadBlocklists() {
 
   # Loop through $sources and download each one
   for ((i = 0; i < "${#sources[@]}"; i++)); do
-    url="${sources[$i]}"
-    domain="${sourceDomains[$i]}"
-    id="${sourceIDs[$i]}"
-    if [[ "${sourceTypes[$i]}" -eq "0" ]]; then
+    url="${sources[${i}]}"
+    domain="${sourceDomains[${i}]}"
+    id="${sourceIDs[${i}]}"
+    if [[ "${sourceTypes[${i}]}" -eq "0" ]]; then
       # Gravity list
       str="blocklist"
       adlist_type="gravity"
@@ -583,12 +583,12 @@ gravity_DownloadBlocklists() {
 
     # this will remove first @ that is after schema and before domain
     # \1 is optional schema, \2 is userinfo
-    check_url="$(sed -re 's#([^:/]*://)?([^/]+)@#\1\2#' <<<"$url")"
+    check_url="$(sed -re 's#([^:/]*://)?([^/]+)@#\1\2#' <<<"${url}")"
 
     if [[ "${check_url}" =~ ${regex} ]]; then
       echo -e "  ${CROSS} Invalid Target"
     else
-      timeit gravity_DownloadBlocklistFromUrl "${url}" "${sourceIDs[$i]}" "${saveLocation}" "${compression}" "${adlist_type}" "${domain}"
+      timeit gravity_DownloadBlocklistFromUrl "${url}" "${sourceIDs[${i}]}" "${saveLocation}" "${compression}" "${adlist_type}" "${domain}"
     fi
     echo ""
   done
@@ -636,7 +636,7 @@ gravity_DownloadBlocklistFromUrl() {
 
   # For all remote files, we try to determine if the file has changed to skip
   # downloading them whenever possible.
-  if [[ $url != "file"* ]]; then
+  if [[ ${url} != "file"* ]]; then
     # Use the HTTP ETag header to determine if the file has changed if supported
     # by curl. Using ETags is supported by raw.githubusercontent.com URLs.
     if [[ "${etag_support}" == true ]]; then
@@ -672,7 +672,7 @@ gravity_DownloadBlocklistFromUrl() {
   blocked=false
   # Check if this domain is blocked by Pi-hole but only if the domain is not a
   # local file or empty
-  if [[ $url != "file"* ]] && [[ -n "${domain}" ]]; then
+  if [[ ${url} != "file"* ]] && [[ -n "${domain}" ]]; then
     case $(getFTLConfigValue dns.blocking.mode) in
     "IP-NODATA-AAAA" | "IP")
       # Get IP address of this domain
@@ -729,7 +729,7 @@ gravity_DownloadBlocklistFromUrl() {
       fi
       echo -e "${OVER}  ${CROSS} ${str} ${domain} is blocked by one of your lists. Using DNS server ${upstream} instead"
       echo -ne "  ${INFO} ${str} Pending..."
-      customUpstreamResolver="--resolve $domain:$port:$ip"
+      customUpstreamResolver="--resolve ${domain}:${port}:${ip}"
     fi
   fi
 
@@ -771,7 +771,7 @@ gravity_DownloadBlocklistFromUrl() {
   fi
 
   # Check for allowed protocols
-  if [[ $url != "http"* && $url != "https"* && $url != "file"* && $url != "ftp"* && $url != "ftps"* && $url != "sftp"* ]]; then
+  if [[ ${url} != "http"* && ${url} != "https"* && ${url} != "file"* && ${url} != "ftp"* && ${url} != "ftps"* && ${url} != "sftp"* ]]; then
     echo -e "${OVER}  ${CROSS} ${str} Invalid protocol specified. Ignoring list."
     echo -e "      Ensure your URL starts with a valid protocol like http:// , https:// or file:// ."
     download=false
@@ -812,9 +812,9 @@ gravity_DownloadBlocklistFromUrl() {
 
 
     # Retrieve http_code and errormsg values, returned by curl command
-    IFS=";" read -r httpCode curlErrorMsg <<<"$curlOutput"
+    IFS=";" read -r httpCode curlErrorMsg <<<"${curlOutput}"
 
-    case $url in
+    case ${url} in
     # Did we "download" a local file?
     "file"*)
       if [[ -s "${listCurlBuffer}" ]]; then
@@ -994,11 +994,11 @@ database_recovery() {
       fi
     else
       echo -e "${OVER}  ${CROSS} ${str} - errors found:"
-      while IFS= read -r line; do echo "  - $line"; done <<<"$result"
+      while IFS= read -r line; do echo "  - ${line}"; done <<<"${result}"
     fi
   else
     echo -e "${OVER}  ${CROSS} ${str} - errors found:"
-    while IFS= read -r line; do echo "  - $line"; done <<<"$result"
+    while IFS= read -r line; do echo "  - ${line}"; done <<<"${result}"
   fi
 
   str="Trying to recover existing gravity database"
@@ -1013,7 +1013,7 @@ database_recovery() {
     echo -ne " ${INFO} The old ${gravityDBfile} has been moved to ${gravityDBfile}.old"
   else
     echo -e "${OVER}  ${CROSS} ${str} - the following errors happened:"
-    while IFS= read -r line; do echo "  - $line"; done <<<"$result"
+    while IFS= read -r line; do echo "  - ${line}"; done <<<"${result}"
     echo -e "  ${CROSS} Recovery failed. Try \"pihole -g -r recreate\" instead."
     gravity_Cleanup "error"
   fi
@@ -1069,7 +1069,7 @@ timeit(){
   ret=$?
 
   if [[ "${timed:-}" != true ]]; then
-    return $ret
+    return ${ret}
   fi
 
   # Capture the end time
@@ -1081,7 +1081,7 @@ timeit(){
   # Display the elapsed time
   printf "  %b--> took %d.%03d seconds%b\n" "${COL_BLUE}" $((elapsed_time / 1000)) $((elapsed_time % 1000)) "${COL_NC}"
 
-  return $ret
+  return ${ret}
 }
 
 migrate_to_listsCache_dir() {

--- a/gravity.sh
+++ b/gravity.sh
@@ -98,7 +98,8 @@ gravity_build_tree() {
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to build ${table} tree in ${gravityTEMPfile}\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to build ${table} tree in ${gravityTEMPfile}\\n"
+    echo -e "  ${CROSS} ${output}\\n"
     echo -e "  ${INFO} If you have a large amount of domains, make sure your Pi-hole has enough RAM available\\n"
     return 1
   fi
@@ -141,7 +142,8 @@ gravity_swap_databases() {
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to clean current database for backup\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to clean current database for backup\\n"
+    echo -e "  ${CROSS} ${output}\\n"
   else
     # Check if the backup directory exists
     if [ ! -d "${gravityBCKdir}" ]; then
@@ -172,7 +174,8 @@ update_gravity_timestamp() {
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to update gravity timestamp in database ${gravityTEMPfile}\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to update gravity timestamp in database ${gravityTEMPfile}\\n"
+    echo -e "  ${CROSS} ${output}\\n"
     return 1
   fi
   return 0
@@ -243,7 +246,8 @@ database_table_from_file() {
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to fill table ${table}${list_type} in database ${gravityDBfile}\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to fill table ${table}${list_type} in database ${gravityDBfile}\\n"
+    echo -e "  ${CROSS} ${output}\\n"
     gravity_Cleanup "error"
   fi
 
@@ -278,7 +282,8 @@ database_adlist_number() {
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to update number of domains in adlist with ID ${1} in database ${gravityTEMPfile}\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to update number of domains in adlist with ID ${1} in database ${gravityTEMPfile}\\n "
+    echo -e "  ${CROSS} ${output}\\n"
     gravity_Cleanup "error"
   fi
 }
@@ -294,7 +299,8 @@ database_adlist_status() {
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to update status of adlist with ID ${1} in database ${gravityTEMPfile}\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to update status of adlist with ID ${1} in database ${gravityTEMPfile}\\n"
+    echo -e "  ${CROSS} ${output}\\n"
     gravity_Cleanup "error"
   fi
 }
@@ -399,7 +405,8 @@ try_restore_backup () {
 
       # Error checking
       if [[ "${status}" -ne 0 ]]; then
-        echo -e "\\n  ${CROSS} Unable to copy data from ${gravityDBfile} to ${gravityTEMPfile}\\n  ${output}"
+        echo -e "\\n  ${CROSS} Unable to copy data from ${gravityDBfile} to ${gravityTEMPfile}\\n"
+        echo -e "  ${CROSS} ${output}\\n"
         gravity_Cleanup "error"
       fi
 
@@ -441,7 +448,8 @@ gravity_DownloadBlocklists() {
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to create new database ${gravityTEMPfile}\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to create new database ${gravityTEMPfile}\\n"
+    echo -e " {CROSS} ${output}\\n"
     gravity_Cleanup "error"
   else
     echo -e "${OVER}  ${TICK} ${str}"
@@ -461,7 +469,8 @@ gravity_DownloadBlocklists() {
   status="$?"
 
   if [[ "${status}" -ne 0 ]]; then
-    echo -e "\\n  ${CROSS} Unable to copy data from ${gravityDBfile} to ${gravityTEMPfile}\\n  ${output}"
+    echo -e "\\n  ${CROSS} Unable to copy data from ${gravityDBfile} to ${gravityTEMPfile}\\n"
+    echo -e "  ${CROSS} ${output}\\n"
 
     # Try to attempt a backup restore
     success=false
@@ -946,12 +955,14 @@ gravity_Cleanup() {
     # Remove any unused .domains/.etag/.sha files
     for file in "${listsCacheDir}"/*."${domainsExtension}"; do
       # If list is not in active array, then remove it and all associated files
-      if [[ ! "${activeDomains[*]}" == *"${file}"* ]]; then
+      if [[ "${activeDomains[*]}" != *"${file}"* ]]; then
         rm -f "${file}"* 2>/dev/null ||
           echo -e "  ${CROSS} Failed to remove ${file##*/}"
       fi
     done
   fi
+  # Delete the temporary gravity database if it still exists (e.g. in case of early exit due ti error or user abort)
+  rm -f "${gravityTEMPfile}" 2>/dev/null
 
   echo -e "${OVER}  ${TICK} ${str}"
 
@@ -1004,7 +1015,7 @@ database_recovery() {
     echo -e "${OVER}  ${CROSS} ${str} - the following errors happened:"
     while IFS= read -r line; do echo "  - $line"; done <<<"$result"
     echo -e "  ${CROSS} Recovery failed. Try \"pihole -g -r recreate\" instead."
-    exit 1
+    gravity_Cleanup "error"
   fi
   echo ""
 }
@@ -1020,7 +1031,8 @@ gravity_optimize() {
     status="$?"
 
     if [[ "${status}" -ne 0 ]]; then
-        echo -e "\\n  ${CROSS} Unable to optimize database ${gravityTEMPfile}\\n  ${output}"
+        echo -e "\\n  ${CROSS} Unable to optimize database ${gravityTEMPfile}\\n"
+        echo -e "  ${CROSS} ${output}\\n"
         gravity_Cleanup "error"
     else
         echo -e "${OVER}  ${TICK} ${str}"
@@ -1150,7 +1162,7 @@ done
 # Check if DNS is available, no need to do any database manipulation if we're not able to download adlists
 if ! timeit gravity_CheckDNSResolutionAvailable; then
   echo -e "   ${CROSS} No DNS resolution available. Please contact support."
-  exit 1
+  gravity_Cleanup "error"
 fi
 
 # Remove OLD (backup) gravity file, if it exists
@@ -1181,7 +1193,7 @@ migrate_to_listsCache_dir
 # Move possibly existing legacy files to the gravity database
 if ! timeit migrate_to_database; then
   echo -e "   ${CROSS} Unable to migrate to database. Please contact support."
-  exit 1
+  gravity_Cleanup "error"
 fi
 
 if [[ "${forceDelete:-}" == true ]]; then
@@ -1195,18 +1207,27 @@ fi
 # Gravity downloads blocklists next
 if ! gravity_DownloadBlocklists; then
   echo -e "   ${CROSS} Unable to create gravity database. Please try again later. If the problem persists, please contact support."
-  exit 1
+  gravity_Cleanup "error"
 fi
 
 # Update gravity timestamp
-update_gravity_timestamp
+if ! update_gravity_timestamp; then
+  echo -e "   ${CROSS} Unable to update gravity timestamp. Please contact support."
+  gravity_Cleanup "error"
+fi
 
 # Ensure proper permissions are set for the database
 fix_owner_permissions "${gravityTEMPfile}"
 
 # Build the tree
-timeit gravity_build_tree gravity
-timeit gravity_build_tree antigravity
+if ! timeit gravity_build_tree gravity; then
+  echo -e "   ${CROSS} Unable to create database. Please contact support."
+  gravity_Cleanup "error"
+fi
+if ! timeit gravity_build_tree antigravity; then
+  echo -e "   ${CROSS} Unable to create database. Please contact support."
+  gravity_Cleanup "error"
+fi
 
 # Compute numbers to be displayed (do this after building the tree to get the
 # numbers quickly from the tree instead of having to scan the whole database)
@@ -1219,7 +1240,7 @@ timeit gravity_optimize
 # IMPORTANT: Swapping the databases must be the last step before the cleanup
 if ! timeit gravity_swap_databases; then
   echo -e "   ${CROSS} Unable to create database. Please contact support."
-  exit 1
+  gravity_Cleanup "error"
 fi
 
 timeit gravity_Cleanup


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Improve gravity error handling. Fixes https://github.com/pi-hole/pi-hole/issues/6633

**How does this PR accomplish the above?:**

0) Guard `update_gravity_timestamp` and `gravity_build_tree gravity/antigravity` by checking their return code and exit in case of an error (This is what fixes  https://github.com/pi-hole/pi-hole/issues/6633)
1) Use `gravity_Cleanup error` instead of exit 1 to cleanup in case of an error
2) Format output nicer in case of an error
3) Remove the temporary gravity database in `gravity_Cleanup()` if it still exists
(4) Fix some shellcheck warnings)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
