### PR TITLE
avoid copytruncate in logrotate

### DIFF
--- a/advanced/Templates/logrotate
+++ b/advanced/Templates/logrotate
@@ -1,18 +1,22 @@
 /var/log/pihole/pihole.log {
     # su #
     daily
-    copytruncate
+    create 640 pihole pihole
     rotate 5
     compress
     delaycompress
     notifempty
     nomail
+    postrotate
+        kill -USR2 $(cat /run/pihole-FTL.pid 2>/dev/null) 2>/dev/null || true
+    endscript
 }
 
+# FTL.log and webserver.log are opened and closed for each line, therefore no postrotate is needed
 /var/log/pihole/FTL.log {
     # su #
     weekly
-    copytruncate
+    create 640 pihole pihole
     rotate 3
     compress
     delaycompress
@@ -23,7 +27,7 @@
 /var/log/pihole/webserver.log {
     # su #
     weekly
-    copytruncate
+    create 640 pihole pihole
     rotate 3
     compress
     delaycompress

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1617,7 +1617,13 @@ installLogrotate() {
 
     printf "\\n  %b %s..." "${INFO}" "${str}"
     if [[ -f ${target} ]]; then
-        printf "\\n\\t%b Existing logrotate file found. No changes made.\\n" "${INFO}"
+        if diff -q "$target" "${PI_HOLE_LOCAL_REPO}/advanced/Templates/logrotate" >/dev/null; then
+            printf "\\n\\t%b logrotate file is up to date.\\n" "${TICK}"
+            return
+        else
+            printf "\\n\\t%b logrotate file is outdated. Not updating.\\n" "${INFO}"
+            return
+        fi
     else
         # Copy the file over from the local repo
         # Logrotate config file must be owned by root and not writable by group or other


### PR DESCRIPTION
Follow-up to #6524

**What does this PR aim to accomplish?:**

`copytruncate` is generally considered bad practice, as it may introduce a race condition between copy and truncate which might lead to data loss.
While working on the structured logging, I noticed that FTL and webserver.log are opened and closed on a per-line basis.
`dnsmasq` re-opens the log via SIGUSR2. This signal is correctly received, even in FTL.
From `man dnsmasq`:
"When it receives SIGUSR2 and it is logging direct to a file (see --log-facility ) dnsmasq will close and reopen the log file. Note that during this operation, dnsmasq will not be running as root. When it first creates the logfile dnsmasq changes the ownership of the file to the non-root user it will run as. Logrotate should be configured to create a new log file with the ownership which matches the existing one before sending SIGUSR2. If TCP DNS queries are in progress, the old logfile will remain open in child processes which are handling TCP queries and may continue to be written. There is a limit of 150 seconds, after which all existing TCP processes will have expired: for this reason, it is not wise to configure logfile compression for logfiles which have just been rotated. Using logrotate, the required options are create and delaycompress."
Since we hard-code the PID file, this is quite simple.

I changed the installer to inform about logrotate changes, while still being non-invasive.

The `dnsmasq` signals are currently not documented at https://docs.pi-hole.net/ftldns/signals/, but still work in FTL. Do we want to add them to the docs?

**How does this PR accomplish the above?:**

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
