### PR TITLE
fix: Following symlinked files could cause DoS

### DIFF
--- a/advanced/Scripts/updatecheck.sh
+++ b/advanced/Scripts/updatecheck.sh
@@ -54,8 +54,10 @@ rm -f "/etc/pihole/localversions"
 
 VERSION_FILE="/etc/pihole/versions"
 
-# Truncates the file to zero length if it exists to clear it up, otherwise creates an empty file.
-truncate -s 0 "${VERSION_FILE}"
+# Recreate the version file as a fresh, root-owned regular file.
+# `truncate` follows symlinks; `rm -f` does not.
+rm -f "${VERSION_FILE}"
+touch "${VERSION_FILE}"
 chmod 644 "${VERSION_FILE}"
 
 # if /pihole.docker.tag file exists, we will use it's value later in this script


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes a symlink-following bug in advanced/Scripts/updatecheck.sh that lets the unprivileged pihole user turn a daily cron job (and an
  @reboot trigger) into an arbitrary-file truncate + chmod 0644 primitive running as root. With ln -sf /etc/shadow /etc/pihole/versions planted ahead of time, the next updatechecker run zeroes out /etc/shadow (or any other root-owned file) and widens its mode which results to a complete lockout.
It is in the same/similar bug class as GHSA-c935-8g63-qp74

Reproduction (as the pihole user):
```
  ln -sfn /etc/shadow /etc/pihole/versions
  sudo pihole updatechecker        # or wait for the daily cron / @reboot
  sudo stat -c '%a %U:%G %n' /etc/shadow
  # Before: 640 root:shadow /etc/shadow
  # After:  644 root:root   /etc/shadow   # contents replaced with version-file cruft → login DoS
```

**How does this PR accomplish the above?:**
Replaces the symlink-unsafe truncate -s 0 + chmod pair with an explicit symlink check followed by touch, so the script refuses to operate on a pre-existing symlink at ${VERSION_FILE}
 

**Link documentation PRs if any are needed to support this PR:**

n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
