### PR TITLE
dev: add Docker compose stack and FTL build helper script

### DIFF
--- a/docker/dev/.gitignore
+++ b/docker/dev/.gitignore
@@ -1,0 +1,2 @@
+.env
+etc-pihole/

--- a/docker/dev/build-ftl.sh
+++ b/docker/dev/build-ftl.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build the modified pihole-FTL binary and hot-swap it into the running
+# pihole-dev container.
+#
+# Run once after first checkout, and whenever C source files change.
+# Requires: cmake, gcc, and the FTL build dependencies (see DEPS below).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+FTL_SRC="${REPO_ROOT}/pihole-FTL"
+COMPOSE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── 1. Install build dependencies (Ubuntu/Debian) ──────────────────────────
+DEPS=(cmake gcc libgmp-dev libnettle-dev libidn2-dev libunistring-dev)
+echo "[build-ftl] Installing build dependencies..."
+sudo apt-get install -y -q "${DEPS[@]}"
+
+# ── 2. Build FTL ─────────────────────────────────────────────────────────
+echo "[build-ftl] Building pihole-FTL..."
+cd "${FTL_SRC}"
+bash build.sh
+BINARY="${FTL_SRC}/cmake/pihole-FTL"
+echo "[build-ftl] Binary: ${BINARY}"
+
+# ── 3. Uncomment the FTL volume mount in docker-compose.yml ──────────────
+# Enable the commented-out FTL binary mount so the container uses our build.
+COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
+sed -i 's|# - \.\.\./\.\.\./pihole-FTL/cmake/pihole-FTL:/usr/bin/pihole-FTL|- ../../../pihole-FTL/cmake/pihole-FTL:/usr/bin/pihole-FTL|' "${COMPOSE_FILE}"
+echo "[build-ftl] Enabled FTL binary mount in docker-compose.yml"
+
+# ── 4. Restart the container to pick up the new binary ───────────────────
+echo "[build-ftl] Restarting pihole-dev container..."
+cd "${COMPOSE_DIR}"
+docker compose down
+docker compose up -d
+
+echo ""
+echo "[build-ftl] Done. The container is using your locally built pihole-FTL."
+echo "  Test the new API param:"
+echo "    curl -s 'http://127.0.0.1:8080/api/stats/top_domains?blocked=true&list=1'"
+echo ""
+echo "  Admin UI: http://127.0.0.1:8080/admin/"

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,0 +1,29 @@
+# Pi-hole dev/test stack — not for production network DNS.
+# Docs: https://docs.pi-hole.net/docker/configuration/
+services:
+  pihole:
+    container_name: pihole-dev
+    image: pihole/pihole:latest
+    hostname: pi.hole
+    ports:
+      # Host 8053 avoids conflict with systemd-resolved (53) and mDNS (5353)
+      - "8053:53/tcp"
+      - "8053:53/udp"
+      - "8080:80/tcp"
+      - "8443:443/tcp"
+    environment:
+      TZ: ${TZ:-UTC}
+      FTLCONF_webserver_api_password: ${FTLCONF_webserver_api_password:-devpassword}
+      FTLCONF_dns_upstreams: ${FTLCONF_dns_upstreams:-8.8.8.8;8.8.4.4}
+      # Bridge network: listen on all interfaces inside the container
+      FTLCONF_dns_listeningMode: ALL
+    volumes:
+      - ./etc-pihole:/etc/pihole
+      # Live-reload web UI changes without rebuilding the image.
+      # Remove this line once changes are merged into the upstream web repo.
+      - ../../../pihole-web:/var/www/html/admin
+      # Mount the locally built FTL binary (built inside the container — see instructions below):
+      # - ../../../pihole-FTL/cmake/pihole-FTL:/usr/bin/pihole-FTL
+    cap_add:
+      - NET_ADMIN
+    restart: unless-stopped

--- a/docker/dev/up.sh
+++ b/docker/dev/up.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker is not accessible. Run once (then log out/in, or: newgrp docker):"
+  echo "  sudo usermod -aG docker \"\$USER\""
+  exit 1
+fi
+
+docker compose pull
+docker compose up -d
+
+echo ""
+echo "Pi-hole dev container is starting."
+echo "  Admin UI:  http://127.0.0.1:8080/admin/"
+echo "  Password:  see FTLCONF_webserver_api_password in .env (default: devpassword)"
+echo ""
+echo "Quick checks:"
+echo "  docker compose logs -f pihole"
+echo "  dig @127.0.0.1 -p 8053 doubleclick.net +short"
+echo "  curl -s http://127.0.0.1:8080/admin/ | head -5"


### PR DESCRIPTION
- docker/dev/docker-compose.yml: single-container dev stack mapping host port 8053 for DNS (avoids conflict with systemd-resolved), with a live bind-mount for the pihole-web UI tree so changes are reflected immediately without rebuilding the image; an optional commented-out mount for a locally built pihole-FTL binary is provided for backend iteration
- docker/dev/build-ftl.sh: helper script that installs build dependencies, compiles pihole-FTL inside the container (ensures glibc compatibility), uncomments the FTL volume mount, and restarts the container

