### PR TITLE
Stop double-rotating logs now that pihole is in /etc/logrotate.d

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -17,11 +17,6 @@ utilsfile="${PI_HOLE_SCRIPT_DIR}/utils.sh"
 # shellcheck source="./advanced/Scripts/utils.sh"
 source "${utilsfile}"
 
-# In case we're running at the same time as a system logrotate, use a
-# separate logrotate state file to prevent stepping on each other's
-# toes.
-STATEFILE="/var/lib/logrotate/pihole"
-
 # Determine database location
 DBFILE=$(getFTLConfigValue "files.database")
 if [ -z "$DBFILE" ]; then
@@ -65,8 +60,10 @@ if [[ "$*" == *"once"* ]]; then
     if [[ "$*" != *"quiet"* ]]; then
         echo -ne "  ${INFO} Running logrotate ..."
     fi
-    mkdir -p "${STATEFILE%/*}"
-    /usr/sbin/logrotate --force --state "${STATEFILE}" /etc/logrotate.d/pihole
+    # Use logrotate's default state file so this run and the system's own
+    # scheduled logrotate (which also reads /etc/logrotate.d/pihole) agree on
+    # what's already been rotated, instead of rotating our logs twice.
+    /usr/sbin/logrotate --force /etc/logrotate.d/pihole
 else
     # Manual flushing
     flush_log "${LOGFILE}"

--- a/advanced/Templates/logrotate
+++ b/advanced/Templates/logrotate
@@ -7,6 +7,7 @@
     delaycompress
     notifempty
     nomail
+    nodateext
     postrotate
         kill -USR2 $(cat /run/pihole-FTL.pid 2>/dev/null) 2>/dev/null || true
     endscript
@@ -22,6 +23,7 @@
     delaycompress
     notifempty
     nomail
+    nodateext
 }
 
 /var/log/pihole/webserver.log {
@@ -33,4 +35,5 @@
     delaycompress
     notifempty
     nomail
+    nodateext
 }

--- a/advanced/Templates/pihole.cron
+++ b/advanced/Templates/pihole.cron
@@ -26,7 +26,7 @@
 #          parameter "quiet": don't print messages
 00 00   * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole flush once quiet
 
-@reboot root /usr/sbin/logrotate --state /var/lib/logrotate/pihole /etc/logrotate.d/pihole
+@reboot root /usr/sbin/logrotate /etc/logrotate.d/pihole
 
 # Pi-hole: Grab remote and local version every 24 hours
 59 17  * * *   root    PATH="$PATH:/usr/sbin:/usr/local/bin/" pihole updatechecker

--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1615,6 +1615,13 @@ installLogrotate() {
     local str="Installing latest logrotate script"
     local target=/etc/logrotate.d/pihole
 
+    # Remove remnants from older Pi-hole versions: the logrotate config used to
+    # live in /etc/pihole/, and logrotate state was tracked in a Pi-hole-specific
+    # file instead of the system's default state file. Leaving these around is
+    # harmless but can be confusing when debugging.
+    rm -f /etc/pihole/logrotate
+    rm -f /var/lib/logrotate/pihole
+
     printf "\\n  %b %s..." "${INFO}" "${str}"
     if [[ -f ${target} ]]; then
         if diff -q "$target" "${PI_HOLE_LOCAL_REPO}/advanced/Templates/logrotate" >/dev/null; then

--- a/automated install/uninstall.sh
+++ b/automated install/uninstall.sh
@@ -158,6 +158,12 @@ removePiholeFiles() {
     # Remove logrotate configuration for Pi-hole
     rm -f /etc/logrotate.d/pihole &> /dev/null
 
+    # Remove remnants from older Pi-hole versions: the logrotate config used to
+    # live in /etc/pihole/, and logrotate state was tracked in a Pi-hole-specific
+    # file instead of the system's default state file
+    rm -f /etc/pihole/logrotate &> /dev/null
+    rm -f /var/lib/logrotate/pihole &> /dev/null
+
     echo -e "  ${TICK} Removed config files"
 }
 


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

Fixes double log rotation reported [here](https://www.reddit.com/r/pihole/comments/1upboi8/comment/ow1xea3/): since the logrotate config moved to `/etc/logrotate.d/pihole`, the system's own scheduled logrotate reads it too, on top of our own nightly/`@reboot` forced runs.

**How does this PR accomplish the above?:**

Our forced runs were using a private state file (`/var/lib/logrotate/pihole`), left over from when the config lived outside `/etc/logrotate.d/` and the system logrotate never saw it. Now that both the system and our own runs read the same config, two separate state files mean neither knows the other already rotated a log, so it happens twice.

- Drop the private state file, use logrotate's default one so both runs agree on what's rotated
- Clean up stale `/etc/pihole/logrotate` and the old state file left over from pre-migration installs
- Force `nodateext` on our stanzas: if the system's `/etc/logrotate.conf` has `dateext` on (the upstream default), our config would inherit it when read via that file, but our own forced runs invoke `/etc/logrotate.d/pihole` directly and bypass it, so rotated filenames depended on which side rotated first. `piholeLogFlush.sh` also already assumes numeric suffixes for its manual flush path.

**Link documentation PRs if any are needed to support this PR:**

None needed.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
