### PR TITLE
fix: check pihole-FTL parseList return code in gravity_DownloadBlocklistFromUrl

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -845,7 +845,12 @@ gravity_DownloadBlocklistFromUrl() {
       # Set list status to "unchanged/cached"
       database_adlist_status "${adlistID}" "2"
       # Add domains to database table file
-      pihole-FTL "${gravity_type}" parseList "${saveLocation}" "${gravityTEMPfile}" "${adlistID}"
+      # parseList silently returns exit code 1 on storage exhaustion; failing to check it
+      # leaves a truncated blocklist with no visible error
+      if ! pihole-FTL "${gravity_type}" parseList "${saveLocation}" "${gravityTEMPfile}" "${adlistID}"; then
+        echo -e "  ${CROSS} Failed to parse list ${saveLocation} (storage problem?)"
+        gravity_Cleanup "error"
+      fi
       done="true"
     # Check if $listCurlBuffer is a non-zero length file
     elif [[ -s "${listCurlBuffer}" ]]; then
@@ -860,7 +865,12 @@ gravity_DownloadBlocklistFromUrl() {
           fix_owner_permissions "${saveLocation}.etag"
       fi
       # Add domains to database table file
-      pihole-FTL "${gravity_type}" parseList "${saveLocation}" "${gravityTEMPfile}" "${adlistID}"
+      # parseList silently returns exit code 1 on storage exhaustion; failing to check it
+      # leaves a truncated blocklist with no visible error
+      if ! pihole-FTL "${gravity_type}" parseList "${saveLocation}" "${gravityTEMPfile}" "${adlistID}"; then
+        echo -e "  ${CROSS} Failed to parse list ${saveLocation} (storage problem?)"
+        gravity_Cleanup "error"
+      fi
       done="true"
     else
       # Fall back to previously cached list if $listCurlBuffer is empty
@@ -876,7 +886,12 @@ gravity_DownloadBlocklistFromUrl() {
       # Set list status to "download-failed/cached"
       database_adlist_status "${adlistID}" "3"
       # Add domains to database table file
-      pihole-FTL "${gravity_type}" parseList "${saveLocation}" "${gravityTEMPfile}" "${adlistID}"
+      # parseList silently returns exit code 1 on storage exhaustion; failing to check it
+      # leaves a truncated blocklist with no visible error
+      if ! pihole-FTL "${gravity_type}" parseList "${saveLocation}" "${gravityTEMPfile}" "${adlistID}"; then
+        echo -e "  ${CROSS} Failed to parse list ${saveLocation} (storage problem?)"
+        gravity_Cleanup "error"
+      fi
     else
       echo -e "  ${CROSS} List download failed: ${COL_RED}no cached list available${COL_NC}"
       # Manually reset these two numbers because we do not call parseList here


### PR DESCRIPTION
Closes #5244

When /tmp or GRAVITY_TMPDIR runs out of storage during gravity,
pihole-FTL parseList silently fails with exit code 1, but gravity
continues and reports [✓] Done. with an updated timestamp, leaving
a silently truncated blocklist.

This wraps all three pihole-FTL parseList call sites in
gravity_DownloadBlocklistFromUrl with return code checks. On
failure, it now prints:

  [✗] Failed to parse list <path> (storage problem?)
and exits with code 1 via gravity_Cleanup "error".

Tested on pihole/pihole:2025.07.1:

8M /tmp → [✗] Failed to parse list, exit 1 (was: [✓] Done., exit 0, -610K domains)
Normal /tmp → 850,699 domains, [✓] Done., exit 0 (no regression)

By submitting this pull request, I confirm the following:

- I have read and understood the contributors guide, as well as this entire template. I understand which branch to base my commits and Pull Requests against.
- I have commented my proposed changes within the code and I have tested my changes.
- I am willing to help maintain this change if there are issues with it later.
- It is compatible with the EUPL 1.2 license
- I have squashed any insignificant commits. (git rebase)
- I have checked that another pull request for this purpose does not exist.
- I have considered, and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- I give this submission freely, and claim no ownership to its content.