### PR TITLE
Fix BATS gravity test on curl version >=8.21

### DIFF
--- a/test/test_gravity.bats
+++ b/test/test_gravity.bats
@@ -14,17 +14,22 @@ INFO="[i]"
 
 # Depending on the curl version, a specific error messages can be returned in case of failure
 curlVersion=$(curl --version | awk '{print $2;exit}')
-if echo "${curlVersion%.*}" | awk '{exit !($1 - 8.21 >= 0)}'; then
+
+# Compare dotted versions semantically
+version_ge() {
+    [ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]
+}
+
+if version_ge "${curlVersion}" "8.21.0"; then
     curl821=true
-elif echo "${curlVersion%.*}" | awk '{exit !($1 - 7.75 >= 0)}'; then
+elif version_ge "${curlVersion}" "7.75.0"; then
     curl775=true
 fi
 
-
 # Really old curl versions miss a fix for using --etag-save and --etag-compare together (https://github.com/curl/curl/pull/5180)
 # Fixed in curl 7.70.0 - April 29 2020
-if echo "${curlVersion%.*}" | awk '{exit !($1 - 7.70 >= 0)}'; then
-    curl770=true
+if version_ge "${curlVersion}" "7.70.0"; then
+    curl_etag_support=true
 fi
 
 setup_file() {
@@ -94,7 +99,7 @@ teardown() {
     refute_line --partial "${INFO} Migrating content of /etc/pihole/adlists.list into new database"
 
     assert_line --partial "${INFO} Target: https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
-    if [ "${curl770}" = true ]; then
+    if [ "${curl_etag_support}" = true ]; then
         assert_line --partial "${TICK} Status: No changes detected"
     else
         assert_line --partial "${TICK} Status: Retrieval successful"
@@ -191,7 +196,7 @@ teardown() {
     assert_line --partial "${INFO} Migrating content of /etc/pihole/adlists.list into new database"
 
     assert_line --partial "${INFO} Target: https://raw.githubusercontent.df"
-    if [ "${curl775}" = true ]; then
+    if [ "${curl775}" = true ] || [ "${curl821}" = true ]; then
         assert_line --partial "${CROSS} Status: Retrieval failed (exit_code=6 Msg: Could not resolve host: raw.githubusercontent.df"
     else
         assert_line --partial "${CROSS} Status: Retrieval failed (exit_code=6 Msg: No message available. Non supported curl version.)"

--- a/test/test_gravity.bats
+++ b/test/test_gravity.bats
@@ -14,9 +14,12 @@ INFO="[i]"
 
 # Depending on the curl version, a specific error messages can be returned in case of failure
 curlVersion=$(curl --version | awk '{print $2;exit}')
-if echo "${curlVersion%.*}" | awk '{exit !($1 - 7.75 >= 0)}'; then
+if echo "${curlVersion%.*}" | awk '{exit !($1 - 8.21 >= 0)}'; then
+    curl821=true
+elif echo "${curlVersion%.*}" | awk '{exit !($1 - 7.75 >= 0)}'; then
     curl775=true
 fi
+
 
 # Really old curl versions miss a fix for using --etag-save and --etag-compare together (https://github.com/curl/curl/pull/5180)
 # Fixed in curl 7.70.0 - April 29 2020
@@ -233,7 +236,9 @@ teardown() {
     assert_line --partial "${INFO} Migrating content of /etc/pihole/adlists.list into new database"
 
     assert_line --partial "${INFO} Target: http://localhost:81/list"
-    if [ "${curl775}" = true ]; then
+    if [ "${curl821}" = true ]; then
+        assert_line --partial "${CROSS} Status: Retrieval failed (exit_code=7 Msg: Failed to connect to localhost:81"
+    elif [ "${curl775}" = true ]; then
         assert_line --partial "${CROSS} Status: Retrieval failed (exit_code=7 Msg: Failed to connect to localhost port 81"
     else
         assert_line --partial "${CROSS} Status: Retrieval failed (exit_code=7 Msg: No message available. Non supported curl version.)"


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Does what it says. `curl` changed the error output again which [breaks our test suite](https://github.com/pi-hole/pi-hole/actions/runs/28702743151/job/85123378404?pr=6660) on with very new `curl` versions (e.g. alpine 3.24)

**How does this PR accomplish the above?:**

Change the assertion line depending on the curl version used.

ADD: additionally fix the version comparison to be really semantically. Otherwise `curl` 8.5.1 would be be `>8.21`

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
