### PR TITLE
harden: the database cleanup script constructs sql quer... in...

### DIFF
--- a/advanced/Scripts/piholeLogFlush.sh
+++ b/advanced/Scripts/piholeLogFlush.sh
@@ -68,6 +68,12 @@ if [[ "$*" == *"once"* ]]; then
     mkdir -p "${STATEFILE%/*}"
     /usr/sbin/logrotate --force --state "${STATEFILE}" /etc/logrotate.d/pihole
 else
+    # Validate DBFILE path before making any changes
+    if [[ ! "${DBFILE}" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
+        echo -e "  ${COL_RED}[✗] Invalid database file path: ${DBFILE}${COL_NC}"
+        exit 1
+    fi
+
     # Manual flushing
     flush_log "${LOGFILE}"
     flush_log "${FTLFILE}"
@@ -81,7 +87,7 @@ else
     service pihole-FTL stop
 
     # Delete most recent 24 hours from FTL's database, leave even older data intact (don't wipe out all history)
-    deleted=$(pihole-FTL sqlite3 -ni "${DBFILE}" "DELETE FROM query_storage WHERE timestamp >= strftime('%s','now')-86400; select changes() from query_storage limit 1")
+    deleted=$(pihole-FTL sqlite3 -ni -- "${DBFILE}" "DELETE FROM query_storage WHERE timestamp >= strftime('%s','now')-86400; select changes() from query_storage limit 1")
 
     # Restart FTL
     service pihole-FTL restart


### PR DESCRIPTION
## Summary
Harden input handling in `advanced/Scripts/piholeLogFlush.sh` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | MEDIUM |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `advanced/Scripts/piholeLogFlush.sh:84` |
| **Assessment** | Defensive hardening |

**Description**:  It is a defence in depth/ path validation. No vulnerability is found/reported in this PR.

## Changes
- `advanced/Scripts/piholeLogFlush.sh`

## Behaviour Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
