### PR TITLE
Fix URL parsing in gravity.sh

### DIFF
--- a/gravity.sh
+++ b/gravity.sh
@@ -504,8 +504,13 @@ gravity_DownloadBlocklists() {
   mapfile -t sourceDomains <<<"$(
     # Logic: Split by folder/port
     awk -F '[/:]' '{
-      # Remove URL protocol & optional username:password@
-      gsub(/(.*:\/\/|.*:.*@)/, "", $0)
+      # Remove URL protocol
+      gsub(/^.*:\/\//, "", $0)
+
+      # Remove optional credentials "username:password@", but keep other "@" characters,
+      # if present (see https://github.com/pi-hole/pi-hole/issues/6685)
+      gsub(/^[^\/]*@/, "", $0)
+
       if(length($1)>0){print $1}
       else {print "local"}
     }' <<<"$(printf '%s\n' "${sources[@]}")" 2>/dev/null


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix awk command to return the domain even when there is a "@" character in the middle of the URL: "http://domain.com/path@version/file.txt"

The new command first removes the protocol, then removes the "@" character, but only when it appears in the first part, before the domain: "http://username:password@domain.com/file.txt"

The old command removed everything (including the actual domain) before the "@" character, unconditionally.

Fix https://github.com/pi-hole/pi-hole/issues/6685

### How does this PR accomplish the above?

Changing the `awk` command to use 2 separate `gsub` calls. One for the protocol and another one to filter credentials. The new command uses a different regex, that removes text only when the "@" character appears before the domain.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