Test Results
pytest -vv -n auto ./test_any_automated_install.py ./test_any_utils.py
================================================= test session starts ==================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /home/sushant/Documents/Public_Repo/pi-hole/test/.tox/py3/bin/python
cachedir: .tox/py3/.pytest_cache
rootdir: /home/sushant/Documents/Public_Repo/pi-hole/test
plugins: xdist-3.8.0, testinfra-10.2.2, clarity-1.0.1
8 workers [25 items]
scheduling tests via LoadScheduling

test_any_automated_install.py::test_supported_package_manager
test_any_automated_install.py::test_FTL_detect_no_errors[x86_64-x86_64-True]
test_any_automated_install.py::test_update_package_cache_failure_no_errors
test_any_automated_install.py::test_FTL_detect_no_errors[armv7-ARMv7 (or newer)-True]
test_any_automated_install.py::test_FTL_detect_no_errors[armv6-ARMv6-True]
test_any_automated_install.py::test_FTL_detect_no_errors[mips-mips-False]
test_any_automated_install.py::test_installPihole_fresh_install_readableFiles
test_any_automated_install.py::test_IPv6_only_link_local
[gw7] [  4%] PASSED test_any_automated_install.py::test_IPv6_only_link_local
[gw2] [  8%] PASSED test_any_automated_install.py::test_update_package_cache_failure_no_errors
test_any_automated_install.py::test_IPv6_only_ULA
test_any_automated_install.py::test_FTL_detect_no_errors[aarch64-AArch64 (64 Bit ARM)-True]
[gw1] [ 12%] PASSED test_any_automated_install.py::test_supported_package_manager
test_any_automated_install.py::test_selinux_not_detected
[gw7] [ 16%] PASSED test_any_automated_install.py::test_IPv6_only_ULA
test_any_automated_install.py::test_IPv6_only_GUA
[gw1] [ 20%] PASSED test_any_automated_install.py::test_selinux_not_detected
test_any_automated_install.py::test_IPv6_ULA_GUA_test
[gw7] [ 24%] PASSED test_any_automated_install.py::test_IPv6_only_GUA
test_any_automated_install.py::test_validate_ip
[gw1] [ 28%] PASSED test_any_automated_install.py::test_IPv6_ULA_GUA_test
test_any_automated_install.py::test_package_manager_has_pihole_deps
[gw4] [ 32%] PASSED test_any_automated_install.py::test_FTL_detect_no_errors[armv7-ARMv7 (or newer)-True]
[gw6] [ 36%] PASSED test_any_automated_install.py::test_FTL_detect_no_errors[mips-mips-False]
test_any_automated_install.py::test_FTL_detect_no_errors[armv8a-ARMv7 (or newer)-True]
[gw5] [ 40%] PASSED test_any_automated_install.py::test_FTL_detect_no_errors[x86_64-x86_64-True]
test_any_automated_install.py::test_FTL_development_binary_installed_and_responsive_no_errors
[gw3] [ 44%] PASSED test_any_automated_install.py::test_FTL_detect_no_errors[armv6-ARMv6-True]
test_any_automated_install.py::test_FTL_detect_no_errors[riscv64-riscv64-True]
test_any_automated_install.py::test_FTL_detect_no_errors[armv7l-ARMv7 (or newer)-True]
[gw2] [ 48%] PASSED test_any_automated_install.py::test_FTL_detect_no_errors[aarch64-AArch64 (64 Bit ARM)-True]
test_any_automated_install.py::test_IPv6_GUA_ULA_test
[gw2] [ 52%] PASSED test_any_automated_install.py::test_IPv6_GUA_ULA_test
[gw7] [ 56%] PASSED test_any_automated_install.py::test_validate_ip
test_any_automated_install.py::test_meta_package_uninstall
[gw6] [ 60%] PASSED test_any_automated_install.py::test_FTL_development_binary_installed_and_responsive_no_errors
test_any_utils.py::test_setFTLConfigValue_getFTLConfigValue
[gw4] [ 64%] PASSED test_any_automated_install.py::test_FTL_detect_no_errors[armv8a-ARMv7 (or newer)-True]
test_any_utils.py::test_getFTLPID_default
[gw4] [ 68%] PASSED test_any_utils.py::test_getFTLPID_default
[gw5] [ 72%] PASSED test_any_automated_install.py::test_FTL_detect_no_errors[riscv64-riscv64-True]
[gw3] [ 76%] PASSED test_any_automated_install.py::test_FTL_detect_no_errors[armv7l-ARMv7 (or newer)-True]
[gw6] [ 80%] PASSED test_any_utils.py::test_setFTLConfigValue_getFTLConfigValue
[gw1] [ 84%] PASSED test_any_automated_install.py::test_package_manager_has_pihole_deps
test_any_utils.py::test_key_val_replacement_works
[gw1] [ 88%] PASSED test_any_utils.py::test_key_val_replacement_works
[gw7] [ 92%] PASSED test_any_automated_install.py::test_meta_package_uninstall
[gw0] [ 96%] PASSED test_any_automated_install.py::test_installPihole_fresh_install_readableFiles
test_any_automated_install.py::test_update_package_cache_success_no_errors
[gw0] [100%] PASSED test_any_automated_install.py::test_update_package_cache_success_no_errors

============================================ 25 passed in 82.26s (0:01:22) =============================================
.pkg: _exit /home/sushant/Documents/Public_Repo/pi-hole/test> python /usr/lib/python3/dist-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py3: OK (117.52=setup[9.59]+cmd[24.96,82.97] seconds)
  congratulations :) (117.77 seconds)